### PR TITLE
Prevent malformed upload path causing arbitrary write

### DIFF
--- a/lib/src/HttpFileImpl.cc
+++ b/lib/src/HttpFileImpl.cc
@@ -66,6 +66,14 @@ int HttpFileImpl::saveAs(const std::string &fileName) const
             HttpAppFrameworkImpl::instance().getUploadPath()));
         fsFileName = fsUploadPath / fsFileName;
     }
+    fsFileName = fsFileName.lexically_normal();
+    if (fsFileName.is_relative())
+    {
+        LOG_ERROR
+            << "Attempt writing outside of upload directory detected. Path: "
+            << fileName;
+        return -1;
+    }
     if (fsFileName.has_parent_path() &&
         !filesystem::exists(fsFileName.parent_path()))
     {

--- a/lib/src/HttpFileImpl.cc
+++ b/lib/src/HttpFileImpl.cc
@@ -38,9 +38,12 @@ int HttpFileImpl::save(const std::string &path) const
     {
         filesystem::path fsUploadPath(utils::toNativePath(
             HttpAppFrameworkImpl::instance().getUploadPath()));
-        fsPath = fsUploadPath / fsPath;
+        fsPath = (fsUploadPath / fsPath).lexically_normal();
     }
-    filesystem::path fsFileName(utils::toNativePath(fileName_));
+    auto fsFileName =
+        filesystem::path(utils::toNativePath(fileName_)).lexically_normal();
+    if (fsFileName.is_relative())
+        return -1;
     if (!filesystem::exists(fsPath))
     {
         LOG_TRACE << "create path:" << fsPath;


### PR DESCRIPTION
This PR prevents a malformed upload path causing the upload function to write outside of the destination directory by checking the upload path.

TBH I'm not 100% sure my patch fixes everything and didn't break unintentionally. Need some review.