### PR TITLE
Fix coroutine objcet destructing before coroutine ends in async_run

### DIFF
--- a/lib/inc/drogon/utils/coroutine.h
+++ b/lib/inc/drogon/utils/coroutine.h
@@ -713,6 +713,8 @@ constexpr bool is_resumable_v = is_resumable<T>::value;
 template <typename Coro>
 void async_run(Coro &&coro)
 {
+    static_assert(std::is_lvalue_reference_v<Coro> == false);
+    static_assert(std::is_invocable_v<Coro>);
     auto functor = [](Coro coro) -> AsyncTask {
         auto frame = coro();
 
@@ -722,7 +724,7 @@ void async_run(Coro &&coro)
         co_await frame;
         co_return;
     };
-    functor(std::move(coro));
+    functor(std::forward<Coro>(coro));
 }
 
 /**
@@ -732,6 +734,8 @@ void async_run(Coro &&coro)
 template <typename Coro>
 std::function<void()> async_func(Coro &&coro)
 {
+    static_assert(std::is_lvalue_reference_v<Coro> == false);
+    static_assert(std::is_invocable_v<Coro>);
     return [coro = std::move(coro)]() { async_run(std::move(coro)); };
 }
 

--- a/lib/inc/drogon/utils/coroutine.h
+++ b/lib/inc/drogon/utils/coroutine.h
@@ -24,6 +24,7 @@
 #include <exception>
 #include <future>
 #include <mutex>
+#include <list>
 #include <type_traits>
 
 namespace drogon
@@ -723,7 +724,24 @@ void async_run(Coro &&coro)
         using Awaiter = decltype(std::declval<Coro>().operator co_await());
         using ResultType = decltype(std::declval<Awaiter>().await_resume());
         static_assert(std::is_same_v<ResultType, void>);
-        [coro = std::move(coro)]() -> AsyncTask { co_await coro; }();
+
+        // Stores the corotuine frame in a shared_ptr. Then store that pointer
+        // in a buffer whom's lifetime is definatelly longer than the coroutine
+        // . Finally release the pointer after await is finished. Note: Can't
+        // just pass the shared_ptr into the coroutine since the coroutine
+        // feame is destructed immidatelly after call. Destructing all lambda
+        // captures with it. Need a way to keep it alive. Also coroutines does
+        // maintaince afetr co_return. Thus can't just use a raw ptr and delete
+        // at the very end of function all.
+        thread_local static std::list<std::shared_ptr<AsyncTask>> coroInFlight;
+        std::shared_ptr<AsyncTask> ptr = std::make_shared<AsyncTask>();
+        coroInFlight.push_back(ptr);
+        *ptr = [coro = std::move(coro),
+                ptr,
+                coroIt = coroInFlight.rbegin()]() mutable -> AsyncTask {
+            co_await coro;
+            coroIt->reset();
+        }();
     }
 }
 

--- a/lib/inc/drogon/utils/coroutine.h
+++ b/lib/inc/drogon/utils/coroutine.h
@@ -719,7 +719,7 @@ void async_run(Coro &&coro)
         auto frame = coro();
 
         using FrameType = std::decay_t<decltype(frame)>;
-        static_assert(std::is_same_v<FrameType, AsyncTask> == false);
+        static_assert(is_awaitable_v<FrameType>);
 
         co_await frame;
         co_return;
@@ -736,7 +736,7 @@ std::function<void()> async_func(Coro &&coro)
 {
     static_assert(std::is_lvalue_reference_v<Coro> == false);
     static_assert(std::is_invocable_v<Coro>);
-    return [coro = std::move(coro)]() { async_run(std::move(coro)); };
+    return [coro = std::move(coro)]() mutable { async_run(std::move(coro)); };
 }
 
 }  // namespace drogon

--- a/lib/inc/drogon/utils/coroutine.h
+++ b/lib/inc/drogon/utils/coroutine.h
@@ -713,9 +713,8 @@ constexpr bool is_resumable_v = is_resumable<T>::value;
 template <typename Coro>
 void async_run(Coro &&coro)
 {
-    static_assert(std::is_lvalue_reference_v<Coro> == false);
-    static_assert(std::is_invocable_v<Coro>);
-    auto functor = [](Coro coro) -> AsyncTask {
+    using CoroValueType = std::remove_cvref_t<Coro>;
+    auto functor = [](CoroValueType coro) -> AsyncTask {
         auto frame = coro();
 
         using FrameType = std::decay_t<decltype(frame)>;
@@ -734,9 +733,9 @@ void async_run(Coro &&coro)
 template <typename Coro>
 std::function<void()> async_func(Coro &&coro)
 {
-    static_assert(std::is_lvalue_reference_v<Coro> == false);
-    static_assert(std::is_invocable_v<Coro>);
-    return [coro = std::move(coro)]() mutable { async_run(std::move(coro)); };
+    return [coro = std::forward<Coro>(coro)]() mutable {
+        async_run(std::move(coro));
+    };
 }
 
 }  // namespace drogon

--- a/lib/inc/drogon/utils/coroutine.h
+++ b/lib/inc/drogon/utils/coroutine.h
@@ -708,7 +708,7 @@ constexpr bool is_resumable_v = is_resumable<T>::value;
 
 /**
  * @brief Runs a coroutine from a regular function
- * @param coro an resubmable object or a coroutine that takes no parameters
+ * @param coro A coroutine that is awaitable
  */
 template <typename Coro>
 void async_run(Coro &&coro)
@@ -723,6 +723,16 @@ void async_run(Coro &&coro)
         co_return;
     };
     functor(std::move(coro));
+}
+
+/**
+ * @brief returns a function that calls a coroutine
+ * @param Coro A coroutine that is awaitable
+ */
+template <typename Coro>
+std::function<void()> async_wrap(Coro &&coro)
+{
+    return [coro = std::move(coro)]() { async_run(std::move(coro)); };
 }
 
 }  // namespace drogon

--- a/lib/inc/drogon/utils/coroutine.h
+++ b/lib/inc/drogon/utils/coroutine.h
@@ -730,7 +730,7 @@ void async_run(Coro &&coro)
  * @param Coro A coroutine that is awaitable
  */
 template <typename Coro>
-std::function<void()> async_wrap(Coro &&coro)
+std::function<void()> async_func(Coro &&coro)
 {
     return [coro = std::move(coro)]() { async_run(std::move(coro)); };
 }

--- a/lib/tests/unittests/CoroutineTest.cc
+++ b/lib/tests/unittests/CoroutineTest.cc
@@ -180,7 +180,7 @@ DROGON_TEST(AsyncWaitLifetime)
     });
 
     auto ptr2 = std::make_shared<std::string>("test");
-    app().getLoop()->queueInLoop(async_wrap([ptr2, TEST_CTX]() -> Task<> {
+    app().getLoop()->queueInLoop(async_func([ptr2, TEST_CTX]() -> Task<> {
         co_await sleepCoro(drogon::app().getLoop(), 0.01);
         CHECK(ptr2.use_count() == 1);
     }));

--- a/lib/tests/unittests/CoroutineTest.cc
+++ b/lib/tests/unittests/CoroutineTest.cc
@@ -178,4 +178,10 @@ DROGON_TEST(AsyncWaitLifetime)
             CHECK(ptr.use_count() == 1);
         });
     });
+
+    auto ptr2 = std::make_shared<std::string>("test");
+    app().getLoop()->queueInLoop(async_wrap([ptr2, TEST_CTX]() -> Task<> {
+        co_await sleepCoro(drogon::app().getLoop(), 0.01);
+        CHECK(ptr2.use_count() == 1);
+    }));
 }


### PR DESCRIPTION
This PR address the issue where a lambda coroutine could easily go out of scope. It updates `async_run` and provides `async_func` to assist uses to ensure their coroutines do not go out of scope.

The following code crashes in spite it's simplicity. It looks perfectly normal. Submits a task to run after 10 seconds.

```c++
std::string name = "Martin";
[name]() -> AsyncTask {
    LOG_INFO << "Hello!";
    co_await sleepCoro(app.getLoop(), 10);
    LOG_INFO << name;
}();
```

Turning on Address Sanitizer, you'll see the following output. 

```
AddressSanitizer: stack-buffer-underflow 
```

How? There's isn't even an array access. The cause is that this is fact a stack use-after-free. The root cause is that in C++, coroutines are just plain functions that returns an awaitable object. Which stores the current state of the coroutine. That lambdas are objects themselves. And the fact that these two objects really have nothing to do with each other. Let's translate the example code into how the compiler sees it. (Roughly)

```c++
struct lambda1
{
    std::string name_;
    promise suspend_1()
    {
        LOG_INFO << "Hello!";
        return promise.resume(sleepCoro(app.getLoop(), 10));
    }
    promise suspend_2()
    {
        LOG_INFO << name_;
    }
};

std::string name = "Martin";
{
    lambda1 l;
    promise.resume(l.suspend_1());
}

// Then in some other thread, 10 seconds later
promise.resume(ptr_l->suspend_2);
```

now the problem is obvious. The lambda destructed long before timer could wake it up. Hence use after free.

This PR modified `async_run` such that it forces the lifetime of the lambda object to be longer than the coroutine. **However** this is a breaking change. 

1. You can no longer `async_run` an AsyncTask (or a coroutine that returns an AsyncTask)
2. You must pass `async_run` the lambda itself. Not just the awaitable.

It also adds an `async_func` function that wraps any lambda such that the lifetime is extended when called. These perfectly safe:

```c++
std::string name = "Martin";
async_run([name]() -> Task<> {
    LOG_INFO << "Hello!";
    co_await sleepCoro(app.getLoop(), 10);
    LOG_INFO << name;
});
```

And
```c++
std::string name = "Martin";
app().getLoop()->queueInLoop(async_func([]() -> Task<> {
    LOG_INFO << "Hello!";
    co_await sleepCoro(app.getLoop(), 10);
    LOG_INFO << name;
}));
```