### PR TITLE
Remove redundant resource release

### DIFF
--- a/orm_lib/src/DbClientManager.cc
+++ b/orm_lib/src/DbClientManager.cc
@@ -76,9 +76,6 @@ void DbClientManager::createDbClients(
                     {
                         c->setTimeout(dbInfo.timeout_);
                     }
-                    ioloops[idx]->runOnQuit([&, name = dbInfo.name_]() {
-                        dbFastClientsMap_[name].getThreadData().reset();
-                    });
                 });
             }
         }


### PR DESCRIPTION
Revert #1242.  Because #1250 handle resources in a better way.
