### PR TITLE
Fix WS test potentially can get stuck

### DIFF
--- a/lib/tests/integration_test/client/MultipleWsTest.cc
+++ b/lib/tests/integration_test/client/MultipleWsTest.cc
@@ -7,46 +7,56 @@
 using namespace drogon;
 using namespace std::chrono_literals;
 
-static std::vector<WebSocketClientPtr> wsClients_;
+struct DataPack
+{
+    WebSocketClientPtr wsPtr;
+    std::shared_ptr<drogon::test::CaseBase> TEST_CTX;
+};
+
 static const int kClientCount = 100;
 
 DROGON_TEST(MultipleWsTest)
 {
-    wsClients_.reserve(kClientCount);
     for (size_t i = 0; i < kClientCount; i++)
     {
         auto wsPtr = WebSocketClient::newWebSocketClient("127.0.0.1", 8848);
+        auto pack = std::make_shared<DataPack*>(new DataPack{wsPtr, TEST_CTX});
+
         wsPtr->setMessageHandler(
-            [TEST_CTX, i](const std::string &message,
+            [pack, i](const std::string &message,
                           const WebSocketClientPtr &wsPtr,
                           const WebSocketMessageType &type) mutable {
+                if(pack == nullptr)
+                    return;
+                auto TEST_CTX = (*pack)->TEST_CTX;
                 CHECK((type == WebSocketMessageType::Text ||
                        type == WebSocketMessageType::Pong));
                 if (type == WebSocketMessageType::Pong && TEST_CTX != nullptr)
                 {
+                    auto wsPtr = (*pack)->wsPtr;
+
                     // Check if the correct connection got the result
                     wsPtr->stop();
-                    wsClients_[i].reset();
                     CHECK(message == std::to_string(i));
-                    TEST_CTX = {};
+                    delete *pack;
+                    pack = nullptr;
                 }
             });
-        wsClients_.emplace_back(std::move(wsPtr));
-    }
-    for (size_t i = 0; i < kClientCount; i++)
-    {
         auto req = HttpRequest::newHttpRequest();
         req->setPath("/chat");
-        wsClients_[i]->connectToServer(
+        wsPtr->connectToServer(
             req,
-            [TEST_CTX, i](ReqResult r,
+            [pack, i](ReqResult r,
                           const HttpResponsePtr &resp,
                           const WebSocketClientPtr &wsPtr) mutable {
+                auto TEST_CTX = (*pack)->TEST_CTX;
+                CHECK((*pack)->wsPtr == wsPtr);
                 CHECK(r == ReqResult::Ok);
                 if (r != ReqResult::Ok)
                 {
                     wsPtr->stop();
-                    wsClients_[i].reset();
+                    delete *pack;
+                    pack = nullptr;
                 }
                 REQUIRE(wsPtr != nullptr);
                 REQUIRE(resp != nullptr);

--- a/lib/tests/integration_test/client/MultipleWsTest.cc
+++ b/lib/tests/integration_test/client/MultipleWsTest.cc
@@ -20,13 +20,13 @@ DROGON_TEST(MultipleWsTest)
     for (size_t i = 0; i < kClientCount; i++)
     {
         auto wsPtr = WebSocketClient::newWebSocketClient("127.0.0.1", 8848);
-        auto pack = std::make_shared<DataPack*>(new DataPack{wsPtr, TEST_CTX});
+        auto pack = std::make_shared<DataPack *>(new DataPack{wsPtr, TEST_CTX});
 
         wsPtr->setMessageHandler(
             [pack, i](const std::string &message,
-                          const WebSocketClientPtr &wsPtr,
-                          const WebSocketMessageType &type) mutable {
-                if(pack == nullptr)
+                      const WebSocketClientPtr &wsPtr,
+                      const WebSocketMessageType &type) mutable {
+                if (pack == nullptr)
                     return;
                 auto TEST_CTX = (*pack)->TEST_CTX;
                 CHECK((type == WebSocketMessageType::Text ||
@@ -47,8 +47,8 @@ DROGON_TEST(MultipleWsTest)
         wsPtr->connectToServer(
             req,
             [pack, i](ReqResult r,
-                          const HttpResponsePtr &resp,
-                          const WebSocketClientPtr &wsPtr) mutable {
+                      const HttpResponsePtr &resp,
+                      const WebSocketClientPtr &wsPtr) mutable {
                 auto TEST_CTX = (*pack)->TEST_CTX;
                 CHECK((*pack)->wsPtr == wsPtr);
                 CHECK(r == ReqResult::Ok);

--- a/lib/tests/integration_test/client/WebSocketTest.cc
+++ b/lib/tests/integration_test/client/WebSocketTest.cc
@@ -17,53 +17,54 @@ static WebSocketClientPtr wsPtr_;
 DROGON_TEST(WebSocketTest)
 {
     wsPtr_ = WebSocketClient::newWebSocketClient("127.0.0.1", 8848);
-    auto pack = std::make_shared<DataPack>(DataPack{wsPtr_, TEST_CTX});
+    auto pack = std::make_shared<DataPack*>(new DataPack{wsPtr_, TEST_CTX});
     auto req = HttpRequest::newHttpRequest();
     req->setPath("/chat");
-    wsPtr_->setMessageHandler([pack](const std::string &message,
-                                     const WebSocketClientPtr &wsPtr,
-                                     const WebSocketMessageType &type) mutable {
-        if (pack != nullptr)
-        {
-            auto TEST_CTX = pack->TEST_CTX;
-            if (type == WebSocketMessageType::Pong)
+    wsPtr_->setMessageHandler(
+        [pack](const std::string &message,
+                   const WebSocketClientPtr &wsPtr,
+                   const WebSocketMessageType &type) mutable {
+            if(pack == nullptr)
+                return;
+            auto TEST_CTX = (*pack)->TEST_CTX;
+            if (type == WebSocketMessageType::Pong )
             {
-                auto wsPtr = pack->wsPtr;
+                auto wsPtr = (*pack)->wsPtr;
 
                 wsPtr_->stop();
                 CHECK(message.empty());
-                pack.reset();
+                delete *pack;
+                pack = nullptr;
             }
             else
             {
                 CHECK(type == WebSocketMessageType::Text);
-                wsPtr_->stop();
-                pack.reset();
             }
-        }
-    });
+        });
 
-    wsPtr_->connectToServer(req,
-                            [TEST_CTX,
-                             pack](ReqResult r,
-                                   const HttpResponsePtr &resp,
-                                   const WebSocketClientPtr &wsPtr) mutable {
-                                if (r != ReqResult::Ok)
-                                {
-                                    wsPtr_->stop();
-                                    wsPtr_.reset();
-                                    pack.reset();
-                                }
-                                REQUIRE(r == ReqResult::Ok);
-                                REQUIRE(wsPtr != nullptr);
-                                REQUIRE(resp != nullptr);
-                                wsPtr->getConnection()->setPingMessage("", 1s);
-                                wsPtr->getConnection()->send("hello!");
-                                CHECK(wsPtr->getConnection()->connected());
-                                // Drop the testing context as WS controllers
-                                // stores the lambda and never release it.
-                                // Causing a dead lock later.
-                                TEST_CTX = {};
-                                pack.reset();
-                            });
+    wsPtr_->connectToServer(
+        req,
+        [pack](ReqResult r,
+                   const HttpResponsePtr &resp,
+                   const WebSocketClientPtr &wsPtr) mutable {
+            auto TEST_CTX = (*pack)->TEST_CTX;
+            CHECK((*pack)->wsPtr == wsPtr);
+            if (r != ReqResult::Ok)
+            {
+                wsPtr_->stop();
+                wsPtr_.reset();
+                delete *pack;
+                pack = nullptr;
+            }
+            REQUIRE(r == ReqResult::Ok);
+            REQUIRE(wsPtr != nullptr);
+            REQUIRE(resp != nullptr);
+            wsPtr->getConnection()->setPingMessage("", 1s);
+            wsPtr->getConnection()->send("hello!");
+            CHECK(wsPtr->getConnection()->connected());
+            // Drop the testing context as WS controllers stores the lambda and
+            // never release it. Causing a dead lock later.
+            TEST_CTX = {};
+            pack.reset();
+        });
 }

--- a/lib/tests/integration_test/client/WebSocketTest.cc
+++ b/lib/tests/integration_test/client/WebSocketTest.cc
@@ -17,23 +17,28 @@ static WebSocketClientPtr wsPtr_;
 DROGON_TEST(WebSocketTest)
 {
     wsPtr_ = WebSocketClient::newWebSocketClient("127.0.0.1", 8848);
-    auto pack = std::make_shared<DataPack>({wsPtr_, TEST_CTX});
+    auto pack = std::make_shared<DataPack>(DataPack{wsPtr_, TEST_CTX});
     auto req = HttpRequest::newHttpRequest();
     req->setPath("/chat");
     wsPtr_->setMessageHandler(
         [pack](const std::string &message,
                    const WebSocketClientPtr &wsPtr,
                    const WebSocketMessageType &type) mutable {
-            CHECK(type == WebSocketMessageType::Text ||
-                   type == WebSocketMessageType::Pong);
-            if (type == WebSocketMessageType::Pong && pack != nullptr)
+            if(pack != nullptr) 
             {
                 auto TEST_CTX = pack->TEST_CTX;
-                auto wsPtr = pack->wsPtr;
+                if (type == WebSocketMessageType::Pong)
+                {
+                    auto wsPtr = pack->wsPtr;
 
-                wsPtr_->stop();
-                CHECK(message.empty());
-                pack.reset();
+                    wsPtr_->stop();
+                    CHECK(message.empty());
+                    pack.reset();
+                }
+                else
+                {
+                    CHECK(type == WebSocketMessageType::Text);
+                }
             }
         });
 

--- a/lib/tests/integration_test/client/WebSocketTest.cc
+++ b/lib/tests/integration_test/client/WebSocketTest.cc
@@ -27,7 +27,7 @@ DROGON_TEST(WebSocketTest)
             if(pack != nullptr) 
             {
                 auto TEST_CTX = pack->TEST_CTX;
-                if (type == WebSocketMessageType::Pong)
+                if (type == WebSocketMessageType::Pong )
                 {
                     auto wsPtr = pack->wsPtr;
 
@@ -38,6 +38,8 @@ DROGON_TEST(WebSocketTest)
                 else
                 {
                     CHECK(type == WebSocketMessageType::Text);
+                    wsPtr_->stop();
+                    pack.reset();
                 }
             }
         });
@@ -62,5 +64,6 @@ DROGON_TEST(WebSocketTest)
             // Drop the testing context as WS controllers stores the lambda and
             // never release it. Causing a dead lock later.
             TEST_CTX = {};
+            pack.reset();
         });
 }

--- a/lib/tests/integration_test/client/WebSocketTest.cc
+++ b/lib/tests/integration_test/client/WebSocketTest.cc
@@ -7,35 +7,46 @@
 using namespace drogon;
 using namespace std::chrono_literals;
 
+struct DataPack
+{
+    WebSocketClientPtr wsPtr;
+    std::shared_ptr<drogon::test::CaseBase> TEST_CTX;
+};
+
 static WebSocketClientPtr wsPtr_;
 DROGON_TEST(WebSocketTest)
 {
     wsPtr_ = WebSocketClient::newWebSocketClient("127.0.0.1", 8848);
+    auto pack = std::make_shared<DataPack>({wsPtr_, TEST_CTX});
     auto req = HttpRequest::newHttpRequest();
     req->setPath("/chat");
     wsPtr_->setMessageHandler(
-        [TEST_CTX](const std::string &message,
+        [pack](const std::string &message,
                    const WebSocketClientPtr &wsPtr,
                    const WebSocketMessageType &type) mutable {
-            CHECK((type == WebSocketMessageType::Text ||
-                   type == WebSocketMessageType::Pong));
-            if (type == WebSocketMessageType::Pong)
+            CHECK(type == WebSocketMessageType::Text ||
+                   type == WebSocketMessageType::Pong);
+            if (type == WebSocketMessageType::Pong && pack != nullptr)
             {
+                auto TEST_CTX = pack->TEST_CTX;
+                auto wsPtr = pack->wsPtr;
+
                 wsPtr_->stop();
                 CHECK(message.empty());
-                TEST_CTX = {};
+                pack.reset();
             }
         });
 
     wsPtr_->connectToServer(
         req,
-        [TEST_CTX](ReqResult r,
+        [TEST_CTX, pack](ReqResult r,
                    const HttpResponsePtr &resp,
                    const WebSocketClientPtr &wsPtr) mutable {
             if (r != ReqResult::Ok)
             {
                 wsPtr_->stop();
                 wsPtr_.reset();
+                pack.reset();
             }
             REQUIRE(r == ReqResult::Ok);
             REQUIRE(wsPtr != nullptr);

--- a/lib/tests/integration_test/client/WebSocketTest.cc
+++ b/lib/tests/integration_test/client/WebSocketTest.cc
@@ -20,50 +20,50 @@ DROGON_TEST(WebSocketTest)
     auto pack = std::make_shared<DataPack>(DataPack{wsPtr_, TEST_CTX});
     auto req = HttpRequest::newHttpRequest();
     req->setPath("/chat");
-    wsPtr_->setMessageHandler(
-        [pack](const std::string &message,
-                   const WebSocketClientPtr &wsPtr,
-                   const WebSocketMessageType &type) mutable {
-            if(pack != nullptr) 
+    wsPtr_->setMessageHandler([pack](const std::string &message,
+                                     const WebSocketClientPtr &wsPtr,
+                                     const WebSocketMessageType &type) mutable {
+        if (pack != nullptr)
+        {
+            auto TEST_CTX = pack->TEST_CTX;
+            if (type == WebSocketMessageType::Pong)
             {
-                auto TEST_CTX = pack->TEST_CTX;
-                if (type == WebSocketMessageType::Pong )
-                {
-                    auto wsPtr = pack->wsPtr;
+                auto wsPtr = pack->wsPtr;
 
-                    wsPtr_->stop();
-                    CHECK(message.empty());
-                    pack.reset();
-                }
-                else
-                {
-                    CHECK(type == WebSocketMessageType::Text);
-                    wsPtr_->stop();
-                    pack.reset();
-                }
-            }
-        });
-
-    wsPtr_->connectToServer(
-        req,
-        [TEST_CTX, pack](ReqResult r,
-                   const HttpResponsePtr &resp,
-                   const WebSocketClientPtr &wsPtr) mutable {
-            if (r != ReqResult::Ok)
-            {
                 wsPtr_->stop();
-                wsPtr_.reset();
+                CHECK(message.empty());
                 pack.reset();
             }
-            REQUIRE(r == ReqResult::Ok);
-            REQUIRE(wsPtr != nullptr);
-            REQUIRE(resp != nullptr);
-            wsPtr->getConnection()->setPingMessage("", 1s);
-            wsPtr->getConnection()->send("hello!");
-            CHECK(wsPtr->getConnection()->connected());
-            // Drop the testing context as WS controllers stores the lambda and
-            // never release it. Causing a dead lock later.
-            TEST_CTX = {};
-            pack.reset();
-        });
+            else
+            {
+                CHECK(type == WebSocketMessageType::Text);
+                wsPtr_->stop();
+                pack.reset();
+            }
+        }
+    });
+
+    wsPtr_->connectToServer(req,
+                            [TEST_CTX,
+                             pack](ReqResult r,
+                                   const HttpResponsePtr &resp,
+                                   const WebSocketClientPtr &wsPtr) mutable {
+                                if (r != ReqResult::Ok)
+                                {
+                                    wsPtr_->stop();
+                                    wsPtr_.reset();
+                                    pack.reset();
+                                }
+                                REQUIRE(r == ReqResult::Ok);
+                                REQUIRE(wsPtr != nullptr);
+                                REQUIRE(resp != nullptr);
+                                wsPtr->getConnection()->setPingMessage("", 1s);
+                                wsPtr->getConnection()->send("hello!");
+                                CHECK(wsPtr->getConnection()->connected());
+                                // Drop the testing context as WS controllers
+                                // stores the lambda and never release it.
+                                // Causing a dead lock later.
+                                TEST_CTX = {};
+                                pack.reset();
+                            });
 }

--- a/lib/tests/integration_test/client/WebSocketTest.cc
+++ b/lib/tests/integration_test/client/WebSocketTest.cc
@@ -17,54 +17,53 @@ static WebSocketClientPtr wsPtr_;
 DROGON_TEST(WebSocketTest)
 {
     wsPtr_ = WebSocketClient::newWebSocketClient("127.0.0.1", 8848);
-    auto pack = std::make_shared<DataPack*>(new DataPack{wsPtr_, TEST_CTX});
+    auto pack = std::make_shared<DataPack *>(new DataPack{wsPtr_, TEST_CTX});
     auto req = HttpRequest::newHttpRequest();
     req->setPath("/chat");
-    wsPtr_->setMessageHandler(
-        [pack](const std::string &message,
-                   const WebSocketClientPtr &wsPtr,
-                   const WebSocketMessageType &type) mutable {
-            if(pack == nullptr)
-                return;
-            auto TEST_CTX = (*pack)->TEST_CTX;
-            if (type == WebSocketMessageType::Pong )
-            {
-                auto wsPtr = (*pack)->wsPtr;
+    wsPtr_->setMessageHandler([pack](const std::string &message,
+                                     const WebSocketClientPtr &wsPtr,
+                                     const WebSocketMessageType &type) mutable {
+        if (pack == nullptr)
+            return;
+        auto TEST_CTX = (*pack)->TEST_CTX;
+        if (type == WebSocketMessageType::Pong)
+        {
+            auto wsPtr = (*pack)->wsPtr;
 
-                wsPtr_->stop();
-                CHECK(message.empty());
-                delete *pack;
-                pack = nullptr;
-            }
-            else
-            {
-                CHECK(type == WebSocketMessageType::Text);
-            }
-        });
+            wsPtr_->stop();
+            CHECK(message.empty());
+            delete *pack;
+            pack = nullptr;
+        }
+        else
+        {
+            CHECK(type == WebSocketMessageType::Text);
+        }
+    });
 
-    wsPtr_->connectToServer(
-        req,
-        [pack](ReqResult r,
-                   const HttpResponsePtr &resp,
-                   const WebSocketClientPtr &wsPtr) mutable {
-            auto TEST_CTX = (*pack)->TEST_CTX;
-            CHECK((*pack)->wsPtr == wsPtr);
-            if (r != ReqResult::Ok)
-            {
-                wsPtr_->stop();
-                wsPtr_.reset();
-                delete *pack;
-                pack = nullptr;
-            }
-            REQUIRE(r == ReqResult::Ok);
-            REQUIRE(wsPtr != nullptr);
-            REQUIRE(resp != nullptr);
-            wsPtr->getConnection()->setPingMessage("", 1s);
-            wsPtr->getConnection()->send("hello!");
-            CHECK(wsPtr->getConnection()->connected());
-            // Drop the testing context as WS controllers stores the lambda and
-            // never release it. Causing a dead lock later.
-            TEST_CTX = {};
-            pack.reset();
-        });
+    wsPtr_->connectToServer(req,
+                            [pack](ReqResult r,
+                                   const HttpResponsePtr &resp,
+                                   const WebSocketClientPtr &wsPtr) mutable {
+                                auto TEST_CTX = (*pack)->TEST_CTX;
+                                CHECK((*pack)->wsPtr == wsPtr);
+                                if (r != ReqResult::Ok)
+                                {
+                                    wsPtr_->stop();
+                                    wsPtr_.reset();
+                                    delete *pack;
+                                    pack = nullptr;
+                                }
+                                REQUIRE(r == ReqResult::Ok);
+                                REQUIRE(wsPtr != nullptr);
+                                REQUIRE(resp != nullptr);
+                                wsPtr->getConnection()->setPingMessage("", 1s);
+                                wsPtr->getConnection()->send("hello!");
+                                CHECK(wsPtr->getConnection()->connected());
+                                // Drop the testing context as WS controllers
+                                // stores the lambda and never release it.
+                                // Causing a dead lock later.
+                                TEST_CTX = {};
+                                pack.reset();
+                            });
 }

--- a/lib/tests/integration_test/client/main.cc
+++ b/lib/tests/integration_test/client/main.cc
@@ -1078,7 +1078,7 @@ DROGON_TEST(HttpsTest)
 
 int main(int argc, char **argv)
 {
-    // trantor::Logger::setLogLevel(trantor::Logger::LogLevel::kTrace);
+    trantor::Logger::setLogLevel(trantor::Logger::LogLevel::kTrace);
     loadFileLengths();
 
     std::promise<void> p1;

--- a/lib/tests/integration_test/client/main.cc
+++ b/lib/tests/integration_test/client/main.cc
@@ -1078,7 +1078,7 @@ DROGON_TEST(HttpsTest)
 
 int main(int argc, char **argv)
 {
-    trantor::Logger::setLogLevel(trantor::Logger::LogLevel::kTrace);
+    // trantor::Logger::setLogLevel(trantor::Logger::LogLevel::kTrace);
     loadFileLengths();
 
     std::promise<void> p1;


### PR DESCRIPTION
This PR hopefully resolves the issue where our WS test can get stuck if the initial WS connection failed. By resetting the TEST_CTX on the `onMessage` handler if connection failed.