### PR TITLE
To avoid accessing a null point, make sure result == OK before accessing the response ptr. #1189

### DIFF
--- a/examples/client_example/main.cc
+++ b/examples/client_example/main.cc
@@ -1,6 +1,7 @@
 #include <drogon/drogon.h>
-#include <iostream>
+
 #include <future>
+#include <iostream>
 
 using namespace drogon;
 
@@ -20,7 +21,15 @@ int main()
         for (int i = 0; i < 10; ++i)
         {
             client->sendRequest(
-                req, [](ReqResult, const HttpResponsePtr &response) {
+                req, [](ReqResult result, const HttpResponsePtr &response) {
+                    if (result != ReqResult::Ok)
+                    {
+                        std::cout
+                            << "error while sending request to server! result: "
+                            << result << std::endl;
+                        return;
+                    }
+
                     std::cout << "receive response!" << std::endl;
                     // auto headers=response.
                     ++nth_resp;


### PR DESCRIPTION
#1189