### PR TITLE
Add async_run

### DIFF
--- a/lib/inc/drogon/utils/coroutine.h
+++ b/lib/inc/drogon/utils/coroutine.h
@@ -705,4 +705,24 @@ struct is_resumable<AsyncTask, std::void_t<AsyncTask>> : std::true_type
 template <typename T>
 constexpr bool is_resumable_v = is_resumable<T>::value;
 
+/**
+ * @brief Runs a coroutine from a regular function
+ * @param coro an resubmable object or a coroutine that takes no parameters
+ */
+template <typename Coro>
+void async_run(Coro &&coro)
+{
+    if constexpr (std::is_invocable_v<Coro>)
+        async_run(std::move(coro()));
+    else if constexpr (std::is_same_v<Coro, AsyncTask>)
+        return;  // Do nothing. AsyncTask runs on it's own.
+    else
+    {
+        using Awaiter = decltype(std::declval<Coro>().operator co_await());
+        using ResultType = decltype(std::declval<Awaiter>().await_resume());
+        static_assert(std::is_same_v<ResultType, void>);
+        [coro = std::move(coro)]() -> AsyncTask { co_await coro; }();
+    }
+}
+
 }  // namespace drogon

--- a/lib/inc/drogon/utils/coroutine.h
+++ b/lib/inc/drogon/utils/coroutine.h
@@ -715,7 +715,9 @@ void async_run(Coro &&coro)
     if constexpr (std::is_invocable_v<Coro>)
         async_run(std::move(coro()));
     else if constexpr (std::is_same_v<Coro, AsyncTask>)
-        return;  // Do nothing. AsyncTask runs on it's own.
+    {
+        // Do nothing. AsyncTask runs on it's own.
+    }
     else
     {
         using Awaiter = decltype(std::declval<Coro>().operator co_await());

--- a/lib/tests/unittests/CoroutineTest.cc
+++ b/lib/tests/unittests/CoroutineTest.cc
@@ -95,6 +95,37 @@ DROGON_TEST(CroutineBasics)
         CHECK(*ptr == 123);
     };
     sync_wait(await_non_copyable());
+
+    // TEST launching coroutine via the async_run API
+    // async_run should run the coroutine wthout waiting for anything else
+    int testVar = 0;
+    async_run([&testVar]() -> AsyncTask {
+        testVar = 1;
+        co_return;
+    }());
+    CHECK(testVar == 1);  // This only works because neither async_run nor the
+                          // coroutine within awaits
+
+    testVar = 0;
+    async_run([&testVar]() -> AsyncTask {
+        testVar = 1;
+        co_return;
+    });  // invoke coroutines with no parameters
+    CHECK(testVar == 1);
+
+    testVar = 0;
+    async_run([&testVar]() -> Task<void> {
+        testVar = 1;
+        co_return;
+    }());
+    CHECK(testVar == 1);
+
+    testVar = 0;
+    async_run([&testVar]() -> Task<void> {
+        testVar = 1;
+        co_return;
+    });
+    CHECK(testVar == 1);
 }
 
 DROGON_TEST(CompilcatedCoroutineLifetime)


### PR DESCRIPTION
Adds a function `async_run` that allows easier spawning of coroutine from normal functions. Especially useful for client side programming to launch coroutines from a thead;

instead of

```c++
app()->getLoop()->queueInLoop([](){
    []()->AsyncTask [
        startCrawlingWebPages();
    }();
});
```

We do

```c++
app()->getLoop()->queueInLoop([](){
    async_run(startCrawlingWebPages());
    // or
    // async_run(startCrawlingWebPages);
});
```