### PR TITLE
Fix core dump causing by logging in destructor.

### DIFF
--- a/lib/src/HttpAppFrameworkImpl.cc
+++ b/lib/src/HttpAppFrameworkImpl.cc
@@ -1017,6 +1017,11 @@ void HttpAppFrameworkImpl::quit()
             dbClientManagerPtr_.reset();
             redisClientManagerPtr_.reset();
             pluginsManagerPtr_.reset();
+            // Release other members
+            staticFileRouterPtr_.reset();
+            httpCtrlsRouterPtr_.reset();
+            httpSimpleCtrlsRouterPtr_.reset();
+            websockCtrlsRouterPtr_.reset();
             // TODO: let HttpAppFrameworkImpl manage IO loops
             // and reset listenerManagerPtr_ before IO loops quit.
             listenerManagerPtr_->stopIoLoops();

--- a/lib/src/HttpAppFrameworkImpl.cc
+++ b/lib/src/HttpAppFrameworkImpl.cc
@@ -1119,15 +1119,16 @@ HttpAppFramework &HttpAppFrameworkImpl::setupFileLogger()
             {
                 baseName = "drogon";
             }
-            asyncFileLoggerPtr_ = std::make_unique<trantor::AsyncFileLogger>();
+            asyncFileLoggerPtr_ = std::make_shared<trantor::AsyncFileLogger>();
             asyncFileLoggerPtr_->setFileName(baseName, ".log", logPath_);
             asyncFileLoggerPtr_->startLogging();
-            trantor::Logger::setOutputFunction(
-                [this](const char *msg, const uint64_t len) {
-                    asyncFileLoggerPtr_->output(msg, len);
-                },
-                [this]() { asyncFileLoggerPtr_->flush(); });
             asyncFileLoggerPtr_->setFileSizeLimit(logfileSize_);
+            trantor::Logger::setOutputFunction(
+                [loggerPtr = asyncFileLoggerPtr_](const char *msg,
+                                                  const uint64_t len) {
+                    loggerPtr->output(msg, len);
+                },
+                [loggerPtr = asyncFileLoggerPtr_]() { loggerPtr->flush(); });
         }
     }
     return *this;

--- a/lib/src/HttpAppFrameworkImpl.cc
+++ b/lib/src/HttpAppFrameworkImpl.cc
@@ -1012,16 +1012,15 @@ void HttpAppFrameworkImpl::quit()
     if (getLoop()->isRunning())
     {
         getLoop()->queueInLoop([this]() mutable {
-            // Release thread-related managers
+            // Release members in the reverse order of initialization
             listenerManagerPtr_->stopListening();
-            dbClientManagerPtr_.reset();
-            redisClientManagerPtr_.reset();
-            pluginsManagerPtr_.reset();
-            // Release other members
-            staticFileRouterPtr_.reset();
-            httpCtrlsRouterPtr_.reset();
-            httpSimpleCtrlsRouterPtr_.reset();
             websockCtrlsRouterPtr_.reset();
+            staticFileRouterPtr_.reset();
+            httpSimpleCtrlsRouterPtr_.reset();
+            httpCtrlsRouterPtr_.reset();
+            pluginsManagerPtr_.reset();
+            redisClientManagerPtr_.reset();
+            dbClientManagerPtr_.reset();
             // TODO: let HttpAppFrameworkImpl manage IO loops
             // and reset listenerManagerPtr_ before IO loops quit.
             listenerManagerPtr_->stopIoLoops();

--- a/lib/src/HttpAppFrameworkImpl.cc
+++ b/lib/src/HttpAppFrameworkImpl.cc
@@ -1011,7 +1011,7 @@ void HttpAppFrameworkImpl::quit()
 {
     if (getLoop()->isRunning())
     {
-        getLoop()->queueInLoop([this]() mutable {
+        getLoop()->queueInLoop([this]() {
             // Release members in the reverse order of initialization
             listenerManagerPtr_->stopListening();
             websockCtrlsRouterPtr_.reset();

--- a/lib/src/HttpAppFrameworkImpl.cc
+++ b/lib/src/HttpAppFrameworkImpl.cc
@@ -1011,8 +1011,16 @@ void HttpAppFrameworkImpl::quit()
 {
     if (getLoop()->isRunning())
     {
-        getLoop()->queueInLoop([this]() {
+        getLoop()->queueInLoop([this]() mutable {
+            // Release thread-related managers
             listenerManagerPtr_->stopListening();
+            dbClientManagerPtr_.reset();
+            redisClientManagerPtr_.reset();
+            pluginsManagerPtr_.reset();
+            // TODO: let HttpAppFrameworkImpl manage IO loops
+            // and reset listenerManagerPtr_ before IO loops quit.
+            listenerManagerPtr_->stopIoLoops();
+            listenerManagerPtr_.reset();
             getLoop()->quit();
         });
     }

--- a/lib/src/HttpAppFrameworkImpl.h
+++ b/lib/src/HttpAppFrameworkImpl.h
@@ -641,7 +641,7 @@ class HttpAppFrameworkImpl final : public HttpAppFramework
     std::function<void()> termSignalHandler_{[]() { app().quit(); }};
     std::function<void()> intSignalHandler_{[]() { app().quit(); }};
     std::unique_ptr<SessionManager> sessionManagerPtr_;
-    std::unique_ptr<trantor::AsyncFileLogger> asyncFileLoggerPtr_;
+    std::shared_ptr<trantor::AsyncFileLogger> asyncFileLoggerPtr_;
     Json::Value jsonConfig_;
     HttpResponsePtr custom404_;
     std::function<HttpResponsePtr(HttpStatusCode)> customErrorHandler_ =

--- a/lib/src/HttpAppFrameworkImpl.h
+++ b/lib/src/HttpAppFrameworkImpl.h
@@ -588,11 +588,10 @@ class HttpAppFrameworkImpl final : public HttpAppFramework
     std::string serverHeader_{"server: drogon/" + drogon::getVersion() +
                               "\r\n"};
 
-    const std::unique_ptr<StaticFileRouter> staticFileRouterPtr_;
-    const std::unique_ptr<HttpControllersRouter> httpCtrlsRouterPtr_;
-    const std::unique_ptr<HttpSimpleControllersRouter>
-        httpSimpleCtrlsRouterPtr_;
-    const std::unique_ptr<WebsocketControllersRouter> websockCtrlsRouterPtr_;
+    std::unique_ptr<StaticFileRouter> staticFileRouterPtr_;
+    std::unique_ptr<HttpControllersRouter> httpCtrlsRouterPtr_;
+    std::unique_ptr<HttpSimpleControllersRouter> httpSimpleCtrlsRouterPtr_;
+    std::unique_ptr<WebsocketControllersRouter> websockCtrlsRouterPtr_;
 
     std::unique_ptr<ListenerManager> listenerManagerPtr_;
     std::unique_ptr<PluginsManager> pluginsManagerPtr_;

--- a/lib/src/HttpAppFrameworkImpl.h
+++ b/lib/src/HttpAppFrameworkImpl.h
@@ -594,10 +594,11 @@ class HttpAppFrameworkImpl final : public HttpAppFramework
         httpSimpleCtrlsRouterPtr_;
     const std::unique_ptr<WebsocketControllersRouter> websockCtrlsRouterPtr_;
 
-    const std::unique_ptr<ListenerManager> listenerManagerPtr_;
-    const std::unique_ptr<PluginsManager> pluginsManagerPtr_;
-    const std::unique_ptr<orm::DbClientManager> dbClientManagerPtr_;
-    const std::unique_ptr<nosql::RedisClientManager> redisClientManagerPtr_;
+    std::unique_ptr<ListenerManager> listenerManagerPtr_;
+    std::unique_ptr<PluginsManager> pluginsManagerPtr_;
+    std::unique_ptr<orm::DbClientManager> dbClientManagerPtr_;
+    std::unique_ptr<nosql::RedisClientManager> redisClientManagerPtr_;
+
     std::string rootPath_{"./"};
     std::string uploadPath_;
     std::atomic_bool running_{false};

--- a/lib/src/ListenerManager.cc
+++ b/lib/src/ListenerManager.cc
@@ -269,7 +269,6 @@ void ListenerManager::stopListening()
         serverPtr->stop();
     }
 #ifndef __linux__
-    assert(listeningloopThreads_.size() == 1);
     for (auto &listenerLoopPtr : listeningloopThreads_)
     {
         auto loop = listenerLoopPtr->getLoop();

--- a/lib/src/ListenerManager.h
+++ b/lib/src/ListenerManager.h
@@ -59,6 +59,7 @@ class ListenerManager : public trantor::NonCopyable
 
     trantor::EventLoop *getIOLoop(size_t id) const;
     void stopListening();
+    void stopIoLoops();
     std::vector<trantor::EventLoop *> ioLoops_;
 
   private:

--- a/lib/src/StaticFileRouter.cc
+++ b/lib/src/StaticFileRouter.cc
@@ -50,10 +50,13 @@ void StaticFileRouter::init(const std::vector<trantor::EventLoop *> &ioloops)
         new IOThreadStorage<
             std::unordered_map<std::string, HttpResponsePtr>>{});
     ioLocationsPtr_ =
-        decltype(ioLocationsPtr_)(new IOThreadStorage<std::vector<Location>>);
+        std::make_shared<IOThreadStorage<std::vector<Location>>>();
     for (auto *loop : ioloops)
     {
-        loop->queueInLoop([this] { **ioLocationsPtr_ = locations_; });
+        loop->queueInLoop(
+            [ioLocationsPtr = ioLocationsPtr_, locations = locations_] {
+                **ioLocationsPtr = locations;
+            });
     }
 }
 

--- a/lib/src/StaticFileRouter.cc
+++ b/lib/src/StaticFileRouter.cc
@@ -37,8 +37,8 @@ using namespace drogon;
 void StaticFileRouter::init(const std::vector<trantor::EventLoop *> &ioloops)
 {
     // Max timeout up to about 70 days;
-    staticFilesCacheMap_ = decltype(staticFilesCacheMap_)(
-        new IOThreadStorage<std::unique_ptr<CacheMap<std::string, char>>>);
+    staticFilesCacheMap_ = std::make_unique<
+        IOThreadStorage<std::unique_ptr<CacheMap<std::string, char>>>>();
     staticFilesCacheMap_->init(
         [&ioloops](std::unique_ptr<CacheMap<std::string, char>> &mapPtr,
                    size_t i) {
@@ -46,9 +46,8 @@ void StaticFileRouter::init(const std::vector<trantor::EventLoop *> &ioloops)
             mapPtr = std::unique_ptr<CacheMap<std::string, char>>(
                 new CacheMap<std::string, char>(ioloops[i], 1.0, 4, 50));
         });
-    staticFilesCache_ = decltype(staticFilesCache_)(
-        new IOThreadStorage<
-            std::unordered_map<std::string, HttpResponsePtr>>{});
+    staticFilesCache_ = std::make_unique<
+        IOThreadStorage<std::unordered_map<std::string, HttpResponsePtr>>>();
     ioLocationsPtr_ =
         std::make_shared<IOThreadStorage<std::vector<Location>>>();
     for (auto *loop : ioloops)

--- a/lib/src/StaticFileRouter.h
+++ b/lib/src/StaticFileRouter.h
@@ -169,7 +169,7 @@ class StaticFileRouter
             }
         }
     };
-    std::unique_ptr<IOThreadStorage<std::vector<Location>>> ioLocationsPtr_;
+    std::shared_ptr<IOThreadStorage<std::vector<Location>>> ioLocationsPtr_;
     std::vector<Location> locations_;
 };
 }  // namespace drogon


### PR DESCRIPTION
Some variables with static lifetime call LOG_XXX in their destructors, where asyncFileLogger or Logger::outputFuncs_ may have already been destructed. When that happend, the program is not able to exit normally, but triggering a core dump during exiting.

This PR fix this situation, but NOT completely.

Since con/destruct order of static things are not predictable in many cases, in order to solve this problem completely, we must(?) make some rules on when should LOG_XXX not be calling.
