### PR TITLE
Allow using json_cpp in other sublibraries

### DIFF
--- a/cmake_modules/FindJsoncpp.cmake
+++ b/cmake_modules/FindJsoncpp.cmake
@@ -58,7 +58,9 @@ if(Jsoncpp_FOUND)
         )
     endif(jsoncpp_ver LESS 1.7)
   endif()
-  add_library(Jsoncpp_lib INTERFACE IMPORTED)
+  if (NOT TARGET Jsoncpp_lib)
+          add_library(Jsoncpp_lib INTERFACE IMPORTED)
+  endif()
   set_target_properties(Jsoncpp_lib
                         PROPERTIES INTERFACE_INCLUDE_DIRECTORIES
                                    "${JSONCPP_INCLUDE_DIRS}"


### PR DESCRIPTION
If another sublibrary also imports jsoncpp, `FindJsonCpp.cmake` fails with error message `add_library cannot create imported target Jsoncpp_lib because another target with the same name already exists.`.  Adding the `if (NOT TARGET Jsoncpp_lib)`-guard fixes this.

It might be useful to check if there's a similar problem with other sublibraries included by Drogon.