### PR TITLE
Fix signal handle

### DIFF
--- a/lib/inc/drogon/HttpAppFramework.h
+++ b/lib/inc/drogon/HttpAppFramework.h
@@ -1108,6 +1108,19 @@ class DROGON_EXPORT HttpAppFramework : public trantor::NonCopyable
     virtual HttpAppFramework &setTermSignalHandler(
         const std::function<void()> &handler) = 0;
 
+    /**
+     * @brief Set the INT Signal Handler. This method provides a way to users
+     * for exiting program gracefully. When the INT signal is received after
+     * app().run() is called, the handler is invoked. Drogon uses a default
+     * signal handler for the INT signal, which calls the 'app().quit()' method
+     * when the INT signal is received.
+     *
+     * @param handler
+     * @return HttpAppFramework&
+     */
+    virtual HttpAppFramework &setIntSignalHandler(
+        const std::function<void()> &handler) = 0;
+
     /// Get homepage, default is "index.html"
     /**
      * @note

--- a/lib/src/HttpAppFrameworkImpl.cc
+++ b/lib/src/HttpAppFrameworkImpl.cc
@@ -189,7 +189,7 @@ static void TERMFunction(int sig)
     else if (sig == SIGINT)
     {
         LOG_WARN << "SIGINT signal received.";
-        HttpAppFrameworkImpl::instance().getTermSignalHandler()();
+        HttpAppFrameworkImpl::instance().getIntSignalHandler()();
     }
 }
 

--- a/lib/src/HttpAppFrameworkImpl.cc
+++ b/lib/src/HttpAppFrameworkImpl.cc
@@ -504,6 +504,7 @@ void HttpAppFrameworkImpl::run()
         struct sigaction sa;
         sa.sa_handler = TERMFunction;
         sigemptyset(&sa.sa_mask);
+        sa.sa_flags = 0;
         if (sigaction(SIGINT, &sa, NULL) == -1)
         {
             LOG_ERROR << "sigaction() failed, can't set SIGINT handler";

--- a/lib/src/HttpAppFrameworkImpl.h
+++ b/lib/src/HttpAppFrameworkImpl.h
@@ -357,6 +357,16 @@ class HttpAppFrameworkImpl final : public HttpAppFramework
     {
         return termSignalHandler_;
     }
+    HttpAppFramework &setIntSignalHandler(
+        const std::function<void()> &handler) override
+    {
+        intSignalHandler_ = handler;
+        return *this;
+    }
+    const std::function<void()> &getIntSignalHandler() const
+    {
+        return intSignalHandler_;
+    }
     HttpAppFramework &setImplicitPageEnable(bool useImplicitPage) override;
     bool isImplicitPageEnabled() const override;
     HttpAppFramework &setImplicitPage(
@@ -622,6 +632,7 @@ class HttpAppFrameworkImpl final : public HttpAppFramework
     size_t clientMaxWebSocketMessageSize_{128 * 1024};
     std::string homePageFile_{"index.html"};
     std::function<void()> termSignalHandler_{[]() { app().quit(); }};
+    std::function<void()> intSignalHandler_{[]() { app().quit(); }};
     std::unique_ptr<SessionManager> sessionManagerPtr_;
     Json::Value jsonConfig_;
     HttpResponsePtr custom404_;


### PR DESCRIPTION
`sa_flags` should be set properly, or it may be a wild value causing `sigaction()` to fail with `errno = EINVAL`.

Need someone to look into the man page to decide what value should sa_flags be. @marty1885  @an-tao 

https://www.man7.org/linux/man-pages/man3/sigaction.3p.html