### PR TITLE
Resolve issue #1275

### DIFF
--- a/lib/src/DbClientManagerSkipped.cc
+++ b/lib/src/DbClientManagerSkipped.cc
@@ -38,7 +38,8 @@ void DbClientManager::createDbClient(const std::string & /*dbType*/,
                                      const std::string & /*name*/,
                                      const bool /*isFast*/,
                                      const std::string & /*characterSet*/,
-                                     double /*timeout*/)
+                                     double /*timeout*/,
+                                     const bool /*autoBatch*/)
 {
     LOG_FATAL << "No database is supported by drogon, please install the "
                  "database development library first.";


### PR DESCRIPTION
The (dummy) `autoBatch` -parameter was missing from `DbClientManagerSkipped.cc`, preventing compilation when there are now db clients configured in the build.