### PR TITLE
Remove sudo from build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -48,7 +48,7 @@ function build_drogon() {
     fi
 
     echo "Installing ..."
-    sudo $make_program install
+    $make_program install
 
     #Go back to the current directory
     cd $current_dir


### PR DESCRIPTION
Somewhat controversial, but in general scripts shouldn't have sudo embedded, if necessary the user should run the whole script under sudo. See for example discussions in:

https://askubuntu.com/questions/425754/how-do-i-run-a-sudo-command-inside-a-script
https://unix.stackexchange.com/questions/20284/should-i-be-using-sudo-in-scripts-that-i-write

with conflicting answers. However, removing the sudo from the script here would allow removing dependency on sudo from Dockerfile (I believe) since in Docker the install is done as root, while a user installing elsewhere is free to use sudo for the whole script.