### PR TITLE
Make orm::Result compatible with C++ STL container concepts

### DIFF
--- a/orm_lib/inc/drogon/orm/Result.h
+++ b/orm_lib/inc/drogon/orm/Result.h
@@ -75,6 +75,17 @@ class DROGON_EXPORT Result
     using ConstReverseIterator = ConstReverseResultIterator;
     using ReverseIterator = ConstReverseIterator;
 
+    // C++ type type defination compatibility
+    using value_type = Row;
+    using size_type = SizeType;
+    using difference_type = DifferenceType;
+    using reference = Reference;
+    using const_reference = const Reference;
+    using iterator = Iterator;
+    using const_iterator = ConstIterator;
+    using reverse_iterator = ConstReverseIterator;
+    using const_reverse_iterator = ConstReverseIterator;
+
     SizeType size() const noexcept;
     SizeType capacity() const noexcept
     {


### PR DESCRIPTION
This PR makes `drogon::orm::Result` compatible with STL container concepts. This enables generic algorithms to be applied over `orm::Result`. Especially ranges and concepts. For example, the following now works:

```cpp
template <typename T, typename Func>
    requires std::is_invocable_v<Func, typename T::value_type>
auto map(const T& data, Func&& func)
{
    using func_ret_type = decltype(func(data.front()));
    std::vector<func_ret_type> ret;
    ret.resize(data.size());
    std::transform(data.begin(), data.end(), std::back_inserter(ret), std::forward<Func>(func));
    return ret;
}


auto result = co_await db->execSqlCoro("SELECT .....");
auto urls = map(result, [](const auto& row) { return row["url"].as<std::string>(); });
```