### PR TITLE
Add content type to multipart file upload (resolves issue #1252)

### DIFF
--- a/lib/inc/drogon/UploadFile.h
+++ b/lib/inc/drogon/UploadFile.h
@@ -31,11 +31,13 @@ class UploadFile
      * default, the file name in the @param filePath
      * is provided to the server.
      * @param itemName The item name on the browser form.
+     * @param contentType The Mime content type for the part
      */
     explicit UploadFile(const std::string &filePath,
                         const std::string &fileName = "",
-                        const std::string &itemName = "file")
-        : path_(filePath), itemName_(itemName)
+                        const std::string &itemName = "file",
+                        ContentType contentType = CT_NONE)
+        : path_(filePath), itemName_(itemName), contentType_(contentType)
     {
         if (!fileName.empty())
         {
@@ -66,10 +68,15 @@ class UploadFile
     {
         return itemName_;
     }
+    ContentType contentType() const
+    {
+        return contentType_;
+    }
 
   private:
     std::string path_;
     std::string fileName_;
     std::string itemName_;
+    ContentType contentType_;
 };
 }  // namespace drogon

--- a/lib/src/HttpRequestImpl.cc
+++ b/lib/src/HttpRequestImpl.cc
@@ -288,7 +288,16 @@ void HttpRequestImpl::appendToBuffer(trantor::MsgBuffer *output) const
                 content.append(file.itemName());
                 content.append("\"; filename=\"");
                 content.append(file.fileName());
-                content.append("\"\r\n\r\n");
+                content.append("\"");
+                if (file.contentType() != CT_NONE)
+                {
+                    content.append("\r\n");
+
+                    auto &type = contentTypeToMime(file.contentType());
+                    content.append("content-type: ");
+                    content.append(type.data(), type.length());
+                }
+                content.append("\r\n\r\n");
                 std::ifstream infile(utils::toNativePath(file.path()),
                                      std::ifstream::binary);
                 if (!infile)


### PR DESCRIPTION
Add `contentType` -field to `UploadFile`, and if it's set to anything else but `CT_NONE`, add the corresponding MIME type to the parts header.

The new parameter is defaulted to `CT_NONE`, so the behaviour of existing code does not change.