### PR TITLE
use decay_t instead of remove_cvref_t in async_run

### DIFF
--- a/lib/inc/drogon/utils/coroutine.h
+++ b/lib/inc/drogon/utils/coroutine.h
@@ -713,7 +713,7 @@ constexpr bool is_resumable_v = is_resumable<T>::value;
 template <typename Coro>
 void async_run(Coro &&coro)
 {
-    using CoroValueType = std::remove_cvref_t<Coro>;
+    using CoroValueType = std::decay_t<Coro>;
     auto functor = [](CoroValueType coro) -> AsyncTask {
         auto frame = coro();
 


### PR DESCRIPTION
A quick patch to fix building the last PR on my ARM workstation. For some reason GCC on Arch Linux ARM does not recognize `std::remove_cvref_t` in C++20 mode. 