### PR TITLE
remove LOG_ERROR in parseJson

### DIFF
--- a/lib/src/HttpRequestImpl.cc
+++ b/lib/src/HttpRequestImpl.cc
@@ -44,7 +44,6 @@ void HttpRequestImpl::parseJson() const
                            jsonPtr_.get(),
                            &errs))
         {
-            LOG_ERROR << errs;
             jsonPtr_.reset();
             jsonParsingErrorPtr_ =
                 std::make_unique<std::string>(std::move(errs));


### PR DESCRIPTION
没有必要在解析请求的json非法时输出错误日志,在jsonObject返回空指针时手动获取错误信息就已足够