### PR TITLE
Fix XXXControllers created on MSVC even if specsfied not to do so

### DIFF
--- a/lib/inc/drogon/HttpController.h
+++ b/lib/inc/drogon/HttpController.h
@@ -74,8 +74,9 @@ class HttpController : public DrObject<T>, public HttpControllerBase
         if (classNameInPath)
         {
             std::string path = "/";
-            path.append(HttpController<T>::classTypeName());
-            LOG_TRACE << "classname:" << HttpController<T>::classTypeName();
+            path.append(HttpController<T, AutoCreation>::classTypeName());
+            LOG_TRACE << "classname:"
+                      << HttpController<T, AutoCreation>::classTypeName();
 
             // transform(path.begin(), path.end(), path.begin(), tolower);
             std::string::size_type pos;

--- a/lib/inc/drogon/HttpSimpleController.h
+++ b/lib/inc/drogon/HttpSimpleController.h
@@ -75,10 +75,12 @@ class HttpSimpleController : public DrObject<T>, public HttpSimpleControllerBase
         const std::vector<internal::HttpConstraint> &filtersAndMethods)
     {
         LOG_TRACE << "register simple controller("
-                  << HttpSimpleController<T>::classTypeName()
+                  << HttpSimpleController<T, AutoCreation>::classTypeName()
                   << ") on path:" << path;
         app().registerHttpSimpleController(
-            path, HttpSimpleController<T>::classTypeName(), filtersAndMethods);
+            path,
+            HttpSimpleController<T, AutoCreation>::classTypeName(),
+            filtersAndMethods);
     }
 
   private:

--- a/lib/inc/drogon/WebSocketController.h
+++ b/lib/inc/drogon/WebSocketController.h
@@ -84,10 +84,12 @@ class WebSocketController : public DrObject<T>, public WebSocketControllerBase
         const std::vector<internal::HttpConstraint> &filtersAndMethods)
     {
         LOG_TRACE << "register websocket controller("
-                  << WebSocketController<T>::classTypeName()
+                  << WebSocketController<T, AutoCreation>::classTypeName()
                   << ") on path:" << path;
         app().registerWebSocketController(
-            path, WebSocketController<T>::classTypeName(), filtersAndMethods);
+            path,
+            WebSocketController<T, AutoCreation>::classTypeName(),
+            filtersAndMethods);
     }
 
   private:

--- a/lib/tests/CMakeLists.txt
+++ b/lib/tests/CMakeLists.txt
@@ -20,7 +20,8 @@ set(UNITTEST_SOURCES
     unittests/HttpFullDateTest.cc
     unittests/MainLoopTest.cc
     unittests/CacheMapTest.cc
-    unittests/StringOpsTest.cc)
+    unittests/StringOpsTest.cc
+    unittests/ControllerCreationTest.cc)
 
 if(DROGON_CXX_STANDARD GREATER_EQUAL 20 AND HAS_COROUTINE)
   set(UNITTEST_SOURCES ${UNITTEST_SOURCES} unittests/CoroutineTest.cc)

--- a/lib/tests/unittests/ControllerCreationTest.cc
+++ b/lib/tests/unittests/ControllerCreationTest.cc
@@ -1,0 +1,50 @@
+#include <drogon/HttpController.h>
+#include <drogon/HttpSimpleController.h>
+#include <drogon/WebSocketController.h>
+#include <drogon/drogon_test.h>
+
+class Ctrl : public drogon::HttpController<Ctrl, false>
+{
+public:
+	static void initPathRouting()
+    {
+        created = true;
+	};
+
+    static bool created;
+};
+
+class SimpleCtrl : public drogon::HttpController<Ctrl, false>
+{
+public:
+	static void initPathRouting()
+    {
+        created = true;
+	};
+
+    static bool created;
+};
+
+class WsCtrl : public drogon::WebSocketController<WsCtrl, false>
+{
+ public:
+    static void initPathRouting()
+    {
+        created = true;
+	};
+
+    static bool created;
+};
+
+
+bool Ctrl::created = false;
+bool SimpleCtrl::created = false;
+bool WsCtrl::created = false;
+
+
+DROGON_TEST(ControllerCreation)
+{
+    REQUIRE(Ctrl::created == false);
+    REQUIRE(SimpleCtrl::created == false);
+    REQUIRE(WsCtrl::created == false);
+}

--- a/lib/tests/unittests/ControllerCreationTest.cc
+++ b/lib/tests/unittests/ControllerCreationTest.cc
@@ -5,42 +5,40 @@
 
 class Ctrl : public drogon::HttpController<Ctrl, false>
 {
-public:
-	static void initPathRouting()
+  public:
+    static void initPathRouting()
     {
         created = true;
-	};
+    };
 
     static bool created;
 };
 
 class SimpleCtrl : public drogon::HttpController<Ctrl, false>
 {
-public:
-	static void initPathRouting()
+  public:
+    static void initPathRouting()
     {
         created = true;
-	};
+    };
 
     static bool created;
 };
 
 class WsCtrl : public drogon::WebSocketController<WsCtrl, false>
 {
- public:
+  public:
     static void initPathRouting()
     {
         created = true;
-	};
+    };
 
     static bool created;
 };
 
-
 bool Ctrl::created = false;
 bool SimpleCtrl::created = false;
 bool WsCtrl::created = false;
-
 
 DROGON_TEST(ControllerCreation)
 {


### PR DESCRIPTION
This is a weird behavior of MSVC. Internally we create XXXController<T> to gather type info. Which those controllers are never materialized. But MSVC still decided to treat them as actual objects and create static members for them.

Resolved https://github.com/drogonframework/drogon/issues/1018