### PR TITLE
Fix sqlite3 and mariadb when using vcpkg

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -364,11 +364,13 @@ if (BUILD_MYSQL)
     find_package(unofficial-libmariadb QUIET)
     if (MySQL_FOUND)
         target_link_libraries(${PROJECT_NAME} PRIVATE MySQL_lib)
+        set(DROGON_FOUND_MYSQL TRUE)
     elseif (unofficial-libmariadb_FOUND)
         target_link_libraries(${PROJECT_NAME} PRIVATE unofficial::libmariadb)
+        set(DROGON_FOUND_MYSQL TRUE)
     endif ()
 
-    if (MySQL_FOUND OR unofficial-libmariadb_FOUND)
+    if (DROGON_FOUND_MYSQL)
         message(STATUS "Ok! We find mariadb!")
         set(DROGON_SOURCES
             ${DROGON_SOURCES}
@@ -378,9 +380,9 @@ if (BUILD_MYSQL)
             ${private_headers}
             orm_lib/src/mysql_impl/MysqlConnection.h
             orm_lib/src/mysql_impl/MysqlResultImpl.h)
-    else (MySQL_FOUND OR unofficial-libmariadb_FOUND)
+    else (DROGON_FOUND_MYSQL)
         message(STATUS "MySql was not found.")
-    endif (MySQL_FOUND OR unofficial-libmariadb_FOUND)
+    endif (DROGON_FOUND_MYSQL)
 endif (BUILD_MYSQL)
 
 if (BUILD_SQLITE)
@@ -389,11 +391,13 @@ if (BUILD_SQLITE)
     find_package(unofficial-sqlite3 QUIET)
     if (SQLite3_FOUND)
         target_link_libraries(${PROJECT_NAME} PRIVATE SQLite3_lib)
+        set(DROGON_FOUND_SQLite3 TRUE)
     elseif (unofficial-sqlite3_FOUND)
         target_link_libraries(${PROJECT_NAME} PRIVATE unofficial::sqlite3::sqlite3)
+        set(DROGON_FOUND_SQLite3 TRUE)
     endif ()
 
-    if (SQLite3_FOUND OR unofficial-sqlite3_FOUND)
+    if (DROGON_FOUND_SQLite3)
         message(STATUS "Ok! We find sqlite3!")
         set(DROGON_SOURCES
             ${DROGON_SOURCES}
@@ -403,9 +407,9 @@ if (BUILD_SQLITE)
             ${private_headers}
             orm_lib/src/sqlite3_impl/Sqlite3Connection.h
             orm_lib/src/sqlite3_impl/Sqlite3ResultImpl.h)
-    else (SQLite3_FOUND OR unofficial-sqlite3_FOUND)
+    else (DROGON_FOUND_SQLite3)
         message(STATUS "sqlite3 was not found.")
-    endif (SQLite3_FOUND OR unofficial-sqlite3_FOUND)
+    endif (DROGON_FOUND_SQLite3)
 endif (BUILD_SQLITE)
 
 if (BUILD_REDIS)
@@ -550,15 +554,15 @@ set(private_headers
     orm_lib/src/DbConnection.h
     orm_lib/src/ResultImpl.h
     orm_lib/src/TransactionImpl.h)
-if (pg_FOUND OR MySQL_FOUND OR unofficial-libmariadb_FOUND OR SQLite3_FOUND OR unofficial-sqlite3_FOUND)
+if (pg_FOUND OR DROGON_FOUND_MYSQL OR DROGON_FOUND_SQLite3)
     set(DROGON_SOURCES
         ${DROGON_SOURCES}
         orm_lib/src/DbClientManager.cc)
-else (pg_FOUND OR MySQL_FOUND OR unofficial-libmariadb_FOUND OR SQLite3_FOUND OR unofficial-sqlite3_FOUND)
+else (pg_FOUND OR DROGON_FOUND_MYSQL OR DROGON_FOUND_SQLite3)
     set(DROGON_SOURCES
         ${DROGON_SOURCES}
         lib/src/DbClientManagerSkipped.cc)
-endif (pg_FOUND OR MySQL_FOUND OR unofficial-libmariadb_FOUND OR SQLite3_FOUND OR unofficial-sqlite3_FOUND)
+endif (pg_FOUND OR DROGON_FOUND_MYSQL OR DROGON_FOUND_SQLite3)
 
 set_target_properties(${PROJECT_NAME}
     PROPERTIES CXX_STANDARD ${DROGON_CXX_STANDARD})
@@ -566,25 +570,25 @@ set_target_properties(${PROJECT_NAME} PROPERTIES CXX_STANDARD_REQUIRED ON)
 set_target_properties(${PROJECT_NAME} PROPERTIES CXX_EXTENSIONS OFF)
 set_target_properties(${PROJECT_NAME} PROPERTIES EXPORT_NAME Drogon)
 
-if (pg_FOUND OR MySQL_FOUND OR unofficial-libmariadb_FOUND OR SQLite3_FOUND OR unofficial-sqlite3_FOUND)
+if (pg_FOUND OR DROGON_FOUND_MYSQL OR DROGON_FOUND_SQLite3)
     if (pg_FOUND)
         option(USE_POSTGRESQL "Enable PostgreSQL" ON)
     else (pg_FOUND)
         option(USE_POSTGRESQL "Disable PostgreSQL" OFF)
     endif (pg_FOUND)
 
-    if (MySQL_FOUND OR unofficial-libmariadb_FOUND)
+    if (DROGON_FOUND_MYSQL)
         option(USE_MYSQL "Enable Mysql" ON)
-    else (MySQL_FOUND OR unofficial-libmariadb_FOUND)
+    else (DROGON_FOUND_MYSQL)
         option(USE_MYSQL "Disable Mysql" OFF)
-    endif (MySQL_FOUND OR unofficial-libmariadb_FOUND)
+    endif (DROGON_FOUND_MYSQL)
 
-    if (SQLite3_FOUND OR unofficial-sqlite3_FOUND)
+    if (DROGON_FOUND_SQLite3)
         option(USE_SQLITE3 "Enable Sqlite3" ON)
-    else (SQLite3_FOUND OR unofficial-sqlite3_FOUND)
+    else (DROGON_FOUND_SQLite3)
         option(USE_SQLITE3 "Disable Sqlite3" OFF)
-    endif (SQLite3_FOUND OR unofficial-sqlite3_FOUND)
-endif (pg_FOUND OR MySQL_FOUND OR unofficial-libmariadb_FOUND OR SQLite3_FOUND OR unofficial-sqlite3_FOUND)
+    endif (DROGON_FOUND_SQLite3)
+endif (pg_FOUND OR DROGON_FOUND_MYSQL OR DROGON_FOUND_SQLite3)
 
 set(COMPILER_COMMAND ${CMAKE_CXX_COMPILER})
 set(COMPILER_ID ${CMAKE_CXX_COMPILER_ID})
@@ -622,12 +626,12 @@ if (BUILD_TESTING)
     if (pg_FOUND)
         add_subdirectory(${PROJECT_SOURCE_DIR}/orm_lib/src/postgresql_impl/test)
     endif (pg_FOUND)
-    if (MySQL_FOUND OR unofficial-libmariadb_FOUND)
+    if (DROGON_FOUND_MYSQL)
         add_subdirectory(${PROJECT_SOURCE_DIR}/orm_lib/src/mysql_impl/test)
-    endif (MySQL_FOUND OR unofficial-libmariadb_FOUND)
-    if (SQLite3_FOUND OR unofficial-sqlite3_FOUND)
+    endif (DROGON_FOUND_MYSQL)
+    if (DROGON_FOUND_SQLite3)
         add_subdirectory(${PROJECT_SOURCE_DIR}/orm_lib/src/sqlite3_impl/test)
-    endif (SQLite3_FOUND OR unofficial-sqlite3_FOUND)
+    endif (DROGON_FOUND_SQLite3)
     add_subdirectory(${PROJECT_SOURCE_DIR}/orm_lib/tests)
 endif (BUILD_TESTING)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -359,11 +359,17 @@ if (BUILD_POSTGRESQL)
 endif (BUILD_POSTGRESQL)
 
 if (BUILD_MYSQL)
-    # Find mysql, only mariadb client liberary is supported
-    find_package(MySQL)
+    # Find mysql, only mariadb client library is supported
+    find_package(MySQL QUIET)
+    find_package(unofficial-libmariadb QUIET)
     if (MySQL_FOUND)
-        message(STATUS "Ok! We find the mariadb!")
         target_link_libraries(${PROJECT_NAME} PRIVATE MySQL_lib)
+    elseif (unofficial-libmariadb_FOUND)
+        target_link_libraries(${PROJECT_NAME} PRIVATE unofficial::libmariadb)
+    endif ()
+
+    if (MySQL_FOUND OR unofficial-libmariadb_FOUND)
+        message(STATUS "Ok! We find mariadb!")
         set(DROGON_SOURCES
             ${DROGON_SOURCES}
             orm_lib/src/mysql_impl/MysqlConnection.cc
@@ -372,14 +378,23 @@ if (BUILD_MYSQL)
             ${private_headers}
             orm_lib/src/mysql_impl/MysqlConnection.h
             orm_lib/src/mysql_impl/MysqlResultImpl.h)
-    endif (MySQL_FOUND)
+    else (MySQL_FOUND OR unofficial-libmariadb_FOUND)
+        message(STATUS "MySql was not found.")
+    endif (MySQL_FOUND OR unofficial-libmariadb_FOUND)
 endif (BUILD_MYSQL)
 
 if (BUILD_SQLITE)
     # Find sqlite3.
-    find_package(SQLite3)
+    find_package(SQLite3 QUIET)
+    find_package(unofficial-sqlite3 QUIET)
     if (SQLite3_FOUND)
         target_link_libraries(${PROJECT_NAME} PRIVATE SQLite3_lib)
+    elseif (unofficial-sqlite3_FOUND)
+        target_link_libraries(${PROJECT_NAME} PRIVATE unofficial::sqlite3::sqlite3)
+    endif ()
+
+    if (SQLite3_FOUND OR unofficial-sqlite3_FOUND)
+        message(STATUS "Ok! We find sqlite3!")
         set(DROGON_SOURCES
             ${DROGON_SOURCES}
             orm_lib/src/sqlite3_impl/Sqlite3Connection.cc
@@ -388,7 +403,9 @@ if (BUILD_SQLITE)
             ${private_headers}
             orm_lib/src/sqlite3_impl/Sqlite3Connection.h
             orm_lib/src/sqlite3_impl/Sqlite3ResultImpl.h)
-    endif (SQLite3_FOUND)
+    else (SQLite3_FOUND OR unofficial-sqlite3_FOUND)
+        message(STATUS "sqlite3 was not found.")
+    endif (SQLite3_FOUND OR unofficial-sqlite3_FOUND)
 endif (BUILD_SQLITE)
 
 if (BUILD_REDIS)
@@ -533,15 +550,15 @@ set(private_headers
     orm_lib/src/DbConnection.h
     orm_lib/src/ResultImpl.h
     orm_lib/src/TransactionImpl.h)
-if (pg_FOUND OR MySQL_FOUND OR SQLite3_FOUND)
+if (pg_FOUND OR MySQL_FOUND OR unofficial-libmariadb_FOUND OR SQLite3_FOUND OR unofficial-sqlite3_FOUND)
     set(DROGON_SOURCES
         ${DROGON_SOURCES}
         orm_lib/src/DbClientManager.cc)
-else (pg_FOUND OR MySQL_FOUND OR SQLite3_FOUND)
+else (pg_FOUND OR MySQL_FOUND OR unofficial-libmariadb_FOUND OR SQLite3_FOUND OR unofficial-sqlite3_FOUND)
     set(DROGON_SOURCES
         ${DROGON_SOURCES}
         lib/src/DbClientManagerSkipped.cc)
-endif (pg_FOUND OR MySQL_FOUND OR SQLite3_FOUND)
+endif (pg_FOUND OR MySQL_FOUND OR unofficial-libmariadb_FOUND OR SQLite3_FOUND OR unofficial-sqlite3_FOUND)
 
 set_target_properties(${PROJECT_NAME}
     PROPERTIES CXX_STANDARD ${DROGON_CXX_STANDARD})
@@ -549,25 +566,25 @@ set_target_properties(${PROJECT_NAME} PROPERTIES CXX_STANDARD_REQUIRED ON)
 set_target_properties(${PROJECT_NAME} PROPERTIES CXX_EXTENSIONS OFF)
 set_target_properties(${PROJECT_NAME} PROPERTIES EXPORT_NAME Drogon)
 
-if (pg_FOUND OR MySQL_FOUND OR SQLite3_FOUND)
+if (pg_FOUND OR MySQL_FOUND OR unofficial-libmariadb_FOUND OR SQLite3_FOUND OR unofficial-sqlite3_FOUND)
     if (pg_FOUND)
         option(USE_POSTGRESQL "Enable PostgreSQL" ON)
     else (pg_FOUND)
         option(USE_POSTGRESQL "Disable PostgreSQL" OFF)
     endif (pg_FOUND)
 
-    if (MySQL_FOUND)
+    if (MySQL_FOUND OR unofficial-libmariadb_FOUND)
         option(USE_MYSQL "Enable Mysql" ON)
-    else (MySQL_FOUND)
+    else (MySQL_FOUND OR unofficial-libmariadb_FOUND)
         option(USE_MYSQL "Disable Mysql" OFF)
-    endif (MySQL_FOUND)
+    endif (MySQL_FOUND OR unofficial-libmariadb_FOUND)
 
-    if (SQLite3_FOUND)
+    if (SQLite3_FOUND OR unofficial-sqlite3_FOUND)
         option(USE_SQLITE3 "Enable Sqlite3" ON)
-    else (SQLite3_FOUND)
+    else (SQLite3_FOUND OR unofficial-sqlite3_FOUND)
         option(USE_SQLITE3 "Disable Sqlite3" OFF)
-    endif (SQLite3_FOUND)
-endif (pg_FOUND OR MySQL_FOUND OR SQLite3_FOUND)
+    endif (SQLite3_FOUND OR unofficial-sqlite3_FOUND)
+endif (pg_FOUND OR MySQL_FOUND OR unofficial-libmariadb_FOUND OR SQLite3_FOUND OR unofficial-sqlite3_FOUND)
 
 set(COMPILER_COMMAND ${CMAKE_CXX_COMPILER})
 set(COMPILER_ID ${CMAKE_CXX_COMPILER_ID})
@@ -605,12 +622,12 @@ if (BUILD_TESTING)
     if (pg_FOUND)
         add_subdirectory(${PROJECT_SOURCE_DIR}/orm_lib/src/postgresql_impl/test)
     endif (pg_FOUND)
-    if (MySQL_FOUND)
+    if (MySQL_FOUND OR unofficial-libmariadb_FOUND)
         add_subdirectory(${PROJECT_SOURCE_DIR}/orm_lib/src/mysql_impl/test)
-    endif (MySQL_FOUND)
-    if (SQLite3_FOUND)
+    endif (MySQL_FOUND OR unofficial-libmariadb_FOUND)
+    if (SQLite3_FOUND OR unofficial-sqlite3_FOUND)
         add_subdirectory(${PROJECT_SOURCE_DIR}/orm_lib/src/sqlite3_impl/test)
-    endif (SQLite3_FOUND)
+    endif (SQLite3_FOUND OR unofficial-sqlite3_FOUND)
     add_subdirectory(${PROJECT_SOURCE_DIR}/orm_lib/tests)
 endif (BUILD_TESTING)
 


### PR DESCRIPTION
The sqlite3 and mariadb package which drogon uses are now prefixed with unofficial when using vcpkg. I fixed it by just adding another find_package(). The problem with this is that all the if checks now have an extra var. 
```cmake
if (MySQL_FOUND OR unofficial-libmariadb_FOUND)
```
instead of
```cmake
if (MySQL_FOUND)
```

i also tried to just set MySQL_FOUND to true when the unofficial version was found but i couldn't get this to work.

<h3>Note:</h3>
I'm pretty bad with cmake so this is kind of a hacky solution