### PR TITLE
CMake: Add CPack for .deb and .rpm package generation.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -748,3 +748,4 @@ if(DOXYGEN_FOUND)
   endif(BUILD_DOC)
 endif(DOXYGEN_FOUND)
 
+include(cmake/Packages.cmake)

--- a/cmake/Packages.cmake
+++ b/cmake/Packages.cmake
@@ -1,0 +1,37 @@
+include(GNUInstallDirs)
+
+set(CPACK_RESOURCE_FILE_LICENSE "${PROJECT_SOURCE_DIR}/LICENSE")
+set(CPACK_PACKAGE_CONTACT "https://github.com/drogonframework/drogon")
+
+set(CPACK_PACKAGE_NAME "${PROJECT_NAME}")
+set(CPACK_PACKAGE_VERSION "${DROGON_VERSION}")
+set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "A C++14/17 based HTTP web application framework running on Linux/macOS/Unix/Windows")
+
+# DEB
+# Figure out dependencies automatically.
+set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON)
+
+# Should be set automatically, but it is not.
+execute_process(COMMAND dpkg --print-architecture
+  OUTPUT_VARIABLE CPACK_DEBIAN_PACKAGE_ARCHITECTURE
+  OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+# The default does not produce valid Debian package names.
+set(CPACK_DEBIAN_FILE_NAME
+  "${CPACK_PACKAGE_NAME}_${CPACK_PACKAGE_VERSION}-0_${CPACK_DEBIAN_PACKAGE_ARCHITECTURE}.deb")
+
+# RPM
+set(CPACK_RPM_PACKAGE_LICENSE "MIT")
+
+# Figure out dependencies automatically.
+set(CPACK_RPM_PACKAGE_AUTOREQ ON)
+
+# Should be set automatically, but it is not.
+execute_process(COMMAND uname -m
+  OUTPUT_VARIABLE CPACK_RPM_PACKAGE_ARCHITECTURE
+  OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+set(CPACK_PACKAGE_FILE_NAME
+    "${CPACK_PACKAGE_NAME}-${CPACK_PACKAGE_VERSION}-0.${CPACK_RPM_PACKAGE_ARCHITECTURE}")
+
+include(CPack)


### PR DESCRIPTION
Compile as normal, run `cpack -G DEB` or `cpack -G RPM` in build directory.

Tested on:
  - Debian 11 (bullseye)
  - OpenSUSE Leap 15
  - Ubuntu 18.04 (bionic)

Bug: https://github.com/drogonframework/drogon/issues/983

----

The recipe can also be modified to create packages for FreeBSD, macOS and Windows, but I can't test it: <https://cmake.org/cmake/help/v3.20/manual/cpack-generators.7.html>.