### PR TITLE
few basic improvements for build.sh and so

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ CMakeSettings.json
 install
 trace.json
 .cache/
+.secret

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+@all:
+	./build.sh
+
+clean:
+	rm -f lib/inc/drogon/config.h
+	rm -rf ${build_dir}
+	mkdir ${build_dir}

--- a/build.sh
+++ b/build.sh
@@ -85,13 +85,13 @@ case nproc in
     ;;
 esac
 
-if [ -f /bin/clang++ ]; then
+if [ -f /usr/bin/clang++ ]; then
     cmake_gen="$cmake_gen -D CMAKE_C_COMPILER=clang -D CMAKE_CXX_COMPILER=clang++"
 else
     cmake_gen="$cmake_gen -D CMAKE_C_COMPILER=gcc -D CMAKE_CXX_COMPILER=g++"
 fi
 
-if [ -f /bin/ninja ]; then
+if [ -f /usr/bin/ninja ]; then
     make_program=ninja
     cmake_gen="$cmake_gen -GNinja"
 else

--- a/build.sh
+++ b/build.sh
@@ -85,9 +85,15 @@ case nproc in
     ;;
 esac
 
+if [ -f /bin/clang++ ]; then
+    cmake_gen="$cmake_gen -D CMAKE_C_COMPILER=clang -D CMAKE_CXX_COMPILER=clang++"
+else
+    cmake_gen="$cmake_gen -D CMAKE_C_COMPILER=gcc -D CMAKE_CXX_COMPILER=g++"
+fi
+
 if [ -f /bin/ninja ]; then
     make_program=ninja
-    cmake_gen='-GNinja'
+    cmake_gen="$cmake_gen -GNinja"
 else
     make_flags="$make_flags -j$parallel"
 fi

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 #build drogon
 function build_drogon() {
@@ -48,7 +48,7 @@ function build_drogon() {
     fi
 
     echo "Installing ..."
-    $make_program install
+    sudo $make_program install
 
     #Go back to the current directory
     cd $current_dir


### PR DESCRIPTION
Added a makefile to simplify inclusion of drogon as external dependency as is easily callable from an external script with make.
Added rule inside build.sh that detect and enable clang compiler if it's installed.
Switched /bin/ninja (and possibly /bin/clang) to more standard /usr/bin/ninja, since in linux it's usually located there.
Added a sudo inside build.sh because is generally more safe to run as superuser only those commands in which is strictly required.