### PR TITLE
Check mysql_optionsv support in cmake.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -365,13 +365,22 @@ if (BUILD_MYSQL)
     if (MySQL_FOUND)
         target_link_libraries(${PROJECT_NAME} PRIVATE MySQL_lib)
         set(DROGON_FOUND_MYSQL TRUE)
+        set(MYSQL_LIB_NAME MySQL_lib)
     elseif (unofficial-libmariadb_FOUND)
         target_link_libraries(${PROJECT_NAME} PRIVATE unofficial::libmariadb)
         set(DROGON_FOUND_MYSQL TRUE)
+        set(MYSQL_LIB_NAME unofficial::libmariadb)
     endif ()
 
     if (DROGON_FOUND_MYSQL)
         message(STATUS "Ok! We find mariadb!")
+        include(CheckLibraryExists)
+        check_library_exists(${MYSQL_LIB_NAME} mysql_optionsv "" HAS_MYSQL_OPTIONSV)
+        if (HAS_MYSQL_OPTIONSV)
+            message(STATUS "Mariadb support mysql_optionsv")
+            add_definitions(-DHAS_MYSQL_OPTIONSV)
+        endif(HAS_MYSQL_OPTIONSV)
+
         set(DROGON_SOURCES
             ${DROGON_SOURCES}
             orm_lib/src/mysql_impl/MysqlConnection.cc

--- a/orm_lib/src/mysql_impl/MysqlConnection.cc
+++ b/orm_lib/src/mysql_impl/MysqlConnection.cc
@@ -56,8 +56,9 @@ MysqlConnection::MysqlConnection(trantor::EventLoop *loop,
 {
     mysql_init(mysqlPtr_.get());
     mysql_options(mysqlPtr_.get(), MYSQL_OPT_NONBLOCK, nullptr);
+#ifdef HAS_MYSQL_OPTIONSV
     mysql_optionsv(mysqlPtr_.get(), MYSQL_OPT_RECONNECT, &reconnect_);
-
+#endif
     // Get the key and value
     auto connParams = parseConnString(connInfo);
     for (auto const &kv : connParams)


### PR DESCRIPTION
Fix a version issue introduced by #1217. `mysql_optionsv` is not supported in official version of libmariadb on ubuntu-18 (maybe more places).
