### PR TITLE
Support retreving IP information from `X-Forwarded-For` header

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -33,7 +33,11 @@
             "use_old_tls": false,
             "ssl_conf": [
                 //["MinProtocol", "TLSv1.3"]
-            ]
+            ],
+            // trust that a proxy sets `X-Forwarded-For` header and use it as the
+            // source IP. Only turn this on when behind a trusted proxy. Otherwise
+            // clients can easily fool their IP address, false by default
+            "trust_proxy": false
         }
     ],
     "db_clients": [

--- a/drogon_ctl/templates/config.csp
+++ b/drogon_ctl/templates/config.csp
@@ -33,7 +33,11 @@
             "use_old_tls": false,
             "ssl_conf": [
                 //["MinProtocol", "TLSv1.3"]
-            ]
+            ],
+            // trust that a proxy sets `X-Forwarded-For` header and use it as the
+            // source IP. Only turn this on when behind a trusted proxy. Otherwise
+            // clients can easily fool their IP address, false by default
+            "trust_proxy": false
         }
     ],
     "db_clients": [

--- a/lib/inc/drogon/HttpAppFramework.h
+++ b/lib/inc/drogon/HttpAppFramework.h
@@ -686,6 +686,11 @@ class DROGON_EXPORT HttpAppFramework : public trantor::NonCopyable
      * method is used.
      * @param useOldTLS If true, the TLS1.0/1.1 are enabled for HTTPS
      * connections.
+     * @param sslConfCmds Options for the underlying SSL library. See
+     * https://www.openssl.org/docs/man1.1.1/man3/SSL_CONF_cmd.html for detail
+     * @param trustProxy If true, trust that a proxy sets `X-Forwarded-For`
+     * header and use it as the source IP. Only turn this on when behind a
+     * trusted proxy. Otherwise clients can easily fool their IP address.
      *
      * @note
      * This operation can be performed by an option in the configuration file.
@@ -698,7 +703,8 @@ class DROGON_EXPORT HttpAppFramework : public trantor::NonCopyable
         const std::string &keyFile = "",
         bool useOldTLS = false,
         const std::vector<std::pair<std::string, std::string>> &sslConfCmds =
-            {}) = 0;
+            {},
+        bool trustProxy = false) = 0;
 
     /// Enable sessions supporting.
     /**

--- a/lib/src/ConfigLoader.cc
+++ b/lib/src/ConfigLoader.cc
@@ -567,6 +567,7 @@ static void loadListeners(const Json::Value &listeners)
         auto cert = listener.get("cert", "").asString();
         auto key = listener.get("key", "").asString();
         auto useOldTLS = listener.get("use_old_tls", false).asBool();
+        auto trustProxy = listener.get("trust_proxy", false).asBool();
         std::vector<std::pair<std::string, std::string>> sslConfCmds;
         if (listener.isMember("ssl_conf"))
         {
@@ -584,7 +585,7 @@ static void loadListeners(const Json::Value &listeners)
         }
         LOG_TRACE << "Add listener:" << addr << ":" << port;
         drogon::app().addListener(
-            addr, port, useSSL, cert, key, useOldTLS, sslConfCmds);
+            addr, port, useSSL, cert, key, useOldTLS, sslConfCmds, trustProxy);
     }
 }
 static void loadSSL(const Json::Value &sslConf)

--- a/lib/src/HttpAppFrameworkImpl.cc
+++ b/lib/src/HttpAppFrameworkImpl.cc
@@ -354,11 +354,18 @@ HttpAppFramework &HttpAppFrameworkImpl::addListener(
     const std::string &certFile,
     const std::string &keyFile,
     bool useOldTLS,
-    const std::vector<std::pair<std::string, std::string>> &sslConfCmds)
+    const std::vector<std::pair<std::string, std::string>> &sslConfCmds,
+    bool trustProxy)
 {
     assert(!running_);
-    listenerManagerPtr_->addListener(
-        ip, port, useSSL, certFile, keyFile, useOldTLS, sslConfCmds);
+    listenerManagerPtr_->addListener(ip,
+                                     port,
+                                     useSSL,
+                                     certFile,
+                                     keyFile,
+                                     useOldTLS,
+                                     sslConfCmds,
+                                     trustProxy);
     return *this;
 }
 HttpAppFramework &HttpAppFrameworkImpl::setMaxConnectionNum(

--- a/lib/src/HttpAppFrameworkImpl.h
+++ b/lib/src/HttpAppFrameworkImpl.h
@@ -59,8 +59,8 @@ class HttpAppFrameworkImpl final : public HttpAppFramework
         const std::string &certFile,
         const std::string &keyFile,
         bool useOldTLS,
-        const std::vector<std::pair<std::string, std::string>> &sslConfCmds)
-        override;
+        const std::vector<std::pair<std::string, std::string>> &sslConfCmds,
+        bool trustProxy) override;
     HttpAppFramework &setThreadNum(size_t threadNum) override;
     size_t getThreadNum() const override
     {

--- a/lib/src/HttpServer.cc
+++ b/lib/src/HttpServer.cc
@@ -762,12 +762,10 @@ void HttpServer::parseForwardHeader(
     {
         const auto &headers = requestParser->requestImpl()->getHeaders();
         auto range = headers.equal_range("forwarded");
-        LOG_WARN << "Start searching header";
         // Iterate through all Forarded header. Find the first `for` field
         for (auto it = range.first; it != range.second; ++it)
         {
             const auto &headerStr = it->second;
-            LOG_DEBUG << "Searching " << headerStr;
             bool success;
             std::multimap<std::string, std::string> fields;
             std::tie(success, fields) = parseKVPairs(headerStr);

--- a/lib/src/HttpServer.h
+++ b/lib/src/HttpServer.h
@@ -110,8 +110,8 @@ class HttpServer : trantor::NonCopyable
         const std::vector<std::pair<HttpResponsePtr, bool>> &responses,
         trantor::MsgBuffer &buffer);
     void parseForwardHeader(
-      const trantor::TcpConnectionPtr &conn,
-      const std::shared_ptr<HttpRequestParser> &requestParser);
+        const trantor::TcpConnectionPtr &conn,
+        const std::shared_ptr<HttpRequestParser> &requestParser);
     trantor::TcpServer server_;
     HttpAsyncCallback httpAsyncCallback_;
     WebSocketNewAsyncCallback newWebsocketCallback_;

--- a/lib/src/HttpServer.h
+++ b/lib/src/HttpServer.h
@@ -35,7 +35,8 @@ class HttpServer : trantor::NonCopyable
                    &syncAdvices,
                const std::vector<std::function<void(const HttpRequestPtr &,
                                                     const HttpResponsePtr &)>>
-                   &preSendingAdvices);
+                   &preSendingAdvices,
+               bool trustProxy);
 
     ~HttpServer();
 
@@ -117,6 +118,7 @@ class HttpServer : trantor::NonCopyable
     const std::vector<
         std::function<void(const HttpRequestPtr &, const HttpResponsePtr &)>>
         &preSendingAdvices_;
+    const bool trustProxy_;
 };
 
 }  // namespace drogon

--- a/lib/src/HttpServer.h
+++ b/lib/src/HttpServer.h
@@ -109,6 +109,9 @@ class HttpServer : trantor::NonCopyable
         const trantor::TcpConnectionPtr &conn,
         const std::vector<std::pair<HttpResponsePtr, bool>> &responses,
         trantor::MsgBuffer &buffer);
+    void parseForwardHeader(
+      const trantor::TcpConnectionPtr &conn,
+      const std::shared_ptr<HttpRequestParser> &requestParser);
     trantor::TcpServer server_;
     HttpAsyncCallback httpAsyncCallback_;
     WebSocketNewAsyncCallback newWebsocketCallback_;

--- a/lib/src/ListenerManager.cc
+++ b/lib/src/ListenerManager.cc
@@ -59,7 +59,8 @@ void ListenerManager::addListener(
     const std::string &certFile,
     const std::string &keyFile,
     bool useOldTLS,
-    const std::vector<std::pair<std::string, std::string>> &sslConfCmds)
+    const std::vector<std::pair<std::string, std::string>> &sslConfCmds,
+    bool trustProxy)
 {
 #ifndef OpenSSL_FOUND
     if (useSSL)
@@ -67,8 +68,14 @@ void ListenerManager::addListener(
         LOG_ERROR << "Can't use SSL without OpenSSL found in your system";
     }
 #endif
-    listeners_.emplace_back(
-        ip, port, useSSL, certFile, keyFile, useOldTLS, sslConfCmds);
+    listeners_.emplace_back(ip,
+                            port,
+                            useSSL,
+                            certFile,
+                            keyFile,
+                            useOldTLS,
+                            sslConfCmds,
+                            trustProxy);
 }
 
 std::vector<trantor::EventLoop *> ListenerManager::createListeners(
@@ -103,6 +110,7 @@ std::vector<trantor::EventLoop *> ListenerManager::createListeners(
         {
             auto const &ip = listener.ip_;
             bool isIpv6 = ip.find(':') == std::string::npos ? false : true;
+            bool trustProxy = listener.trustProxy_;
             std::shared_ptr<HttpServer> serverPtr;
             InetAddress listenAddress(ip, listener.port_, isIpv6);
             if (listenAddress.isUnspecified())
@@ -126,7 +134,8 @@ std::vector<trantor::EventLoop *> ListenerManager::createListeners(
                                                  std::move(listenAddress),
                                                  "drogon",
                                                  syncAdvices,
-                                                 preSendingAdvices);
+                                                 preSendingAdvices,
+                                                 trustProxy);
             }
             else
             {
@@ -135,7 +144,8 @@ std::vector<trantor::EventLoop *> ListenerManager::createListeners(
                                                  std::move(listenAddress),
                                                  "drogon",
                                                  syncAdvices,
-                                                 preSendingAdvices);
+                                                 preSendingAdvices,
+                                                 trustProxy);
             }
 
             if (listener.useSSL_)

--- a/lib/src/ListenerManager.cc
+++ b/lib/src/ListenerManager.cc
@@ -192,12 +192,14 @@ std::vector<trantor::EventLoop *> ListenerManager::createListeners(
             LOG_TRACE << "thread num=" << threadNum;
             auto ip = listener.ip_;
             bool isIpv6 = ip.find(':') == std::string::npos ? false : true;
+            bool trustProxy = listener.trustProxy_;
             auto serverPtr = std::make_shared<HttpServer>(
                 loopThreadPtr->getLoop(),
                 InetAddress(ip, listener.port_, isIpv6),
                 "drogon",
                 syncAdvices,
-                preSendingAdvices);
+                preSendingAdvices,
+                trustProxy);
             if (listener.useSSL_)
             {
 #ifdef OpenSSL_FOUND

--- a/lib/src/ListenerManager.h
+++ b/lib/src/ListenerManager.h
@@ -37,7 +37,8 @@ class ListenerManager : public trantor::NonCopyable
                      const std::string &keyFile = "",
                      bool useOldTLS = false,
                      const std::vector<std::pair<std::string, std::string>>
-                         &sslConfCmds = {});
+                         &sslConfCmds = {},
+                     bool trustProxy = false);
     std::vector<trantor::EventLoop *> createListeners(
         const HttpAsyncCallback &httpCallback,
         const WebSocketNewAsyncCallback &webSocketCallback,
@@ -71,14 +72,16 @@ class ListenerManager : public trantor::NonCopyable
             const std::string &certFile,
             const std::string &keyFile,
             bool useOldTLS,
-            const std::vector<std::pair<std::string, std::string>> &sslConfCmds)
+            const std::vector<std::pair<std::string, std::string>> &sslConfCmds,
+            bool trustProxy)
             : ip_(ip),
               port_(port),
               useSSL_(useSSL),
               certFile_(certFile),
               keyFile_(keyFile),
               useOldTLS_(useOldTLS),
-              sslConfCmds_(sslConfCmds)
+              sslConfCmds_(sslConfCmds),
+              trustProxy_(trustProxy)
         {
         }
         std::string ip_;
@@ -88,6 +91,7 @@ class ListenerManager : public trantor::NonCopyable
         std::string keyFile_;
         bool useOldTLS_;
         std::vector<std::pair<std::string, std::string>> sslConfCmds_;
+        bool trustProxy_;
     };
     std::vector<ListenerInfo> listeners_;
     std::vector<std::shared_ptr<HttpServer>> servers_;


### PR DESCRIPTION
As of now, when drogon is running behind a reverse proxy, drogon can only see the reverse proxy's IP as the peer IP. Which is technically true. But not what we want. Causing `AccessLogger` logging the IP of the proxy, etc... This PR adds an option `trustProxy` to listeners (name taken from express.js). When set, it uses the information in `X-Forwarded-For` header for the peer IP.