### PR TITLE
fix(style): Change the NotFound page text color

### DIFF
--- a/lib/src/NotFound.cc
+++ b/lib/src/NotFound.cc
@@ -28,7 +28,7 @@ std::string NotFound::genText(const HttpViewData &NotFound_view_data)
     std::stringstream NotFound_tmp_stream;
     NotFound_tmp_stream << "<html>\n";
     NotFound_tmp_stream << "<head><title>404 Not Found</title></head>\n";
-    NotFound_tmp_stream << "<body bgcolor=\"white\">\n";
+    NotFound_tmp_stream << "<body bgcolor=\"white\" text=\"black\">\n";
     NotFound_tmp_stream << "<center><h1>404 Not Found</h1></center>\n";
     NotFound_tmp_stream << "<hr><center>drogon/";
     NotFound_tmp_stream << NotFound_view_data.get<std::string>("version");


### PR DESCRIPTION
Key changes:
- Set the text color for 404 page to `"black"`

Refs:
- https://github.com/drogonframework/drogon/issues/977