### PR TITLE
Fixed Model Generation for PostgreSQL Primary Keys

### DIFF
--- a/drogon_ctl/create_model.cc
+++ b/drogon_ctl/create_model.cc
@@ -194,6 +194,10 @@ void create_model::createModelClassFromPG(
                         info.isAutoVal_ = true;
                     }
                 }
+                auto isIdentity = row["is_identity"].as<std::string>();
+                if (isIdentity == "YES") {
+                    info.isAutoVal_ = true;
+                }
                 cols.push_back(std::move(info));
             }
         } >>


### PR DESCRIPTION
As per definition Drogon should return the last ID after an insert
when “a table contains an auto-increasing primary key”, but the
current detection mechanism isn’t enough to catch all cases.

PostgreSQL has the concept of generated identity columns that act as
primary key columns, but this information is held in the "is_identity"
column that wasn’t checked before.

This commit fixes #410, and also detects generated identity columns as
auto incrementing columns, so that the model generation correctly
appends " returning " statements.