### PR TITLE
Check for colons in HTTP request header values

### DIFF
--- a/lib/src/HttpRequestParser.cc
+++ b/lib/src/HttpRequestParser.cc
@@ -205,6 +205,14 @@ bool HttpRequestParser::parseRequest(MsgBuffer *buf)
                 const char *colon = std::find(buf->peek(), crlf, ':');
                 if (colon != crlf)
                 {
+                    string_view value(colon + 1,
+                                      std::distance(colon + 1, crlf));
+                    if (value.find(':') != string_view::npos)
+                    {
+                        buf->retrieveAll();
+                        shutdownConnection(k400BadRequest);
+                        return false;
+                    }
                     request_->addHeader(buf->peek(), colon, crlf);
                 }
                 else


### PR DESCRIPTION
I came across HTTP request smuggling research today and checked if drogon is potentially vulnerable to it. Yes. It's possible for non-conforming HTTP/2 proxies being tricked to generate multiple HTTP/1 requests from a single HTTP/2 one. How it works is as follows.

HTTP/2 is a binary protocol. Instead of parsing via a state machine. Headers in HTTP/2 is basically a length proceeded by some data.  Thus the following header in HTTP/2 is possible (not saying it's conforming to the RFC).

```
my-header: whatever\n\r\n\rGET /foobar HTTP/1.1\r\ncontent-length:0....
```

Which can be rendered into the following HTTP/1.1 stream by some proxies:

```
GET /req1 HTTP/1.1
...
my-header: whatever

GET /foobar HTTP/1.1
content-length:0
....
```

Which then drogon will treat as 2 requests instead of one. Causing HTTP request smuggling. The solution is quite easy, We just check if any headers' value contains `:` in them. That character is invalid in header in HTTP/1.1 anyways.

```
Most HTTP header field values are defined using common syntax
   components (token, quoted-string, and comment) separated by
   whitespace or specific delimiting characters.  Delimiters are chosen
   from the set of US-ASCII visual characters not allowed in a token
   (DQUOTE and "(),/:;<=>?@[\]{}").
```

For reference. https://youtu.be/sI6YS9a7Qyg?t=957