### PR TITLE
Check HTTP client is not sending requests in sync mode on the same event loop in debug mode

### DIFF
--- a/lib/inc/drogon/HttpClient.h
+++ b/lib/inc/drogon/HttpClient.h
@@ -130,8 +130,8 @@ class DROGON_EXPORT HttpClient : public trantor::NonCopyable
                                                       double timeout = 0)
     {
         assert(!getLoop()->isInLoopThread() &&
-               "Deadlock detected! Using a sync API in it's own event loop "
-               "will deadlock the event loop");
+               "Deadlock detected! Calling a sync API from the same loop as "
+               "the HTTP client processes on will deadlock the event loop");
         std::promise<std::pair<ReqResult, HttpResponsePtr>> prom;
         auto f = prom.get_future();
         sendRequest(

--- a/lib/inc/drogon/HttpClient.h
+++ b/lib/inc/drogon/HttpClient.h
@@ -129,6 +129,9 @@ class DROGON_EXPORT HttpClient : public trantor::NonCopyable
     std::pair<ReqResult, HttpResponsePtr> sendRequest(const HttpRequestPtr &req,
                                                       double timeout = 0)
     {
+        assert(!getLoop()->isInLoopThread() &&
+               "Deadlock detected! Using a sync API in it's own event loop "
+               "will deadlock the event loop");
         std::promise<std::pair<ReqResult, HttpResponsePtr>> prom;
         auto f = prom.get_future();
         sendRequest(


### PR DESCRIPTION
This PR disallows HTTP clients to send requests in sync mode on the same event loop. As it'll deadlock the loop. I tried to add the same thing for DB. But failing due to the DbConnection abstraction. I'll find some way to do that in the future.

This check is disabled in release move