### PR TITLE
Add API to allow manually crafted requests/reroute requests

### DIFF
--- a/lib/inc/drogon/HttpAppFramework.h
+++ b/lib/inc/drogon/HttpAppFramework.h
@@ -1346,6 +1346,17 @@ class DROGON_EXPORT HttpAppFramework : public trantor::NonCopyable
      */
     virtual const ExceptionHandler &getExceptionHandler() const = 0;
 
+    /**
+     * @brief routes the HttpRequest and calls the callback once finised
+     * processing
+     * @param req A request
+     * @param callback A callable object that gets called when a response is
+     * generated
+     */
+    virtual void handleAsyncRequest(
+        const HttpRequestPtr &req,
+        std::function<void(const HttpResponsePtr &)> &&callback) = 0;
+
   private:
     virtual void registerHttpController(
         const std::string &pathPattern,

--- a/lib/src/HttpAppFrameworkImpl.cc
+++ b/lib/src/HttpAppFrameworkImpl.cc
@@ -1095,3 +1095,17 @@ HttpAppFramework &HttpAppFrameworkImpl::setDefaultHandler(
     staticFileRouterPtr_->setDefaultHandler(std::move(handler));
     return *this;
 }
+
+void HttpAppFrameworkImpl::handleAsyncRequest(
+    const HttpRequestPtr &req,
+    std::function<void(const HttpResponsePtr &)> &&callback)
+{
+    auto ptr = std::dynamic_pointer_cast<HttpRequestImpl>(req);
+    if (!ptr)
+    {
+        LOG_ERROR << "Req is not HttpRequestPtr. Ignoring.";
+        return;
+    }
+
+    onAsyncRequest(ptr, std::move(callback));
+}

--- a/lib/src/HttpAppFrameworkImpl.h
+++ b/lib/src/HttpAppFrameworkImpl.h
@@ -535,6 +535,10 @@ class HttpAppFrameworkImpl final : public HttpAppFramework
         return exceptionHandler_;
     }
 
+    void handleAsyncRequest(
+        const HttpRequestPtr &req,
+        std::function<void(const HttpResponsePtr &)> &&callback) override;
+
   private:
     void registerHttpController(const std::string &pathPattern,
                                 const internal::HttpBinderBasePtr &binder,


### PR DESCRIPTION
The PR introduces a new API `handleAsyncRequests` that allow user supplied requests to go though the AOP and HTTP router. This is useful for some tricky situation where requests need to be conditionally sent to another endpoint (I know, bad design when you have to do this). Or when users are implementing their own protocol plugins and wish to use drogon's router. 

I'm planing on using the as a way to build a [Gemini](https://gemini.circumlunar.space/) server using components of drogon (my own project, out of drogon's scope). 

