### PR TITLE
fix(MutliPart): Does not respect quotes in Content-Disposition header

### DIFF
--- a/lib/src/MultiPart.cc
+++ b/lib/src/MultiPart.cc
@@ -77,7 +77,7 @@ int MultiPartParser::parse(const HttpRequestPtr &req)
 int MultiPartParser::parseEntity(const char *begin, const char *end)
 {
     static const char entityName[] = "name=";
-    static const char quotationMark[] = ";";
+    static const char semiColon[] = ";";
     static const char fileName[] = "filename=";
     static const char CRLF[] = "\r\n\r\n";
 
@@ -85,11 +85,17 @@ int MultiPartParser::parseEntity(const char *begin, const char *end)
     if (pos == end)
         return -1;
     pos += 5;
-    auto pos1 = std::search(pos, end, quotationMark, quotationMark + 1);
+    auto pos1 = std::search(pos, end, semiColon, semiColon + 1);
     if (pos1 == end)
-        return -1;
-    if (*pos == '"') pos++;
-    if (*(pos1-1) == '"') pos1--;
+    {
+        pos1 = std::search(pos, end, CRLF, CRLF + 2);
+        if (pos1 == end)
+            return -1;
+    }
+    if (*pos == '"')
+        pos++;
+    if (*(pos1 - 1) == '"')
+        pos1--;
     std::string name(pos, pos1);
     pos = std::search(pos1, end, fileName, fileName + 9);
     if (pos == end)
@@ -103,15 +109,23 @@ int MultiPartParser::parseEntity(const char *begin, const char *end)
     else
     {
         pos += 9;
-        pos1 = std::search(pos, end, quotationMark, quotationMark + 1);
+        pos1 = std::search(pos, end, semiColon, semiColon + 1);
         if (pos1 == end)
         {
             pos1 = std::search(pos, end, CRLF, CRLF + 2);
             if (pos1 == end)
                 return -1;
         }
-        if (*pos == '"') pos++;
-        if (*(pos1-1) == '"') pos1--;
+        else
+        {
+            auto pos2 = std::search(pos, pos1, CRLF, CRLF + 2);
+            if (pos2 != end)
+                pos1 = pos2;
+        }
+        if (*pos == '"')
+            pos++;
+        if (*(pos1 - 1) == '"')
+            pos1--;
         auto filePtr = std::make_shared<HttpFileImpl>();
         filePtr->setRequest(requestPtr_);
         filePtr->setItemName(name);

--- a/lib/src/MultiPart.cc
+++ b/lib/src/MultiPart.cc
@@ -76,20 +76,22 @@ int MultiPartParser::parse(const HttpRequestPtr &req)
 
 int MultiPartParser::parseEntity(const char *begin, const char *end)
 {
-    static const char entityName[] = "name=\"";
-    static const char quotationMark[] = "\"";
-    static const char fileName[] = "filename=\"";
+    static const char entityName[] = "name=";
+    static const char quotationMark[] = ";";
+    static const char fileName[] = "filename=";
     static const char CRLF[] = "\r\n\r\n";
 
-    auto pos = std::search(begin, end, entityName, entityName + 6);
+    auto pos = std::search(begin, end, entityName, entityName + 5);
     if (pos == end)
         return -1;
-    pos += 6;
+    pos += 5;
     auto pos1 = std::search(pos, end, quotationMark, quotationMark + 1);
     if (pos1 == end)
         return -1;
+    if (*pos == '"') pos++;
+    if (*(pos1-1) == '"') pos1--;
     std::string name(pos, pos1);
-    pos = std::search(pos1, end, fileName, fileName + 10);
+    pos = std::search(pos1, end, fileName, fileName + 9);
     if (pos == end)
     {
         pos1 = std::search(pos1, end, CRLF, CRLF + 4);
@@ -100,10 +102,16 @@ int MultiPartParser::parseEntity(const char *begin, const char *end)
     }
     else
     {
-        pos += 10;
-        auto pos1 = std::search(pos, end, quotationMark, quotationMark + 1);
+        pos += 9;
+        pos1 = std::search(pos, end, quotationMark, quotationMark + 1);
         if (pos1 == end)
-            return -1;
+        {
+            pos1 = std::search(pos, end, CRLF, CRLF + 2);
+            if (pos1 == end)
+                return -1;
+        }
+        if (*pos == '"') pos++;
+        if (*(pos1-1) == '"') pos1--;
         auto filePtr = std::make_shared<HttpFileImpl>();
         filePtr->setRequest(requestPtr_);
         filePtr->setItemName(name);


### PR DESCRIPTION
Currently, Drogon MultiPart parser expects quotes for name and filename in the Content-Disposition header.

The builtin HTTP library for .NET Core (System.Net.Http.HttpClient) leaves the quotes in this header, which means that by default, .NET Core applications cannot upload files to drogon.

The [related RFC](https://datatracker.ietf.org/doc/html/rfc6266) allows for both usages.

This contribution aims to fix this and handle both cases (with or without quotes)

To test, run `file_upload` example, and execute these 3 curl commands that should all return `The server has calculated the file's MD5 hash to be D41D8CD98F00B204E9800998ECF8427E`

```sh
curl 'http://localhost:8848/upload_endpoint' \
-H 'Content-Type: multipart/form-data; boundary=----WebKitFormBoundarydOpNqjiGmshxfAhY' \
  --data-raw $'------WebKitFormBoundarydOpNqjiGmshxfAhY\r\nContent-Disposition: form-data; name="temp-ee2d580b-825c-b6ed-da2a-9c1cdbea80d8"; filename="IMG1.tif"\r\nContent-Type: image/tiff\r\n\r\n\r\n------WebKitFormBoundarydOpNqjiGmshxfAhY--\r\n' 

curl 'http://localhost:8848/upload_endpoint' \
-H 'Content-Type: multipart/form-data; boundary=----WebKitFormBoundarydOpNqjiGmshxfAhY' \
  --data-raw $'------WebKitFormBoundarydOpNqjiGmshxfAhY\r\nContent-Disposition: form-data; name=temp-ee2d580b-825c-b6ed-da2a-9c1cdbea80d8; filename=IMG1.tif\r\nContent-Type: image/tiff\r\n\r\n\r\n------WebKitFormBoundarydOpNqjiGmshxfAhY--\r\n' 

curl 'http://localhost:8848/upload_endpoint' \
-H 'Content-Type: multipart/form-data; boundary=----WebKitFormBoundarydOpNqjiGmshxfAhY' \
  --data-raw $'------WebKitFormBoundarydOpNqjiGmshxfAhY\r\nContent-Disposition: form-data; name=temp-ee2d580b-825c-b6ed-da2a-9c1cdbea80d8; filename=IMG1.tif; filename*=utf-8\'\'IMG1.tif\r\nContent-Type: image/tiff\r\n\r\n\r\n------WebKitFormBoundarydOpNqjiGmshxfAhY--\r\n' 
```

