### PR TITLE
Enable setup output of logs to files at any time.

### DIFF
--- a/lib/inc/drogon/HttpAppFramework.h
+++ b/lib/inc/drogon/HttpAppFramework.h
@@ -350,6 +350,17 @@ class DROGON_EXPORT HttpAppFramework : public trantor::NonCopyable
         const std::function<void(const HttpRequestPtr &,
                                  const HttpResponsePtr &)> &advice) = 0;
 
+    /// Setup output of logs to files
+    /**
+     * @note
+     * Logs are output to the standard output by default.
+     * Logging is setuped only if output path of logs is defined.
+     * This method is called in run() function, hence use this method only if
+     * you want to setup logging earlier.
+     * @return HttpAppFramework&
+     */
+    virtual HttpAppFramework &setupFileLogger() = 0;
+
     /* End of AOP methods */
 
     /// Load the configuration file with json format.

--- a/lib/src/HttpAppFrameworkImpl.h
+++ b/lib/src/HttpAppFrameworkImpl.h
@@ -205,6 +205,8 @@ class HttpAppFrameworkImpl final : public HttpAppFramework
     }
     HttpAppFramework &setDefaultHandler(DefaultHandler handler) override;
 
+    HttpAppFramework &setupFileLogger() override;
+
     HttpAppFramework &enableSession(const size_t timeout) override
     {
         useSession_ = true;
@@ -634,6 +636,7 @@ class HttpAppFrameworkImpl final : public HttpAppFramework
     std::function<void()> termSignalHandler_{[]() { app().quit(); }};
     std::function<void()> intSignalHandler_{[]() { app().quit(); }};
     std::unique_ptr<SessionManager> sessionManagerPtr_;
+    std::unique_ptr<trantor::AsyncFileLogger> asyncFileLoggerPtr_;
     Json::Value jsonConfig_;
     HttpResponsePtr custom404_;
     std::function<HttpResponsePtr(HttpStatusCode)> customErrorHandler_ =

--- a/lib/src/impl_forwards.h
+++ b/lib/src/impl_forwards.h
@@ -56,6 +56,7 @@ class EventLoop;
 class TcpConnection;
 using TcpConnectionPtr = std::shared_ptr<TcpConnection>;
 class Resolver;
+class AsyncFileLogger;
 }  // namespace trantor
 
 namespace drogon


### PR DESCRIPTION
## What?
I've added separate function to HttpAppFramework interface, to setup output of logs to files at any time.
## Why?
These changes allow to make logs to the files before server starts work and when it stops work (before and after Http AppFramework::run() method). For instance, I need to run licence check and log result of checking before server starts accept requests.
## How?
Extracted some code from HttpAppFrameworkImpl::run() to HttpAppFramework::setupFileLogger function, to keep backward compatibility setupFileLogger() is called  inside run(). Note, setupFileLogger() can be called several times, but HttpAppFrameworkImpl::asyncFileLoggerPtr_ will be initialised only once.
