### PR TITLE
Return on redis connection error.

### DIFF
--- a/nosql_lib/redis/src/RedisConnection.cc
+++ b/nosql_lib/redis/src/RedisConnection.cc
@@ -47,9 +47,9 @@ void RedisConnection::startConnectionInLoop()
 
         // Strange things have happend. In some kinds of connection errors, such
         // as setsockopt errors, hiredis already set redisContext_->c.fd to -1,
-        // but the tcp connection stays in ESTABLISHED status. And there is no way
-        // for us to obtain the fd of that socket nor close it.
-        // This probably is a bug of hiredis.
+        // but the tcp connection stays in ESTABLISHED status. And there is no
+        // way for us to obtain the fd of that socket nor close it. This
+        // probably is a bug of hiredis.
         return;
     }
 

--- a/nosql_lib/redis/src/RedisConnection.cc
+++ b/nosql_lib/redis/src/RedisConnection.cc
@@ -38,11 +38,21 @@ void RedisConnection::startConnectionInLoop()
     if (redisContext_->err)
     {
         LOG_ERROR << "Error: " << redisContext_->errstr;
+        redisAsyncDisconnect(redisContext_);
+
         if (disconnectCallback_)
         {
             disconnectCallback_(shared_from_this());
         }
+
+        // Strange things have happend. In some kinds of connection errors, such
+        // as setsockopt errors, hiredis already set redisContext_->c.fd to -1,
+        // but the tcp connection stays in ESTABLISHED status. And there is no way
+        // for us to obtain the fd of that socket nor close it.
+        // This probably is a bug of hiredis.
+        return;
     }
+
     redisContext_->ev.addWrite = addWrite;
     redisContext_->ev.delWrite = delWrite;
     redisContext_->ev.addRead = addRead;

--- a/nosql_lib/redis/src/RedisConnection.cc
+++ b/nosql_lib/redis/src/RedisConnection.cc
@@ -38,7 +38,6 @@ void RedisConnection::startConnectionInLoop()
     if (redisContext_->err)
     {
         LOG_ERROR << "Error: " << redisContext_->errstr;
-        redisAsyncDisconnect(redisContext_);
 
         if (disconnectCallback_)
         {


### PR DESCRIPTION
`startConnectionInLoop()` should return on redis connection error. Or dead channels will be added to poller.
