### PR TITLE
Prevent drogon_ctl create_view appending new line on empty line in c++ section

### DIFF
--- a/drogon_ctl/create_view.cc
+++ b/drogon_ctl/create_view.cc
@@ -118,7 +118,7 @@ static void parseLine(std::ofstream &oSrcFile,
     {
         // std::cout<<"blank line!"<<std::endl;
         // std::cout<<streamName<<"<<\"\\n\";\n";
-        if (returnFlag)
+        if (returnFlag && !cxx_flag)
             oSrcFile << streamName << "<<\"\\n\";\n";
         return;
     }


### PR DESCRIPTION
This PR fixes a bug in `drogon_ctl create_view` appending empty lines to output when encountering empty line in c++ secion.

For example. The following CSP should have generated a single line with text "Hello World".

```
<%c++

%>
Hello world
```

But drogon_ctl generated the following code
```c++
	drogon::OStringStream test_tmp_stream;
	std::string layoutName{""};
test_tmp_stream<<"\n";
	test_tmp_stream << "Hello world\n";
```

This patch fixes it 

```c++
	drogon::OStringStream test_tmp_stream;
	std::string layoutName{""};
	test_tmp_stream << "Hello world\n";
```

This bug cause problem when declaring lambda functions within CSP. For example, the following CSP causes a compilation error due to drogon_ctl inseting `test_tmp_stream<<"\n";` into the empty line, which is within the lambda body. But the lambda did not capture the stream. Thus an error

```
<%c++
auto func = [](){

return 1;
};
%>
```