### PR TITLE
fix(cmake): error in FindFilesystem

### DIFF
--- a/cmake_modules/FindFilesystem.cmake
+++ b/cmake_modules/FindFilesystem.cmake
@@ -199,7 +199,7 @@ if(CXX_FILESYSTEM_HAVE_FS)
 
         int main() {
             auto cwd = @CXX_FILESYSTEM_NAMESPACE@::current_path();
-            printf("%s", cwd.c_str());
+            printf("%s", cwd.generic_string().c_str());
             return EXIT_SUCCESS;
         }
     ]] code @ONLY)


### PR DESCRIPTION
When building an application on Windows using Drogon as a dependency and with warnings treated as errors, the FindFilesystem.cmake generates this error (in CMakeError.log):

```
src.cxx(6): error C2220: the following warning is treated as an error
src.cxx(6): warning C4477: 'printf' : format string '%s' requires an argument of type 'char *', but variadic argument 1 has type 'const std::filesystem::path::value_type *'
src.cxx(6): note: consider using '%ls' in the format string
src.cxx(6): note: consider using '%lls' in the format string
src.cxx(6): note: consider using '%Ls' in the format string
src.cxx(6): note: consider using '%ws' in the format string
```

Documentation of `std::filesystem::path` :
> value_type: character type used by the native encoding of the filesystem: char on POSIX, wchar_t on Windows

Using generic_string() fixes this warning