### PR TITLE
Support setting client certificate and SSL options on HTTP client

### DIFF
--- a/lib/inc/drogon/HttpClient.h
+++ b/lib/inc/drogon/HttpClient.h
@@ -270,11 +270,14 @@ class DROGON_EXPORT HttpClient : public trantor::NonCopyable
                              const std::string &key) = 0;
 
     /**
-     * @brief Supplies file style options for `SSL_CONF_cmd`
+     * @brief Supplies command style options for `SSL_CONF_cmd`
      *
      * @param sslConfCmds options for SSL_CONF_cmd
      * @note this method has no effect if the HTTP client is communicating via
      * unencrypted HTTP
+     * @code
+     * addSSLConfigs({{"-dhparam", "/path/to/dhparam"}, {"-strict", ""}});
+     * @endcode
      */
     virtual void addSSLConfigs(
         const std::vector<std::pair<std::string, std::string>>

--- a/lib/inc/drogon/HttpClient.h
+++ b/lib/inc/drogon/HttpClient.h
@@ -258,6 +258,17 @@ class DROGON_EXPORT HttpClient : public trantor::NonCopyable
         return port() == 80;
     }
 
+    /**
+     * @brief Set the client certificate used by the HTTP connection
+     *
+     * @param cert Path to the certificate
+     * @param key Path to the certificate's private key
+     * @note this method has no effect if the HTTP client is communicating via
+     * unencrypted HTTP
+     */
+    virtual void setCertPath(const std::string &cert,
+                             const std::string &key) = 0;
+
     /// Create a Http client using the hostString to connect to server
     /**
      *

--- a/lib/inc/drogon/HttpClient.h
+++ b/lib/inc/drogon/HttpClient.h
@@ -269,6 +269,17 @@ class DROGON_EXPORT HttpClient : public trantor::NonCopyable
     virtual void setCertPath(const std::string &cert,
                              const std::string &key) = 0;
 
+    /**
+     * @brief Supplies file style options for `SSL_CONF_cmd`
+     *
+     * @param sslConfCmds options for SSL_CONF_cmd
+     * @note this method has no effect if the HTTP client is communicating via
+     * unencrypted HTTP
+     */
+    virtual void addSSLConfigs(
+        const std::vector<std::pair<std::string, std::string>>
+            &sslConfCmds) = 0;
+
     /// Create a Http client using the hostString to connect to server
     /**
      *

--- a/lib/src/HttpClientImpl.cc
+++ b/lib/src/HttpClientImpl.cc
@@ -39,14 +39,10 @@ void HttpClientImpl::createTcpClient()
     {
         LOG_TRACE << "useOldTLS=" << useOldTLS_;
         LOG_TRACE << "domain=" << domain_;
-        if (!clientCertPath_.empty() && !clientKeyPath_.empty())
-            tcpClientPtr_->enableSSL(useOldTLS_, validateCert_, domain_);
-        else
-            tcpClientPtr_->enableSSL(useOldTLS_,
-                                     validateCert_,
-                                     domain_,
-                                     {{"-cert", clientCertPath_},
-                                      {"-key", clientKeyPath_}});
+        tcpClientPtr_->enableSSL(useOldTLS_,
+                                 validateCert_,
+                                 domain_,
+                                 sslConfCmds_);
     }
 #endif
     auto thisPtr = shared_from_this();
@@ -656,6 +652,15 @@ void HttpClientImpl::handleCookies(const HttpResponseImplPtr &resp)
 void HttpClientImpl::setCertPath(const std::string &cert,
                                  const std::string &key)
 {
-    clientCertPath_ = cert;
-    clientKeyPath_ = key;
+    sslConfCmds_.push_back(std::make_pair("-cert", cert));
+    sslConfCmds_.push_back(std::make_pair("-key", key));
+}
+
+void HttpClientImpl::addSSLConfigs(
+    const std::vector<std::pair<std::string, std::string>> &sslConfCmds)
+{
+    for (const auto &cmd : sslConfCmds)
+    {
+        sslConfCmds_.push_back(cmd);
+    }
 }

--- a/lib/src/HttpClientImpl.cc
+++ b/lib/src/HttpClientImpl.cc
@@ -42,7 +42,9 @@ void HttpClientImpl::createTcpClient()
         tcpClientPtr_->enableSSL(useOldTLS_,
                                  validateCert_,
                                  domain_,
-                                 sslConfCmds_);
+                                 sslConfCmds_,
+                                 clientCertPath_,
+                                 clientKeyPath_);
     }
 #endif
     auto thisPtr = shared_from_this();
@@ -652,8 +654,8 @@ void HttpClientImpl::handleCookies(const HttpResponseImplPtr &resp)
 void HttpClientImpl::setCertPath(const std::string &cert,
                                  const std::string &key)
 {
-    sslConfCmds_.push_back(std::make_pair("-cert", cert));
-    sslConfCmds_.push_back(std::make_pair("-key", key));
+    clientCertPath_ = cert;
+    clientKeyPath_ = key;
 }
 
 void HttpClientImpl::addSSLConfigs(

--- a/lib/src/HttpClientImpl.cc
+++ b/lib/src/HttpClientImpl.cc
@@ -39,7 +39,14 @@ void HttpClientImpl::createTcpClient()
     {
         LOG_TRACE << "useOldTLS=" << useOldTLS_;
         LOG_TRACE << "domain=" << domain_;
-        tcpClientPtr_->enableSSL(useOldTLS_, validateCert_, domain_);
+        if (!clientCertPath_.empty() && !clientKeyPath_.empty())
+            tcpClientPtr_->enableSSL(useOldTLS_, validateCert_, domain_);
+        else
+            tcpClientPtr_->enableSSL(useOldTLS_,
+                                     validateCert_,
+                                     domain_,
+                                     {{"-cert", clientCertPath_},
+                                      {"-key", clientKeyPath_}});
     }
 #endif
     auto thisPtr = shared_from_this();
@@ -644,4 +651,11 @@ void HttpClientImpl::handleCookies(const HttpResponseImplPtr &resp)
             validCookies_.emplace_back(cookie);
         }
     }
+}
+
+void HttpClientImpl::setCertPath(const std::string &cert,
+                                 const std::string &key)
+{
+    clientCertPath_ = cert;
+    clientKeyPath_ = key;
 }

--- a/lib/src/HttpClientImpl.h
+++ b/lib/src/HttpClientImpl.h
@@ -102,6 +102,8 @@ class HttpClientImpl final : public HttpClient,
     }
 
     void setCertPath(const std::string &cert, const std::string &key) override;
+    void addSSLConfigs(const std::vector<std::pair<std::string, std::string>>
+                           &sslConfCmds) override;
 
   private:
     std::shared_ptr<trantor::TcpClient> tcpClientPtr_;
@@ -135,8 +137,7 @@ class HttpClientImpl final : public HttpClient,
     std::shared_ptr<trantor::Resolver> resolverPtr_;
     bool useOldTLS_{false};
     std::string userAgent_{"DrogonClient"};
-    std::string clientCertPath_;
-    std::string clientKeyPath_;
+    std::vector<std::pair<std::string, std::string>> sslConfCmds_;
 };
 using HttpClientImplPtr = std::shared_ptr<HttpClientImpl>;
 }  // namespace drogon

--- a/lib/src/HttpClientImpl.h
+++ b/lib/src/HttpClientImpl.h
@@ -101,6 +101,8 @@ class HttpClientImpl final : public HttpClient,
         return useSSL_;
     }
 
+    void setCertPath(const std::string &cert, const std::string &key) override;
+
   private:
     std::shared_ptr<trantor::TcpClient> tcpClientPtr_;
     trantor::EventLoop *loop_;
@@ -133,6 +135,8 @@ class HttpClientImpl final : public HttpClient,
     std::shared_ptr<trantor::Resolver> resolverPtr_;
     bool useOldTLS_{false};
     std::string userAgent_{"DrogonClient"};
+    std::string clientCertPath_;
+    std::string clientKeyPath_;
 };
 using HttpClientImplPtr = std::shared_ptr<HttpClientImpl>;
 }  // namespace drogon

--- a/lib/src/HttpClientImpl.h
+++ b/lib/src/HttpClientImpl.h
@@ -138,6 +138,8 @@ class HttpClientImpl final : public HttpClient,
     bool useOldTLS_{false};
     std::string userAgent_{"DrogonClient"};
     std::vector<std::pair<std::string, std::string>> sslConfCmds_;
+    std::string clientCertPath_;
+    std::string clientKeyPath_;
 };
 using HttpClientImplPtr = std::shared_ptr<HttpClientImpl>;
 }  // namespace drogon


### PR DESCRIPTION
Resolves #1083 

Usage example

```
auto client = HttpClient::newHttpClient("https://example.com");
client->setCertPath("./cert.pem", "./key.pem");
```

I've tested with a nodejs server that rejects all connections without client certificates.

Server:

```js
var fs = require('fs');
var https = require('https');

var options = {
    key: fs.readFileSync('server_key.pem'),
    cert: fs.readFileSync('server_cert.pem'),
    requestCert: true,
    rejectUnauthorized: false,

};

https.createServer(options, function (req, res) {
  console.log(req.socket.getPeerCertificate(true).raw.toString('base64'));
  res.writeHead(200);
  res.end("hello world\n");
}).listen(8000);
```
Client:
```c++
int main()
{
    trantor::Logger::setLogLevel(trantor::Logger::kTrace);
    auto client = HttpClient::newHttpClient("https://localhost:8000/", app().getLoop(), false, false);
    client->setCertPath(
        "./client_cert.pem",
        "./client_key.pem");
    auto req = HttpRequest::newHttpRequest();

    client->sendRequest(
        req, [](ReqResult, const HttpResponsePtr &response) {
            std::cout << "receive response!" << std::endl;
            std::cout << response->getBody() << std::endl;
        });

    app().run();
}
```

Result:

Server
```
MIIBtzCCAT2gAwIBAgIBATAKBggqhkjOPQQDAjA0MRUwEwYDVQQKDAxnbW5pc3J2IHVzZXIxGzAZBgNVBAMMEmdlbWluaS5jbGVoYXh6ZS50dzAgFw0yMTExMTcwMDQ3MjlaGA97MDg5MTIwNTA0MDEzNlowNDEVMBMGA1UECgwMZ21uaXNydiB1c2VyMRswGQYDVQQDDBJnZW1pbmkuY2xlaGF4emUudHcwdjAQBgcqhkjOPQIBBgUrgQQAIgNiAATvNWCaOC6jE5RSNVGyGWPm0P04qThZePsSJ+eQQwNhh8nGSAAZUbmfQ5fbk8fpQx5UwlWzOc65+CIemRDAIUjV2eoEwk+WVuFDBB6i6QPIkL1Acu7SucOOzft0VCDwrYKjITAfMB0GA1UdEQQWMBSCEmdlbWluaS5jbGVoYXh6ZS50dzAKBggqhkjOPQQDAgNoADBlAjAubojonp5Ftv14mvjhBMHBJ4DOYH1N/uPotFDvJKc62Sqo3hz3bRTnVsNPQu8sOy8CMQDquXkiSFMHRvxmY3WoNGaHlg1JrZZmLYszk4cY3n++eYP9z4VpgY2dNZwLkJaZ7Kk=
```

Client
```
20211125 14:34:04.799876 UTC 3151536 TRACE [HttpClientImpl] userSSL=1 domain=localhost - HttpClientImpl.cc:237
20211125 14:34:04.802170 UTC 3151536 TRACE [onQueryResult] onQueryResult 0 - AresResolver.cc:173
20211125 14:34:04.802282 UTC 3151536 TRACE [operator()] dns:domain=localhost;ip=127.0.0.1 - HttpClientImpl.cc:391
20211125 14:34:04.802319 UTC 3151536 TRACE [createTcpClient] New TcpClient,127.0.0.1:8000 - HttpClientImpl.cc:33
20211125 14:34:04.802351 UTC 3151536 TRACE [TcpClient] TcpClient::TcpClient[httpClient] - connector  - TcpClient.cc:75
20211125 14:34:04.802366 UTC 3151536 TRACE [createTcpClient] useOldTLS=0 - HttpClientImpl.cc:40
20211125 14:34:04.802375 UTC 3151536 TRACE [createTcpClient] domain=localhost - HttpClientImpl.cc:41
20211125 14:34:04.814953 UTC 3151536 TRACE [connect] TcpClient::connect[httpClient] - connecting to 127.0.0.1:8000 - TcpClient.cc:110
20211125 14:34:04.815035 UTC 3151536 TRACE [createNonblockingSocketOrDie] sock=6 - Socket.h:46
20211125 14:34:04.815181 UTC 3151536 TRACE [connect] connecting - Connector.cc:78
20211125 14:34:04.815222 UTC 3151536 TRACE [connecting] connecting:6 - Connector.cc:136
20211125 14:34:04.815287 UTC 3151536 TRACE [run] Start to run... - HttpAppFrameworkImpl.cc:449
20211125 14:34:04.818975 UTC 3151536 TRACE [createListeners] thread num=1 - ListenerManager.cc:98
20211125 14:34:04.820061 UTC 3151536 TRACE [TcpConnectionImpl] new connection:127.0.0.1:8000->127.0.0.1:45724 - TcpConnectionImpl.cc:1673
20211125 14:34:04.820512 UTC 3151536 TRACE [operator()] connectEstablished - TcpConnectionImpl.cc:887
20211125 14:34:04.820651 UTC 3151536 TRACE [writeCallback] write Callback - TcpConnectionImpl.cc:855
20211125 14:34:04.821357 UTC 3151536 TRACE [doHandshaking] hand shaking: -1 - TcpConnectionImpl.cc:1751
20211125 14:34:04.821384 UTC 3151536 TRACE [doHandshaking] hand shaking: 2 - TcpConnectionImpl.cc:1783
20211125 14:34:04.822956 UTC 3151536 TRACE [readCallback] read Callback - TcpConnectionImpl.cc:637
20211125 14:34:04.829454 UTC 3151536 TRACE [doHandshaking] hand shaking: 1 - TcpConnectionImpl.cc:1751
20211125 14:34:04.829560 UTC 3151536 TRACE [operator()] Connection established! - HttpClientImpl.cc:63
20211125 14:34:04.829595 UTC 3151536 TRACE [sendReq] Send request:GET / HTTP/1.1
user-agent: DrogonClient
host: localhost:8000
connection: Keep-Alive

 - HttpClientImpl.cc:478
20211125 14:34:04.829685 UTC 3151536 TRACE [writeInLoop] send in loop - TcpConnectionImpl.cc:1607
20211125 14:34:04.836596 UTC 3151536 TRACE [readCallback] read Callback - TcpConnectionImpl.cc:637
20211125 14:34:04.836911 UTC 3151536 TRACE [readCallback] ssl read:-1 bytes - TcpConnectionImpl.cc:656
20211125 14:34:04.845673 UTC 3151536 TRACE [readCallback] read Callback - TcpConnectionImpl.cc:637
20211125 14:34:04.845737 UTC 3151536 TRACE [readCallback] ssl read:153 bytes - TcpConnectionImpl.cc:656
20211125 14:34:04.845765 UTC 3151536 TRACE [processResponseLine] 1 - HttpResponseParser.cc:46
20211125 14:34:04.845784 UTC 3151536 TRACE [processResponseLine] 200 OK - HttpResponseParser.cc:67
receive response!
hello world

20211125 14:34:09.855166 UTC 3151536 TRACE [readCallback] read Callback - TcpConnectionImpl.cc:637
20211125 14:34:09.855260 UTC 3151536 TRACE [readCallback] ssl read:0 bytes - TcpConnectionImpl.cc:656
20211125 14:34:09.855291 UTC 3151536 TRACE [readCallback] ssl read err:5 - TcpConnectionImpl.cc:667
20211125 14:34:09.855308 UTC 3151536 TRACE [handleClose] connection closed, fd=6 - TcpConnectionImpl.cc:909
20211125 14:34:09.855339 UTC 3151536 TRACE [operator()] connection disconnect - HttpClientImpl.cc:77
20211125 14:34:09.855361 UTC 3151536 TRACE [~TcpClient] TcpClient::~TcpClient[httpClient] - connector  - TcpClient.cc:80
20211125 14:34:09.855481 UTC 3151536 TRACE [handleClose] to call close callback - TcpConnectionImpl.cc:919
20211125 14:34:09.856242 UTC 3151536 TRACE [~Socket] Socket deconstructed:6 - Socket.cc:241
```

This PR needs a patch in trantor