### PR TITLE
use operator<< to convert ReqResult to string

### DIFF
--- a/lib/inc/drogon/HttpClient.h
+++ b/lib/inc/drogon/HttpClient.h
@@ -341,17 +341,10 @@ inline void internal::HttpRespAwaiter::await_suspend(
                 setValue(resp);
             else
             {
-                std::string reason;
-                if (result == ReqResult::BadResponse)
-                    reason = "BadResponse";
-                else if (result == ReqResult::NetworkFailure)
-                    reason = "NetworkFailure";
-                else if (result == ReqResult::BadServerAddress)
-                    reason = "BadServerAddress";
-                else if (result == ReqResult::Timeout)
-                    reason = "Timeout";
+                std::stringstream ss;
+                ss << result;
                 setException(
-                    std::make_exception_ptr(std::runtime_error(reason)));
+                    std::make_exception_ptr(std::runtime_error(ss.str())));
             }
             handle.resume();
         },


### PR DESCRIPTION
This PR makes exception messages from HttpClient coroutines also handle SSL errors. However (to clean up stuff) this PR changes how ReqResult is converted. Which changes the exception message. I don't think this is a problem since error handling should not depend on the message. But it is a breaking change.