### PR TITLE
Start listening after beginning advices

### DIFF
--- a/lib/src/HttpAppFrameworkImpl.cc
+++ b/lib/src/HttpAppFrameworkImpl.cc
@@ -584,13 +584,13 @@ void HttpAppFrameworkImpl::run()
     staticFileRouterPtr_->init(ioLoops);
     websockCtrlsRouterPtr_->init();
     getLoop()->queueInLoop([this]() {
-        // Let listener event loops run when everything is ready.
-        listenerManagerPtr_->startListening();
         for (auto &adv : beginningAdvices_)
         {
             adv();
         }
         beginningAdvices_.clear();
+        // Let listener event loops run when everything is ready.
+        listenerManagerPtr_->startListening();
     });
     getLoop()->loop();
 }

--- a/lib/tests/CMakeLists.txt
+++ b/lib/tests/CMakeLists.txt
@@ -60,6 +60,7 @@ set(INTEGRATION_TEST_SERVER_SOURCES
     integration_test/server/DigestAuthFilter.cc
     integration_test/server/MethodTest.cc
     integration_test/server/RangeTestController.cc
+    integration_test/server/BeginAdviceTest.cc
     integration_test/server/main.cc)
 
 if(DROGON_CXX_STANDARD GREATER_EQUAL 20 AND HAS_COROUTINE)

--- a/lib/tests/integration_test/client/main.cc
+++ b/lib/tests/integration_test/client/main.cc
@@ -66,8 +66,19 @@ void doTest(const HttpClientPtr &client, std::shared_ptr<test::Case> TEST_CTX)
     else
         client->addCookie(sessionID);
 
-    /// Test session
+    /// Test begin advice
     auto req = HttpRequest::newHttpRequest();
+    req->setMethod(drogon::Get);
+    req->setPath("/test_begin_advice");
+    client->sendRequest(req,
+                        [req, client, TEST_CTX](ReqResult result,
+                                                const HttpResponsePtr &resp) {
+                            REQUIRE(result == ReqResult::Ok);
+                            CHECK(resp->getBody() == "DrogonReady");
+                        });
+
+    /// Test session
+    req = HttpRequest::newHttpRequest();
     req->setMethod(drogon::Get);
     req->setPath("/slow");
     client->sendRequest(

--- a/lib/tests/integration_test/server/BeginAdviceTest.cc
+++ b/lib/tests/integration_test/server/BeginAdviceTest.cc
@@ -1,0 +1,12 @@
+#include "BeginAdviceTest.h"
+
+std::string BeginAdviceTest::content_ = "Default content";
+
+void BeginAdviceTest::asyncHandleHttpRequest(
+    const HttpRequestPtr &req,
+    std::function<void(const HttpResponsePtr &)> &&callback)
+{
+    auto resp = HttpResponse::newHttpResponse();
+    resp->setBody(content_);
+    callback(resp);
+}

--- a/lib/tests/integration_test/server/BeginAdviceTest.h
+++ b/lib/tests/integration_test/server/BeginAdviceTest.h
@@ -1,0 +1,30 @@
+#pragma once
+#include <drogon/HttpSimpleController.h>
+#include <string>
+
+using namespace drogon;
+
+class BeginAdviceTest : public drogon::HttpSimpleController<BeginAdviceTest>
+{
+  public:
+    virtual void asyncHandleHttpRequest(
+        const HttpRequestPtr &req,
+        std::function<void(const HttpResponsePtr &)> &&callback) override;
+    PATH_LIST_BEGIN
+    // list path definations here;
+    // PATH_ADD("/path","filter1","filter2",...);
+    PATH_ADD("/test_begin_advice", Get);
+    PATH_LIST_END
+    BeginAdviceTest()
+    {
+        LOG_DEBUG << "BeginAdviceTest constructor";
+    }
+
+    static void setContent(const std::string &content)
+    {
+        content_ = content;
+    }
+
+  private:
+    static std::string content_;
+};

--- a/lib/tests/integration_test/server/main.cc
+++ b/lib/tests/integration_test/server/main.cc
@@ -1,11 +1,13 @@
 
+#include "BeginAdviceTest.h"
 #include "CustomCtrl.h"
 #include "CustomHeaderFilter.h"
 #include "DigestAuthFilter.h"
+
 #include <drogon/drogon.h>
-#include <vector>
-#include <string>
 #include <iostream>
+#include <string>
+#include <vector>
 
 using namespace drogon;
 using namespace std::chrono_literals;
@@ -367,5 +369,9 @@ int main()
               << std::string{drogon::utils::getHttpFullDate(
                      trantor::Date::now())}
               << std::endl;
+
+    app().registerBeginningAdvice(
+        []() { BeginAdviceTest::setContent("DrogonReady"); });
+
     app().run();
 }


### PR DESCRIPTION
Start listening threads after beginning advices return, so they can actually do initialization jobs.