### PR TITLE
Load ParseAndAddDrogonTests in DrogonConfig

### DIFF
--- a/cmake/templates/DrogonConfig.cmake.in
+++ b/cmake/templates/DrogonConfig.cmake.in
@@ -49,6 +49,7 @@ get_filename_component(DROGON_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
 if(NOT TARGET Drogon::Drogon)
   include("${DROGON_CMAKE_DIR}/DrogonTargets.cmake")
   include("${DROGON_CMAKE_DIR}/DrogonUtilities.cmake")
+  include("${DROGON_CMAKE_DIR}/ParseAndAddDrogonTests.cmake")
 endif()
 
 get_target_property(DROGON_INCLUDE_DIRS Drogon::Drogon INTERFACE_INCLUDE_DIRECTORIES)

--- a/drogon_ctl/create_project.cc
+++ b/drogon_ctl/create_project.cc
@@ -67,6 +67,11 @@ static void newModelConfigFile(std::ofstream &configFile)
     auto templ = DrTemplateBase::newTemplate("model_json");
     configFile << templ->genText();
 }
+static void newTestMainFile(std::ofstream &mainFile)
+{
+    auto templ = DrTemplateBase::newTemplate("test_main");
+    mainFile << templ->genText();
+}
 void create_project::createProject(const std::string &projectName)
 {
 #ifdef _WIN32
@@ -100,6 +105,7 @@ void create_project::createProject(const std::string &projectName)
     drogon::utils::createPath("plugins");
     drogon::utils::createPath("build");
     drogon::utils::createPath("models");
+    drogon::utils::createPath("test");
 
     std::ofstream gitFile(".gitignore", std::ofstream::out);
     newGitIgFile(gitFile);
@@ -107,4 +113,6 @@ void create_project::createProject(const std::string &projectName)
     newConfigFile(configFile);
     std::ofstream modelConfigFile("models/model.json", std::ofstream::out);
     newModelConfigFile(modelConfigFile);
+    std::ofstream testMainFile("test/test_main.cc", std::ofstream::out);
+    newTestMainFile(testMainFile);
 }

--- a/drogon_ctl/templates/cmake.csp
+++ b/drogon_ctl/templates/cmake.csp
@@ -18,16 +18,19 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 add_executable(${PROJECT_NAME} main.cc)
+add_executable(${PROJECT_NAME}_test)
 
 # ##############################################################################
 # If you include the drogon source code locally in your project, use this method
 # to add drogon 
 # add_subdirectory(drogon) 
 # target_link_libraries(${PROJECT_NAME} PRIVATE drogon)
+# target_link_libraries(${PROJECT_NAME}_test PRIVATE drogon)
 #
 # and comment out the following lines
 find_package(Drogon CONFIG REQUIRED)
 target_link_libraries(${PROJECT_NAME} PRIVATE Drogon::Drogon)
+target_link_libraries(${PROJECT_NAME}_test PRIVATE Drogon::Drogon)
 
 # ##############################################################################
 
@@ -66,3 +69,14 @@ target_sources(${PROJECT_NAME}
 # ##############################################################################
 # uncomment the following line for dynamically loading views 
 # set_property(TARGET ${PROJECT_NAME} PROPERTY ENABLE_EXPORTS ON)
+
+# ##############################################################################
+
+aux_source_directory(test TEST_SRC)
+target_sources(${PROJECT_NAME}_test
+               PRIVATE
+               ${TEST_SRC})
+ParseAndAddDrogonTests(${PROJECT_NAME}_test)
+target_include_directories(${PROJECT_NAME}_test
+                           PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
+                                   ${CMAKE_CURRENT_SOURCE_DIR}/models)

--- a/drogon_ctl/templates/cmake.csp
+++ b/drogon_ctl/templates/cmake.csp
@@ -77,6 +77,3 @@ target_sources(${PROJECT_NAME}_test
                PRIVATE
                ${TEST_SRC})
 ParseAndAddDrogonTests(${PROJECT_NAME}_test)
-target_include_directories(${PROJECT_NAME}_test
-                           PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
-                                   ${CMAKE_CURRENT_SOURCE_DIR}/models)

--- a/drogon_ctl/templates/test_main.csp
+++ b/drogon_ctl/templates/test_main.csp
@@ -1,0 +1,32 @@
+#define DROGON_TEST_MAIN
+#include <drogon/drogon_test.h>
+#include <drogon/drogon.h>
+
+DROGON_TEST(BasicTest)
+{
+    // Add your tests here
+}
+
+int main(int argc, char** argv) 
+{
+    using namespace drogon;
+
+    std::promise<void> p1;
+    std::future<void> f1 = p1.get_future();
+
+    // Start the main loop on another thread
+    std::thread thr([&]() {
+        // Queues the promise to be fulfilled after starting the loop
+        app().getLoop()->queueInLoop([&p1]() { p1.set_value(); });
+        app().run();
+    });
+
+    // The future is only satisfied after the event loop started
+    f1.get();
+    int status = test::run(argc, argv);
+
+    // Ask the event loop to shutdown and wait
+    app().getLoop()->queueInLoop([]() { app().quit(); });
+    thr.join();
+    return status;
+}


### PR DESCRIPTION
Partially addresses #929. This PR makes `find_package(Drogon)` automatically loads the test parser. @an-tao  Should we create test folders in drogon_ctl for the users? Or leave it as it is?