### PR TITLE
Mark all awaiters as nodiscard

### DIFF
--- a/lib/inc/drogon/WebSocketClient.h
+++ b/lib/inc/drogon/WebSocketClient.h
@@ -36,7 +36,8 @@ using WebSocketRequestCallback = std::function<
 #ifdef __cpp_impl_coroutine
 namespace internal
 {
-struct WebSocketConnectionAwaiter : public CallbackAwaiter<HttpResponsePtr>
+struct [[nodiscard]] WebSocketConnectionAwaiter
+    : public CallbackAwaiter<HttpResponsePtr>
 {
     WebSocketConnectionAwaiter(WebSocketClient *client, HttpRequestPtr req)
         : client_(client), req_(std::move(req))

--- a/lib/inc/drogon/utils/coroutine.h
+++ b/lib/inc/drogon/utils/coroutine.h
@@ -648,7 +648,7 @@ inline auto co_future(Await &&await) noexcept
 
 namespace internal
 {
-struct TimerAwaiter : CallbackAwaiter<void>
+struct [[nodiscard]] TimerAwaiter : CallbackAwaiter<void>
 {
     TimerAwaiter(trantor::EventLoop *loop,
                  const std::chrono::duration<double> &delay)

--- a/nosql_lib/redis/inc/drogon/nosql/RedisClient.h
+++ b/nosql_lib/redis/inc/drogon/nosql/RedisClient.h
@@ -34,7 +34,7 @@ class RedisClient;
 class RedisTransaction;
 namespace internal
 {
-struct RedisAwaiter : public CallbackAwaiter<RedisResult>
+struct [[nodiscard]] RedisAwaiter : public CallbackAwaiter<RedisResult>
 {
     using RedisFunction =
         std::function<void(RedisResultCallback &&, RedisExceptionCallback &&)>;
@@ -60,7 +60,7 @@ struct RedisAwaiter : public CallbackAwaiter<RedisResult>
     RedisFunction function_;
 };
 
-struct RedisTransactionAwaiter
+struct [[nodiscard]] RedisTransactionAwaiter
     : public CallbackAwaiter<std::shared_ptr<RedisTransaction> >
 {
     RedisTransactionAwaiter(RedisClient *client) : client_(client)

--- a/orm_lib/inc/drogon/orm/CoroMapper.h
+++ b/orm_lib/inc/drogon/orm/CoroMapper.h
@@ -23,7 +23,7 @@ namespace orm
 namespace internal
 {
 template <typename ReturnType>
-struct MapperAwaiter : public CallbackAwaiter<ReturnType>
+struct [[nodiscard]] MapperAwaiter : public CallbackAwaiter<ReturnType>
 {
     using MapperFunction =
         std::function<void(std::function<void(ReturnType result)> &&,

--- a/orm_lib/inc/drogon/orm/DbClient.h
+++ b/orm_lib/inc/drogon/orm/DbClient.h
@@ -46,7 +46,7 @@ class DbClient;
 namespace internal
 {
 #ifdef __cpp_impl_coroutine
-struct SqlAwaiter : public CallbackAwaiter<Result>
+struct [[nodiscard]] SqlAwaiter : public CallbackAwaiter<Result>
 {
     SqlAwaiter(internal::SqlBinder &&binder) : binder_(std::move(binder))
     {
@@ -69,7 +69,7 @@ struct SqlAwaiter : public CallbackAwaiter<Result>
     internal::SqlBinder binder_;
 };
 
-struct TransactionAwaiter
+struct [[nodiscard]] TransactionAwaiter
     : public CallbackAwaiter<std::shared_ptr<Transaction> >
 {
     TransactionAwaiter(DbClient *client) : client_(client)


### PR DESCRIPTION
Currently the nodiscard tag is added to `Task<T>` to remind users to await their coroutines. This PR marks all Awaiters as nodiscard too so none of them can slip through and ignored.