### PR TITLE
Fix CI to actually build in C++14

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -161,7 +161,7 @@ jobs:
       if: matrix.buildname == 'ubuntu-20.04/C++14'
       run: |
         [[ ${{ matrix.link }} == "SHARED" ]] && shared="ON" || shared="OFF"
-        cmake .. -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DBUILD_TESTING=on -DCMAKE_CXX_VERSION=14 -DBUILD_DROGON_SHARED=$shared
+        cmake .. -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DBUILD_TESTING=on -DCMAKE_CXX_STANDARD=14 -DBUILD_DROGON_SHARED=$shared
 
     - name: (Linux) Build
       working-directory: ./build

--- a/lib/src/StaticFileRouter.cc
+++ b/lib/src/StaticFileRouter.cc
@@ -289,7 +289,7 @@ static bool getFileStat(const std::string &filePath, FileStat &myStat)
 #endif
         std::string &timeStr = myStat.modifiedTimeStr_;
         timeStr.resize(64);
-        size_t len = strftime((char*)timeStr.data(),
+        size_t len = strftime((char *)timeStr.data(),
                               timeStr.size(),
                               "%a, %d %b %Y %H:%M:%S GMT",
                               &myStat.modifiedTime_);

--- a/lib/src/StaticFileRouter.cc
+++ b/lib/src/StaticFileRouter.cc
@@ -289,7 +289,7 @@ static bool getFileStat(const std::string &filePath, FileStat &myStat)
 #endif
         std::string &timeStr = myStat.modifiedTimeStr_;
         timeStr.resize(64);
-        size_t len = strftime(timeStr.data(),
+        size_t len = strftime((char*)timeStr.data(),
                               timeStr.size(),
                               "%a, %d %b %Y %H:%M:%S GMT",
                               &myStat.modifiedTime_);


### PR DESCRIPTION
Now in CI logs

```
-- Found std::filesystem
-- use c++14
-- Found Boost: /usr/lib/x86_64-linux-gnu/cmake/Boost-1.71.0/BoostConfig.cmake (found suitable version "1.71.0", minimum required is "1.61.0")  
-- Using Boost filesystem, string_view and any
```