### PR TITLE
Add port() and host() to HttpClient

### DIFF
--- a/lib/inc/drogon/HttpClient.h
+++ b/lib/inc/drogon/HttpClient.h
@@ -238,10 +238,16 @@ class DROGON_EXPORT HttpClient : public trantor::NonCopyable
     virtual size_t bytesReceived() const = 0;
 
     virtual std::string host() const = 0;
-    std::string getHost() const { return host(); }
+    std::string getHost() const
+    {
+        return host();
+    }
 
     virtual uint16_t port() const = 0;
-    uint16_t getPort() const { return port(); }
+    uint16_t getPort() const
+    {
+        return port();
+    }
 
     virtual bool secure() const = 0;
 

--- a/lib/inc/drogon/HttpClient.h
+++ b/lib/inc/drogon/HttpClient.h
@@ -253,7 +253,7 @@ class DROGON_EXPORT HttpClient : public trantor::NonCopyable
 
     bool onDefaultPort() const
     {
-        if(secure())
+        if (secure())
             return port() == 443;
         return port() == 80;
     }

--- a/lib/inc/drogon/HttpClient.h
+++ b/lib/inc/drogon/HttpClient.h
@@ -237,6 +237,21 @@ class DROGON_EXPORT HttpClient : public trantor::NonCopyable
     virtual size_t bytesSent() const = 0;
     virtual size_t bytesReceived() const = 0;
 
+    virtual std::string host() const = 0;
+    std::string getHost() const { return host(); }
+
+    virtual uint16_t port() const = 0;
+    uint16_t getPort() const { return port(); }
+
+    virtual bool secure() const = 0;
+
+    bool onDefaultPort() const
+    {
+        if(secure())
+            return port() == 443;
+        return port() == 80;
+    }
+
     /// Create a Http client using the hostString to connect to server
     /**
      *

--- a/lib/src/HttpClientImpl.cc
+++ b/lib/src/HttpClientImpl.cc
@@ -319,32 +319,15 @@ void HttpClientImpl::sendRequestInLoop(const drogon::HttpRequestPtr &req,
             req->addHeader("user-agent", userAgent_);
     }
     // Set the host header.
-    if (!domain_.empty())
+    if(onDefaultPort())
     {
-        if ((useSSL_ && serverAddr_.toPort() != 443) ||
-            (!useSSL_ && serverAddr_.toPort() != 80))
-        {
-            std::string host =
-                domain_ + ":" + std::to_string(serverAddr_.toPort());
-            req->addHeader("host", host);
-        }
-        else
-        {
-            req->addHeader("host", domain_);
-        }
+        req->addHeader("host", host());
     }
-    else
+    else 
     {
-        if ((useSSL_ && serverAddr_.toPort() != 443) ||
-            (!useSSL_ && serverAddr_.toPort() != 80))
-        {
-            req->addHeader("host", serverAddr_.toIpPort());
-        }
-        else
-        {
-            req->addHeader("host", serverAddr_.toIp());
-        }
+        req->addHeader("host", host()+":"+std::to_string(port()));
     }
+
     for (auto &cookie : validCookies_)
     {
         if ((cookie.expiresDate().microSecondsSinceEpoch() == 0 ||

--- a/lib/src/HttpClientImpl.cc
+++ b/lib/src/HttpClientImpl.cc
@@ -319,13 +319,13 @@ void HttpClientImpl::sendRequestInLoop(const drogon::HttpRequestPtr &req,
             req->addHeader("user-agent", userAgent_);
     }
     // Set the host header.
-    if(onDefaultPort())
+    if (onDefaultPort())
     {
         req->addHeader("host", host());
     }
-    else 
+    else
     {
-        req->addHeader("host", host()+":"+std::to_string(port()));
+        req->addHeader("host", host() + ":" + std::to_string(port()));
     }
 
     for (auto &cookie : validCookies_)

--- a/lib/src/HttpClientImpl.h
+++ b/lib/src/HttpClientImpl.h
@@ -84,6 +84,23 @@ class HttpClientImpl final : public HttpClient,
         userAgent_ = userAgent;
     }
 
+    uint16_t port() const override
+    {
+        return serverAddr_.toPort();
+    }
+
+    std::string host() const override
+    {
+        if(domain_.empty())
+            return serverAddr_.toIp();
+        return domain_;
+    }
+
+    bool secure() const override
+    {
+        return useSSL_;
+    }
+
   private:
     std::shared_ptr<trantor::TcpClient> tcpClientPtr_;
     trantor::EventLoop *loop_;

--- a/lib/src/HttpClientImpl.h
+++ b/lib/src/HttpClientImpl.h
@@ -91,7 +91,7 @@ class HttpClientImpl final : public HttpClient,
 
     std::string host() const override
     {
-        if(domain_.empty())
+        if (domain_.empty())
             return serverAddr_.toIp();
         return domain_;
     }

--- a/lib/tests/integration_test/client/main.cc
+++ b/lib/tests/integration_test/client/main.cc
@@ -928,6 +928,11 @@ DROGON_TEST(HttpTest)
 {
     auto client = HttpClient::newHttpClient("http://127.0.0.1:8848");
     client->setPipeliningDepth(10);
+    REQUIRE(client->secure() == false);
+    REQUIRE(client->port() == 8848);
+    REQUIRE(client->host() == "127.0.0.1");
+    REQUIRE(client->onDefaultPort() == false);
+
     doTest(client, TEST_CTX);
 }
 
@@ -941,6 +946,11 @@ DROGON_TEST(HttpsTest)
                                             false,
                                             false);
     client->setPipeliningDepth(10);
+    REQUIRE(client->secure() == true);
+    REQUIRE(client->port() == 8849);
+    REQUIRE(client->host() == "127.0.0.1");
+    REQUIRE(client->onDefaultPort() == false);
+
     doTest(client, TEST_CTX);
 }
 


### PR DESCRIPTION
This PR adds the ability access the port and host information form a HTTP client. This is needed for tasks like signing [HTTP signatures](https://tools.ietf.org/id/draft-cavage-http-signatures-01.html). 