### PR TITLE
Fix compiler warnings

### DIFF
--- a/lib/inc/drogon/HttpViewData.h
+++ b/lib/inc/drogon/HttpViewData.h
@@ -107,10 +107,10 @@ class DROGON_EXPORT HttpViewData
                 }
 
                 va_copy(backup_ap, ap);
-                auto result = vsnprintf((char *)strBuffer.data(),
-                                        strBuffer.size(),
-                                        format,
-                                        backup_ap);
+                result = vsnprintf((char *)strBuffer.data(),
+                                   strBuffer.size(),
+                                   format,
+                                   backup_ap);
                 va_end(backup_ap);
 
                 if ((result >= 0) &&

--- a/lib/inc/drogon/utils/Utilities.h
+++ b/lib/inc/drogon/utils/Utilities.h
@@ -395,7 +395,9 @@ inline bool fromString<bool>(const std::string &p) noexcept(false)
         return false;
     }
     std::string l{p};
-    std::transform(p.begin(), p.end(), l.begin(), tolower);
+    std::transform(p.begin(), p.end(), l.begin(), [](unsigned char ch) {
+        return static_cast<unsigned char>(tolower(ch));
+    });
     if (l == "true")
     {
         return true;

--- a/orm_lib/inc/drogon/orm/Field.h
+++ b/orm_lib/inc/drogon/orm/Field.h
@@ -225,7 +225,7 @@ inline int8_t Field::as<int8_t>() const
 {
     if (isNull())
         return 0;
-    return atoi(result_.getValue(row_, column_));
+    return static_cast<int8_t>(atoi(result_.getValue(row_, column_)));
 }
 
 template <>


### PR DESCRIPTION
Contents:

 * Convert two implicit conversions to explicit ones
 * Do not redeclare variable in inner scope (prevent shadowing outer variable)

The conversions represent the intention of the code better and fix the compiler warnings which would prevent compiling the library with strict compiler settings.

Not redeclaring the `result` variable in ` lib/inc/drogon/HttpViewData.h` also represents the intention of the code better and also fixes associated compiler warnings.

All changes sould not change the behaviour of the code.