### PR TITLE
Experimental HaikuOS Support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,7 +127,7 @@ if(${CMAKE_SYSTEM_NAME} STREQUAL "Haiku")
     target_link_libraries(${PROJECT_NAME} PRIVATE network)
 elseif (NOT WIN32 AND NOT ${CMAKE_SYSTEM_NAME} STREQUAL "OpenBSD")
     target_link_libraries(${PROJECT_NAME} PRIVATE dl)
-else ()
+elseif (WIN32)
     target_link_libraries(${PROJECT_NAME} PRIVATE shlwapi)
 endif ()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,13 +123,13 @@ add_subdirectory(trantor)
 
 target_link_libraries(${PROJECT_NAME} PUBLIC trantor)
 
-if (NOT WIN32)
-    if (NOT ${CMAKE_SYSTEM_NAME} STREQUAL "OpenBSD")
-        target_link_libraries(${PROJECT_NAME} PRIVATE dl)
-    endif (NOT ${CMAKE_SYSTEM_NAME} STREQUAL "OpenBSD")
-else (NOT WIN32)
+if(${CMAKE_SYSTEM_NAME} STREQUAL "Haiku")
+    target_link_libraries(${PROJECT_NAME} PRIVATE network)
+elseif (NOT WIN32 AND NOT ${CMAKE_SYSTEM_NAME} STREQUAL "OpenBSD")
+    target_link_libraries(${PROJECT_NAME} PRIVATE dl)
+else ()
     target_link_libraries(${PROJECT_NAME} PRIVATE shlwapi)
-endif (NOT WIN32)
+endif ()
 
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake_modules/)
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ English | [简体中文](./README.zh-CN.md) | [繁體中文](./README.zh-TW.md)
 ### Overview
 **Drogon** is a C++14/17-based HTTP application framework. Drogon can be used to easily build various types of web application server programs using C++. **Drogon** is the name of a dragon in the American TV series "Game of Thrones" that I really like.
 
-Drogon is a cross-platform framework, It supports Linux, macOS, FreeBSD, OpenBSD, and Windows. Its main features are as follows:
+Drogon is a cross-platform framework, It supports Linux, macOS, FreeBSD, OpenBSD, HaikuOS, and Windows. Its main features are as follows:
 
 * Use a non-blocking I/O network lib based on epoll (kqueue under macOS/FreeBSD) to provide high-concurrency, high-performance network IO, please visit the [TFB Tests Results](https://www.techempower.com/benchmarks/#section=data-r19&hw=ph&test=composite) for more details;
 * Provide a completely asynchronous programming mode;

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -12,7 +12,7 @@
 **Drogon**是一个基于C++14/17的Http应用框架，使用Drogon可以方便的使用C++构建各种类型的Web应用服务端程序。
 本版本库是github上[Drogon工程](https://github.com/an-tao/drogon)的镜像库。**Drogon**是作者非常喜欢的美剧《权力的游戏》中的一条龙的名字(汉译作卓耿)，和龙有关但并不是dragon的误写，为了不至于引起不必要的误会这里说明一下。
 
-Drogon是一个跨平台框架，它支持Linux，也支持macOS、FreeBSD，OpenBSD，和Windows。它的主要特点如下：
+Drogon是一个跨平台框架，它支持Linux，也支持macOS、FreeBSD，OpenBSD，HaikuOS，和Windows。它的主要特点如下：
 
 * 网络层使用基于epoll(macOS/FreeBSD下是kqueue)的非阻塞IO框架，提供高并发、高性能的网络IO。详细请见[TFB Tests Results](https://www.techempower.com/benchmarks/#section=data-r19&hw=ph&test=composite)；
 * 全异步编程模式；

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -12,7 +12,7 @@
 **Drogon**是一個基於C++14/17的Http應用框架，使用Drogon可以方便的使用C++構建各種類型的Web App伺服器程式。
 本版本庫是github上[Drogon](https://github.com/an-tao/drogon)的鏡像庫。 **Drogon**是作者非常喜歡的美劇《冰與火之歌：權力遊戲》中的一條龍的名字(漢譯作卓耿)，和龍有關但並不是dragon的誤寫，為了不至於引起不必要的誤會這裡說明一下。
 
-Drogon是一個跨平台框架，它支援Linux，也支援macOS、FreeBSD/OpenBSD和Windows。它的主要特點如下：
+Drogon是一個跨平台框架，它支援Linux，也支援macOS、FreeBSD/OpenBSD、HaikuOS和Windows。它的主要特點如下：
 
 * 網路層使用基於epoll(macOS/FreeBSD下是kqueue)的非阻塞IO框架，提供高並發、高性能的網路IO。詳細請見[TFB Tests Results](https://www.techempower.com/benchmarks/#section=data-r19&hw=ph&test=composite)；
 * 全異步程式設計；

--- a/lib/src/AccessLogger.cc
+++ b/lib/src/AccessLogger.cc
@@ -17,9 +17,11 @@
 #include <drogon/plugins/AccessLogger.h>
 #include <regex>
 #include <thread>
-#ifndef _WIN32
+#if !defined _WIN32 && !defined __HAIKU__
 #include <unistd.h>
 #include <sys/syscall.h>
+#elif defined __HAIKU__
+#include <unistd.h>
 #else
 #include <sstream>
 #endif
@@ -343,7 +345,7 @@ void AccessLogger::outputThreadNumber(trantor::LogStream &stream,
     {
         threadId_ = getthrid();
     }
-#elif defined _WIN32
+#elif defined _WIN32 || defined __HAIKU__
     if (threadId_ == 0)
     {
         std::stringstream ss;

--- a/lib/src/SharedLibManager.cc
+++ b/lib/src/SharedLibManager.cc
@@ -107,7 +107,7 @@ void SharedLibManager::managerLibs()
                         void *oldHandle = nullptr;
                         if (dlMap_.find(filename) != dlMap_.end())
                         {
-#ifdef __linux__
+#if defined __linux__ || defined __HAIKU__
                             if (st.st_mtim.tv_sec >
                                 dlMap_[filename].mTime.tv_sec)
 #elif defined _WIN32
@@ -168,7 +168,7 @@ void SharedLibManager::managerLibs()
                             dlStat.handle =
                                 compileAndLoadLib(srcFile, oldHandle);
                         }
-#ifdef __linux__
+#if defined __linux__ || defined __HAIKU__
                         dlStat.mTime = st.st_mtim;
 #elif defined _WIN32
                         dlStat.mTime.tv_sec = st.st_mtime;
@@ -236,7 +236,7 @@ void *SharedLibManager::compileAndLoadLib(const std::string &sourceFile,
 bool SharedLibManager::shouldCompileLib(const std::string &soFile,
                                         const struct stat &sourceStat)
 {
-#ifdef __linux__
+#if defined __linux__ || defined __HAIKU__
     auto sourceModifiedTime = sourceStat.st_mtim.tv_sec;
 #elif defined _WIN32
     auto sourceModifiedTime = sourceStat.st_mtime;
@@ -251,7 +251,7 @@ bool SharedLibManager::shouldCompileLib(const std::string &soFile,
         return true;
     }
 
-#ifdef __linux__
+#if defined __linux__ || defined __HAIKU__
     auto soModifiedTime = soStat.st_mtim.tv_sec;
 #elif defined _WIN32
     auto soModifiedTime = soStat.st_mtime;

--- a/orm_lib/inc/drogon/orm/SqlBinder.h
+++ b/orm_lib/inc/drogon/orm/SqlBinder.h
@@ -41,7 +41,7 @@
 #endif
 
 #if defined __linux__ || defined __FreeBSD__ || defined __OpenBSD__ || \
-    defined __MINGW32__
+    defined __MINGW32__ || defined __HAIKU__
 
 #ifdef __linux__
 #include <endian.h>  // __BYTE_ORDER __LITTLE_ENDIAN


### PR DESCRIPTION
Make Drogon support HaikuOS

Baically:
* Adds macros to detect HaikuOS
* README updates to reflect HaikuOS support

Known issues
* PostgreSQL doesn't work due to missing symbol in their build
* A bug in Haiku's implementation of `timegm` causing unittest to fail.

```
# On HaikuOS
In test case HttpDate
↳ /boot/home/Documents/drogon/lib/tests/unittests/HttpDateTest.cc:13  FAILED:
  CHECK(date.microSecondsSinceEpoch() / 1000000 == 1591348778)
With expansion
  1591388378 == 1591348778
```