### PR TITLE
allow outside access to the file path of a HTTP response

### DIFF
--- a/lib/inc/drogon/HttpResponse.h
+++ b/lib/inc/drogon/HttpResponse.h
@@ -416,6 +416,21 @@ class DROGON_EXPORT HttpResponse
         return toResponse(std::forward<T>(obj));
     }
 
+    /**
+     * @brief If the response is a file response (i.e. created by
+     * newHttpFileResponse) returns the path on the filesystem. Otherwise a
+     * empty string.
+     */
+    virtual const std::string &sendfileName() const = 0;
+
+    /**
+     * @brief Returns the range of the file response as a pair ot size_t
+     * (offset, length). Length of 0 means the entire file is sent. Behaivor of
+     * this function is undefined if the response if not a file response
+     */
+    using SendfileRange = std::pair<size_t, size_t>;  // { offset, length }
+    virtual const SendfileRange &sendfileRange() const = 0;
+
     virtual ~HttpResponse()
     {
     }

--- a/lib/src/HttpResponseImpl.h
+++ b/lib/src/HttpResponseImpl.h
@@ -315,12 +315,11 @@ class DROGON_EXPORT HttpResponseImpl : public HttpResponse
     }
     bool shouldBeCompressed() const;
     void generateBodyFromJson() const;
-    const std::string &sendfileName() const
+    const std::string &sendfileName() const override
     {
         return sendfileName_;
     }
-    using SendfileRange = std::pair<size_t, size_t>;  // { offset, length }
-    const SendfileRange &sendfileRange() const
+    const SendfileRange &sendfileRange() const override
     {
         return sendfileRange_;
     }


### PR DESCRIPTION
Allow outside read to the file path and range of a HTTP response. 