### PR TITLE
Enable automatic reconnect in mysql

### DIFF
--- a/orm_lib/src/mysql_impl/MysqlConnection.cc
+++ b/orm_lib/src/mysql_impl/MysqlConnection.cc
@@ -56,6 +56,7 @@ MysqlConnection::MysqlConnection(trantor::EventLoop *loop,
 {
     mysql_init(mysqlPtr_.get());
     mysql_options(mysqlPtr_.get(), MYSQL_OPT_NONBLOCK, nullptr);
+    mysql_optionsv(mysqlPtr_.get(), MYSQL_OPT_RECONNECT, &reconnect_);
 
     // Get the key and value
     auto connParams = parseConnString(connInfo);

--- a/orm_lib/src/mysql_impl/MysqlConnection.h
+++ b/orm_lib/src/mysql_impl/MysqlConnection.h
@@ -110,6 +110,7 @@ class MysqlConnection : public DbConnection,
     void startQuery();
     void startStoreResult(bool queueInLoop);
     int waitStatus_;
+    unsigned int reconnect_{1};
     enum class ExecStatus
     {
         None = 0,


### PR DESCRIPTION
Setting MYSQL_OPT_RECONNECT option to true will allow the connection to
be reestablished once before giving up and returning an error.

This is useful in cases where the database is behind a loadbalancer
(e.g. ipvs) and the tcp connection is terminated after some period of
time.

resolves #1215 #1213 