### PR TITLE
Handle SIGINT too

### DIFF
--- a/lib/src/HttpAppFrameworkImpl.cc
+++ b/lib/src/HttpAppFrameworkImpl.cc
@@ -186,6 +186,11 @@ static void TERMFunction(int sig)
         LOG_WARN << "SIGTERM signal received.";
         HttpAppFrameworkImpl::instance().getTermSignalHandler()();
     }
+    else if (sig == SIGINT)
+    {
+        LOG_WARN << "SIGINT signal received.";
+        HttpAppFrameworkImpl::instance().getTermSignalHandler()();
+    }
 }
 
 }  // namespace drogon
@@ -492,7 +497,17 @@ void HttpAppFrameworkImpl::run()
     }
     if (handleSigterm_)
     {
-        signal(SIGTERM, TERMFunction);
+        struct sigaction sa;
+        sa.sa_handler = TERMFunction;
+        sigemptyset(&sa.sa_mask);
+        if (sigaction(SIGINT, &sa, NULL) == -1) {
+            LOG_ERROR << "sigaction() failed, can't set SIGINT handler";
+            abort();
+        }
+        if (sigaction(SIGTERM, &sa, NULL) == -1) {
+            LOG_ERROR << "sigaction() failed, can't set SIGINT handler";
+            abort();
+        }
     }
     // set logger
     if (!logPath_.empty())

--- a/lib/src/HttpAppFrameworkImpl.cc
+++ b/lib/src/HttpAppFrameworkImpl.cc
@@ -497,6 +497,10 @@ void HttpAppFrameworkImpl::run()
     }
     if (handleSigterm_)
     {
+#ifdef WIN32
+        signal(SIGTERM, TERMFunction);
+        signal(SIGINT, TERMFunction);
+#else
         struct sigaction sa;
         sa.sa_handler = TERMFunction;
         sigemptyset(&sa.sa_mask);
@@ -510,6 +514,7 @@ void HttpAppFrameworkImpl::run()
             LOG_ERROR << "sigaction() failed, can't set SIGTERM handler";
             abort();
         }
+#endif
     }
     // set logger
     if (!logPath_.empty())

--- a/lib/src/HttpAppFrameworkImpl.cc
+++ b/lib/src/HttpAppFrameworkImpl.cc
@@ -500,11 +500,13 @@ void HttpAppFrameworkImpl::run()
         struct sigaction sa;
         sa.sa_handler = TERMFunction;
         sigemptyset(&sa.sa_mask);
-        if (sigaction(SIGINT, &sa, NULL) == -1) {
+        if (sigaction(SIGINT, &sa, NULL) == -1)
+        {
             LOG_ERROR << "sigaction() failed, can't set SIGINT handler";
             abort();
         }
-        if (sigaction(SIGTERM, &sa, NULL) == -1) {
+        if (sigaction(SIGTERM, &sa, NULL) == -1)
+        {
             LOG_ERROR << "sigaction() failed, can't set SIGINT handler";
             abort();
         }

--- a/lib/src/HttpAppFrameworkImpl.cc
+++ b/lib/src/HttpAppFrameworkImpl.cc
@@ -507,7 +507,7 @@ void HttpAppFrameworkImpl::run()
         }
         if (sigaction(SIGTERM, &sa, NULL) == -1)
         {
-            LOG_ERROR << "sigaction() failed, can't set SIGINT handler";
+            LOG_ERROR << "sigaction() failed, can't set SIGTERM handler";
             abort();
         }
     }


### PR DESCRIPTION
Maybe it would be nice to also handle SIGINT's too because for the moment nothing happens when I use Ctrl-C on the terminal.
Obviously this isn't meant for production but when testing the server it's nice to be able to quickly close and restart it.
I guess the user could implement it himself in his own server implementation but it doesn't seem irrelevant to me to have it included.

If you end up rejecting this PR for the SIGINT, at least consider changing signal calls to sigaction, I can open a new PR if needed.