### PR TITLE
Add keepalive option to mysql database connections

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -65,7 +65,10 @@
             "number_of_connections": 1,
             //timeout: -1.0 by default, in seconds, the timeout for executing a SQL query.
             //zero or negative value means no timeout.
-            "timeout": -1.0
+            "timeout": -1.0,
+            //keepalive: the interval in seconds at which the connection to the database is checked to prevent
+            // it from being terminated. zero or -1 means use the database wait_timeout setting (only for mysql).
+            "keepalive": -1.0
         }
     ],
     "redis_clients": [

--- a/lib/inc/drogon/HttpAppFramework.h
+++ b/lib/inc/drogon/HttpAppFramework.h
@@ -1268,6 +1268,9 @@ class DROGON_EXPORT HttpAppFramework : public trantor::NonCopyable
      * @param characterSet The character set of the database server.
      * @param timeout The timeout in seconds for executing SQL queries. zero or
      * negative value means no timeout.
+     * @param keepalive the interval in seconds at which the connection to the
+     * database is checked to prevent it from being terminated. zero or -1 means
+     * use the database wait_timeout setting (only for mysql).
      *
      * @note
      * This operation can be performed by an option in the configuration file.
@@ -1284,7 +1287,8 @@ class DROGON_EXPORT HttpAppFramework : public trantor::NonCopyable
         const std::string &name = "default",
         const bool isFast = false,
         const std::string &characterSet = "",
-        double timeout = -1.0) = 0;
+        double timeout = -1.0,
+        const double keepalive = -1.0) = 0;
 
     /// Create a redis client
     /**

--- a/lib/src/ConfigLoader.cc
+++ b/lib/src/ConfigLoader.cc
@@ -532,6 +532,7 @@ static void loadDbClients(const Json::Value &dbClients)
             characterSet = client.get("client_encoding", "").asString();
         }
         auto timeout = client.get("timeout", -1.0).asDouble();
+        auto keepalive = client.get("keepalive_", -1.0).asDouble();
         drogon::app().createDbClient(type,
                                      host,
                                      (unsigned short)port,
@@ -543,7 +544,8 @@ static void loadDbClients(const Json::Value &dbClients)
                                      name,
                                      isFast,
                                      characterSet,
-                                     timeout);
+                                     timeout,
+                                     keepalive);
     }
 }
 

--- a/lib/src/ConfigLoader.cc
+++ b/lib/src/ConfigLoader.cc
@@ -532,7 +532,7 @@ static void loadDbClients(const Json::Value &dbClients)
             characterSet = client.get("client_encoding", "").asString();
         }
         auto timeout = client.get("timeout", -1.0).asDouble();
-        auto keepalive = client.get("keepalive_", -1.0).asDouble();
+        auto keepalive = client.get("keepalive", -1.0).asDouble();
         drogon::app().createDbClient(type,
                                      host,
                                      (unsigned short)port,

--- a/lib/src/DbClientManager.h
+++ b/lib/src/DbClientManager.h
@@ -53,7 +53,8 @@ class DbClientManager : public trantor::NonCopyable
                         const std::string &name,
                         const bool isFast,
                         const std::string &characterSet,
-                        double timeout);
+                        double timeout,
+                        double keepalive);
     bool areAllDbClientsAvailable() const noexcept;
 
   private:
@@ -66,6 +67,7 @@ class DbClientManager : public trantor::NonCopyable
         bool isFast_;
         size_t connectionNumber_;
         double timeout_;
+        double keepalive_;
     };
     std::vector<DbInfo> dbInfos_;
     std::map<std::string, IOThreadStorage<orm::DbClientPtr>> dbFastClientsMap_;

--- a/lib/src/HttpAppFrameworkImpl.cc
+++ b/lib/src/HttpAppFrameworkImpl.cc
@@ -966,7 +966,8 @@ HttpAppFramework &HttpAppFrameworkImpl::createDbClient(
     const std::string &name,
     const bool isFast,
     const std::string &characterSet,
-    double timeout)
+    double timeout,
+    double keepalive)
 {
     assert(!running_);
     dbClientManagerPtr_->createDbClient(dbType,
@@ -980,7 +981,8 @@ HttpAppFramework &HttpAppFrameworkImpl::createDbClient(
                                         name,
                                         isFast,
                                         characterSet,
-                                        timeout);
+                                        timeout,
+                                        keepalive);
     return *this;
 }
 

--- a/lib/src/HttpAppFrameworkImpl.h
+++ b/lib/src/HttpAppFrameworkImpl.h
@@ -477,7 +477,8 @@ class HttpAppFrameworkImpl final : public HttpAppFramework
                                      const std::string &name,
                                      bool isFast,
                                      const std::string &characterSet,
-                                     double timeout) override;
+                                     double timeout,
+                                     double keepalive) override;
     HttpAppFramework &createRedisClient(const std::string &ip,
                                         unsigned short port,
                                         const std::string &name,

--- a/orm_lib/src/DbClientManager.cc
+++ b/orm_lib/src/DbClientManager.cc
@@ -139,7 +139,8 @@ void DbClientManager::createDbClient(const std::string &dbType,
                                      const std::string &name,
                                      const bool isFast,
                                      const std::string &characterSet,
-                                     double timeout)
+                                     double timeout,
+                                     double keepalive)
 {
     auto connStr =
         utils::formattedString("host=%s port=%u dbname=%s user=%s",
@@ -182,6 +183,8 @@ void DbClientManager::createDbClient(const std::string &dbType,
     else if (type == "mysql")
     {
 #if USE_MYSQL
+        if (keepalive > 0.0)
+            connStr += " keepalive=" + std::to_string(keepalive);
         info.dbType_ = orm::ClientType::Mysql;
         dbInfos_.push_back(info);
 #else

--- a/orm_lib/src/mysql_impl/MysqlConnection.h
+++ b/orm_lib/src/mysql_impl/MysqlConnection.h
@@ -121,7 +121,7 @@ class MysqlConnection : public DbConnection,
 
     void outputError();
     std::string sql_;
-    std::string host_, user_, passwd_, dbname_, port_;
+    std::string host_, user_, passwd_, dbname_, port_, keepalive_;
 };
 
 }  // namespace orm


### PR DESCRIPTION
The `wait_timeout` option of mysql databases terminates idle connections
for that specific amount of time but the tcp connection might be
terminated earlier for example if the database server is behind ipvs
with default tcp timeout of 900 seconds (15 minutes).

This `keepalive` value is compared to the `wait_timeout` value and the
smallest is used as an interval at which the database connection is
checked to ensure it's not terminated. If the value is less zero it's
not used.