### PR TITLE
Support compressed request

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -287,7 +287,11 @@
         //One can set it to "1024", "1k", "10M", "1G", etc. Setting it to "" means no limit.
         "client_max_websocket_message_size": "128K",
         //reuse_port: Defaults to false, users can run multiple processes listening on the same port at the same time.
-        "reuse_port": false
+        "reuse_port": false, 
+        // enabled_compresed_request: Defaults to false. If true the server will automatically decompress compressed request bodies.
+        // Currently only gzip and br are supported. _IMPORTANT_: Only use this under safe conditions. We can't know the size of the
+        // uncompressed body without actually decompressing it. It can lead to memory exhaustion and denial of service.
+        "enabled_compresed_request": false
     },
     //plugins: Define all plugins running in the application
     "plugins": [

--- a/config.example.json
+++ b/config.example.json
@@ -289,8 +289,9 @@
         //reuse_port: Defaults to false, users can run multiple processes listening on the same port at the same time.
         "reuse_port": false, 
         // enabled_compresed_request: Defaults to false. If true the server will automatically decompress compressed request bodies.
-        // Currently only gzip and br are supported. _IMPORTANT_: Only use this under safe conditions. We can't know the size of the
-        // uncompressed body without actually decompressing it. It can lead to memory exhaustion and denial of service.
+        // Currently only gzip and br are supported. Note: max_memory_body_size and max_body_size applies twice to compressed requests.
+        // Once when receiving the request and once when decompressing. i.e. if the decompressed body is larger than max_body_size,
+        // the request will be rejected.
         "enabled_compresed_request": false
     },
     //plugins: Define all plugins running in the application

--- a/config.example.json
+++ b/config.example.json
@@ -289,9 +289,9 @@
         //reuse_port: Defaults to false, users can run multiple processes listening on the same port at the same time.
         "reuse_port": false, 
         // enabled_compresed_request: Defaults to false. If true the server will automatically decompress compressed request bodies.
-        // Currently only gzip and br are supported. Note: max_memory_body_size and max_body_size applies twice to compressed requests.
-        // Once when receiving the request and once when decompressing. i.e. if the decompressed body is larger than max_body_size,
-        // the request will be rejected.
+        // Currently only gzip and br are supported. Note: max_memory_body_size and max_body_size applies twice for compressed requests.
+        // Once when receiving and once when decompressing. i.e. if the decompressed body is larger than max_body_size, the request
+        // will be rejected.
         "enabled_compresed_request": false
     },
     //plugins: Define all plugins running in the application

--- a/lib/inc/drogon/HttpAppFramework.h
+++ b/lib/inc/drogon/HttpAppFramework.h
@@ -1387,7 +1387,7 @@ class DROGON_EXPORT HttpAppFramework : public trantor::NonCopyable
     virtual HttpAppFramework &registerCustomExtensionMime(
         const std::string &ext,
         const std::string &mime) = 0;
-    
+
     virtual HttpAppFramework &enableCompressedRequest(bool enable = true) = 0;
     virtual bool isCompressedRequestEnabled() const = 0;
 

--- a/lib/inc/drogon/HttpAppFramework.h
+++ b/lib/inc/drogon/HttpAppFramework.h
@@ -1387,6 +1387,9 @@ class DROGON_EXPORT HttpAppFramework : public trantor::NonCopyable
     virtual HttpAppFramework &registerCustomExtensionMime(
         const std::string &ext,
         const std::string &mime) = 0;
+    
+    virtual HttpAppFramework &enableCompressedRequest(bool enable = true) = 0;
+    virtual bool isCompressedRequestEnabled() const = 0;
 
   private:
     virtual void registerHttpController(

--- a/lib/src/ConfigLoader.cc
+++ b/lib/src/ConfigLoader.cc
@@ -487,6 +487,8 @@ static void loadApp(const Json::Value &app)
                 drogon::app().registerCustomExtensionMime(extension, mime);
         }
     }
+    bool enableCompressedRequests = app.get("enabled_compresed_request", false).asBool();
+    drogon::app().enableCompressedRequest(enableCompressedRequests);
 }
 static void loadDbClients(const Json::Value &dbClients)
 {

--- a/lib/src/ConfigLoader.cc
+++ b/lib/src/ConfigLoader.cc
@@ -487,7 +487,8 @@ static void loadApp(const Json::Value &app)
                 drogon::app().registerCustomExtensionMime(extension, mime);
         }
     }
-    bool enableCompressedRequests = app.get("enabled_compresed_request", false).asBool();
+    bool enableCompressedRequests =
+        app.get("enabled_compresed_request", false).asBool();
     drogon::app().enableCompressedRequest(enableCompressedRequests);
 }
 static void loadDbClients(const Json::Value &dbClients)

--- a/lib/src/HttpAppFrameworkImpl.h
+++ b/lib/src/HttpAppFrameworkImpl.h
@@ -555,6 +555,17 @@ class HttpAppFrameworkImpl final : public HttpAppFramework
         return exceptionHandler_;
     }
 
+    HttpAppFramework &enableCompressedRequest(bool enable) override
+    {
+        enableCompressedRequest_ = enable;
+        return *this;
+    }
+
+    bool isCompressedRequestEnabled() const override
+    {
+        return enableCompressedRequest_;
+    }
+
     HttpAppFramework &registerCustomExtensionMime(
         const std::string &ext,
         const std::string &mime) override;
@@ -688,6 +699,7 @@ class HttpAppFrameworkImpl final : public HttpAppFramework
     std::vector<std::function<void(const HttpRequestPtr &)>>
         preHandlingObservers_;
     ExceptionHandler exceptionHandler_{defaultExceptionHandler};
+    bool enableCompressedRequest_{false};
 };
 
 }  // namespace drogon

--- a/lib/src/HttpRequestImpl.cc
+++ b/lib/src/HttpRequestImpl.cc
@@ -769,8 +769,9 @@ void HttpRequestImpl::setContentTypeString(const char *typeString,
 StreamDecompressStatus HttpRequestImpl::decompressBody()
 {
     auto contentEncoding = getHeaderBy("content-encoding");
-    if (contentEncoding.empty())
+    if (contentEncoding.empty() || contentEncoding == "identity")
     {
+        removeHeaderBy("content-encoding");
         return StreamDecompressStatus::Ok;
     }
 #ifdef USE_BROTLI

--- a/lib/src/HttpRequestImpl.cc
+++ b/lib/src/HttpRequestImpl.cc
@@ -768,7 +768,7 @@ void HttpRequestImpl::setContentTypeString(const char *typeString,
 
 StreamDecompressStatus HttpRequestImpl::decompressBody()
 {
-    auto& contentEncoding = getHeaderBy("content-encoding");
+    auto &contentEncoding = getHeaderBy("content-encoding");
     if (contentEncoding.empty() || contentEncoding == "identity")
     {
         removeHeaderBy("content-encoding");

--- a/lib/src/HttpRequestImpl.cc
+++ b/lib/src/HttpRequestImpl.cc
@@ -768,7 +768,7 @@ void HttpRequestImpl::setContentTypeString(const char *typeString,
 
 StreamDecompressStatus HttpRequestImpl::decompressBody()
 {
-    auto contentEncoding = getHeaderBy("content-encoding");
+    auto& contentEncoding = getHeaderBy("content-encoding");
     if (contentEncoding.empty() || contentEncoding == "identity")
     {
         removeHeaderBy("content-encoding");

--- a/lib/src/HttpRequestImpl.cc
+++ b/lib/src/HttpRequestImpl.cc
@@ -808,8 +808,7 @@ void HttpRequestImpl::decompressBodyBrotli()
 
     size_t availableIn = compressed.size();
     auto nextIn = (const uint8_t *)(compressed.data());
-    auto decompressed =
-        std::string(minVal(maxMemorySize, availableIn * 3), 0);
+    auto decompressed = std::string(minVal(maxMemorySize, availableIn * 3), 0);
     auto nextOut = (uint8_t *)(decompressed.data());
     size_t totalOut{0};
     bool done = false;

--- a/lib/src/HttpRequestImpl.cc
+++ b/lib/src/HttpRequestImpl.cc
@@ -776,11 +776,13 @@ StreamDecompressStatus HttpRequestImpl::decompressBody()
 #ifdef USE_BROTLI
     else if (contentEncoding == "br")
     {
+        removeHeaderBy("content-encoding");
         return decompressBodyBrotli();
     }
 #endif
     else if (contentEncoding == "gzip")
     {
+        removeHeaderBy("content-encoding");
         return decompressBodyGzip();
     }
     return StreamDecompressStatus::NotSupported;

--- a/lib/src/HttpRequestImpl.h
+++ b/lib/src/HttpRequestImpl.h
@@ -527,6 +527,7 @@ class HttpRequestImpl : public HttpRequest
 #ifdef USE_BROTLI
     void decompressBodyBrotli();
 #endif
+    void decompressBodyGzip();
     mutable bool flagForParsingParameters_{false};
     mutable bool flagForParsingJson_{false};
     HttpMethod method_{Invalid};

--- a/lib/src/HttpRequestImpl.h
+++ b/lib/src/HttpRequestImpl.h
@@ -464,6 +464,7 @@ class HttpRequestImpl : public HttpRequest
             return *jsonParsingErrorPtr_;
         return none;
     }
+    size_t decompressBody();
 
     ~HttpRequestImpl();
 
@@ -523,6 +524,9 @@ class HttpRequestImpl : public HttpRequest
     }
     void createTmpFile();
     void parseJson() const;
+#ifdef USE_BROTLI
+    void decompressBodyBrotli();
+#endif
     mutable bool flagForParsingParameters_{false};
     mutable bool flagForParsingJson_{false};
     HttpMethod method_{Invalid};

--- a/lib/src/HttpRequestImpl.h
+++ b/lib/src/HttpRequestImpl.h
@@ -533,9 +533,9 @@ class HttpRequestImpl : public HttpRequest
     void createTmpFile();
     void parseJson() const;
 #ifdef USE_BROTLI
-    StreamDecompressStatus decompressBodyBrotli();
+    StreamDecompressStatus decompressBodyBrotli() noexcept;
 #endif
-    StreamDecompressStatus decompressBodyGzip();
+    StreamDecompressStatus decompressBodyGzip() noexcept;
     mutable bool flagForParsingParameters_{false};
     mutable bool flagForParsingJson_{false};
     HttpMethod method_{Invalid};

--- a/lib/src/HttpRequestImpl.h
+++ b/lib/src/HttpRequestImpl.h
@@ -33,6 +33,14 @@
 
 namespace drogon
 {
+enum class StreamDecompressStatus
+{
+    TooLarge,
+    DecompressError,
+    NotSupported,
+    Ok
+};
+
 class HttpRequestImpl : public HttpRequest
 {
   public:
@@ -464,7 +472,7 @@ class HttpRequestImpl : public HttpRequest
             return *jsonParsingErrorPtr_;
         return none;
     }
-    size_t decompressBody();
+    StreamDecompressStatus decompressBody();
 
     ~HttpRequestImpl();
 
@@ -525,9 +533,9 @@ class HttpRequestImpl : public HttpRequest
     void createTmpFile();
     void parseJson() const;
 #ifdef USE_BROTLI
-    void decompressBodyBrotli();
+    StreamDecompressStatus decompressBodyBrotli();
 #endif
-    void decompressBodyGzip();
+    StreamDecompressStatus decompressBodyGzip();
     mutable bool flagForParsingParameters_{false};
     mutable bool flagForParsingJson_{false};
     HttpMethod method_{Invalid};

--- a/lib/src/HttpServer.cc
+++ b/lib/src/HttpServer.cc
@@ -536,7 +536,7 @@ void HttpServer::onRequests(
         {
             auto contentEncoding = req->getHeaderBy("content-encoding");
             auto body = req->getBody();
-            if(contentEncoding == "")
+            if (contentEncoding == "")
             {
                 // NoOP
             }
@@ -546,9 +546,7 @@ void HttpServer::onRequests(
                 req->removeHeader("content-encoding");
             }
 #ifdef USE_BROTLI
-            // only enable brotli decompression if over secure connection. Same logic as browsers only accept
-            // brotli over HTTPS. There are past issues with brotli over plain http.
-            else if (contentEncoding == "br" && req->isOnSecureConnection())
+            else if (contentEncoding == "br")
             {
                 req->setBody(utils::brotliDecompress(body.data(), body.size()));
                 req->removeHeader("content-encoding");

--- a/lib/src/HttpServer.cc
+++ b/lib/src/HttpServer.cc
@@ -535,25 +535,18 @@ void HttpServer::onRequests(
         if (enableDecompression)
         {
             auto status = req->decompressBody();
-            if (status == StreamDecompressStatus::DecompressError)
+            if (status != StreamDecompressStatus::Ok)
             {
                 sendForProcessing = false;
                 auto resp = HttpResponse::newHttpResponse();
-                resp->setStatusCode(k422UnprocessableEntity);
-                handleResponse(resp);
-            }
-            else if (status == StreamDecompressStatus::TooLarge)
-            {
-                sendForProcessing = false;
-                auto resp = HttpResponse::newHttpResponse();
-                resp->setStatusCode(k413RequestEntityTooLarge);
-                handleResponse(resp);
-            }
-            else if (status == StreamDecompressStatus::NotSupported)
-            {
-                sendForProcessing = false;
-                auto resp = HttpResponse::newHttpResponse();
-                resp->setStatusCode(k415UnsupportedMediaType);
+                if (status == StreamDecompressStatus::DecompressError)
+                    resp->setStatusCode(k422UnprocessableEntity);
+                else if (status == StreamDecompressStatus::NotSupported)
+                    resp->setStatusCode(k415UnsupportedMediaType);
+                else if (status == StreamDecompressStatus::TooLarge)
+                    resp->setStatusCode(k413RequestEntityTooLarge);
+                else  // Should not happen
+                    resp->setStatusCode(k422UnprocessableEntity);
                 handleResponse(resp);
             }
         }

--- a/lib/src/HttpServer.cc
+++ b/lib/src/HttpServer.cc
@@ -411,75 +411,47 @@ void HttpServer::onRequests(
                                                              &syncFlag,
                                                              close_,
                                                              isHeadMethod);
-        httpAsyncCallback_(
-            req,
-            [paramPack = std::move(paramPack),
-             this](const HttpResponsePtr &response) {
-                auto &conn = paramPack->conn;
-                auto &close_ = paramPack->close;
-                auto &req = paramPack->req;
-                auto &syncFlag = *paramPack->syncFlagPtr;
-                auto &isHeadMethod = paramPack->isHeadMethod;
-                auto &loopFlagPtr = paramPack->loopFlag;
-                auto &requestParser = paramPack->requestParser;
 
-                if (!response)
-                    return;
+        auto handleResponse = [paramPack = std::move(paramPack),
+                               this](const HttpResponsePtr &response) {
+            auto &conn = paramPack->conn;
+            auto &close_ = paramPack->close;
+            auto &req = paramPack->req;
+            auto &syncFlag = *paramPack->syncFlagPtr;
+            auto &isHeadMethod = paramPack->isHeadMethod;
+            auto &loopFlagPtr = paramPack->loopFlag;
+            auto &requestParser = paramPack->requestParser;
+
+            if (!response)
+                return;
+            if (!conn->connected())
+                return;
+
+            response->setVersion(req->getVersion());
+            response->setCloseConnection(close_);
+            for (auto &advice : preSendingAdvices_)
+            {
+                advice(req, response);
+            }
+            auto newResp = getCompressedResponse(req, response, isHeadMethod);
+            if (conn->getLoop()->isInLoopThread())
+            {
+                /*
+                 * A client that supports persistent connections MAY
+                 * "pipeline" its requests (i.e., send multiple requests
+                 * without waiting for each response). A server MUST send
+                 * its responses to those requests in the same order that
+                 * the requests were received. rfc2616-8.1.1.2
+                 */
                 if (!conn->connected())
                     return;
-
-                response->setVersion(req->getVersion());
-                response->setCloseConnection(close_);
-                for (auto &advice : preSendingAdvices_)
+                if (*loopFlagPtr)
                 {
-                    advice(req, response);
-                }
-                auto newResp =
-                    getCompressedResponse(req, response, isHeadMethod);
-                if (conn->getLoop()->isInLoopThread())
-                {
-                    /*
-                     * A client that supports persistent connections MAY
-                     * "pipeline" its requests (i.e., send multiple requests
-                     * without waiting for each response). A server MUST send
-                     * its responses to those requests in the same order that
-                     * the requests were received. rfc2616-8.1.1.2
-                     */
-                    if (!conn->connected())
-                        return;
-                    if (*loopFlagPtr)
+                    syncFlag = true;
+                    if (requestParser->emptyPipelining())
                     {
-                        syncFlag = true;
-                        if (requestParser->emptyPipelining())
-                        {
-                            requestParser->getResponseBuffer().emplace_back(
-                                newResp, isHeadMethod);
-                        }
-                        else
-                        {
-                            // some earlier requests are waiting for responses;
-                            requestParser->pushResponseToPipelining(
-                                req, newResp, isHeadMethod);
-                        }
-                    }
-                    else if (requestParser->getFirstRequest() == req)
-                    {
-                        requestParser->popFirstRequest();
-
-                        std::vector<std::pair<HttpResponsePtr, bool>> resps;
-                        resps.emplace_back(newResp, isHeadMethod);
-                        while (!requestParser->emptyPipelining())
-                        {
-                            auto resp = requestParser->getFirstResponse();
-                            if (resp.first)
-                            {
-                                requestParser->popFirstRequest();
-                                resps.push_back(std::move(resp));
-                            }
-                            else
-                                break;
-                        }
-                        sendResponses(conn, resps, requestParser->getBuffer());
+                        requestParser->getResponseBuffer().emplace_back(
+                            newResp, isHeadMethod);
                     }
                     else
                     {
@@ -489,49 +461,101 @@ void HttpServer::onRequests(
                                                                 isHeadMethod);
                     }
                 }
+                else if (requestParser->getFirstRequest() == req)
+                {
+                    requestParser->popFirstRequest();
+
+                    std::vector<std::pair<HttpResponsePtr, bool>> resps;
+                    resps.emplace_back(newResp, isHeadMethod);
+                    while (!requestParser->emptyPipelining())
+                    {
+                        auto resp = requestParser->getFirstResponse();
+                        if (resp.first)
+                        {
+                            requestParser->popFirstRequest();
+                            resps.push_back(std::move(resp));
+                        }
+                        else
+                            break;
+                    }
+                    sendResponses(conn, resps, requestParser->getBuffer());
+                }
                 else
                 {
-                    conn->getLoop()->queueInLoop([conn,
-                                                  req,
-                                                  newResp,
-                                                  this,
-                                                  isHeadMethod,
-                                                  requestParser]() {
-                        if (conn->connected())
-                        {
-                            if (requestParser->getFirstRequest() == req)
-                            {
-                                requestParser->popFirstRequest();
-                                std::vector<std::pair<HttpResponsePtr, bool>>
-                                    resps;
-                                resps.emplace_back(newResp, isHeadMethod);
-                                while (!requestParser->emptyPipelining())
-                                {
-                                    auto resp =
-                                        requestParser->getFirstResponse();
-                                    if (resp.first)
-                                    {
-                                        requestParser->popFirstRequest();
-                                        resps.push_back(std::move(resp));
-                                    }
-                                    else
-                                        break;
-                                }
-                                sendResponses(conn,
-                                              resps,
-                                              requestParser->getBuffer());
-                            }
-                            else
-                            {
-                                // some earlier requests are waiting for
-                                // responses;
-                                requestParser->pushResponseToPipelining(
-                                    req, newResp, isHeadMethod);
-                            }
-                        }
-                    });
+                    // some earlier requests are waiting for responses;
+                    requestParser->pushResponseToPipelining(req,
+                                                            newResp,
+                                                            isHeadMethod);
                 }
-            });
+            }
+            else
+            {
+                conn->getLoop()->queueInLoop([conn,
+                                              req,
+                                              newResp,
+                                              this,
+                                              isHeadMethod,
+                                              requestParser]() {
+                    if (conn->connected())
+                    {
+                        if (requestParser->getFirstRequest() == req)
+                        {
+                            requestParser->popFirstRequest();
+                            std::vector<std::pair<HttpResponsePtr, bool>> resps;
+                            resps.emplace_back(newResp, isHeadMethod);
+                            while (!requestParser->emptyPipelining())
+                            {
+                                auto resp = requestParser->getFirstResponse();
+                                if (resp.first)
+                                {
+                                    requestParser->popFirstRequest();
+                                    resps.push_back(std::move(resp));
+                                }
+                                else
+                                    break;
+                            }
+                            sendResponses(conn,
+                                          resps,
+                                          requestParser->getBuffer());
+                        }
+                        else
+                        {
+                            // some earlier requests are waiting for
+                            // responses;
+                            requestParser->pushResponseToPipelining(
+                                req, newResp, isHeadMethod);
+                        }
+                    }
+                });
+            }
+        };
+
+        const bool decompress = true;
+        bool sendForProcessing = true;
+        if (decompress)
+        {
+            auto contentEncoding = req->getHeaderBy("content-encoding");
+            auto body = req->getBody();
+            if (contentEncoding == "gzip")
+            {
+                req->setBody(utils::gzipDecompress(body.data(), body.size()));
+            }
+#ifdef USE_BROTLI
+            else if (contentEncoding == "br")
+            {
+                req->setBody(utils::brotliDecompress(body.data(), body.size()));
+            }
+#endif
+            else
+            {
+                sendForProcessing = false;
+                auto resp = HttpResponse::newHttpResponse();
+                resp->setStatusCode(k415UnsupportedMediaType);
+                handleResponse(resp);
+            }
+        }
+        if (sendForProcessing)
+            httpAsyncCallback_(req, std::move(handleResponse));
         if (syncFlag == false)
         {
             requestParser->pushRequestToPipelining(req);

--- a/lib/src/HttpServer.cc
+++ b/lib/src/HttpServer.cc
@@ -536,14 +536,22 @@ void HttpServer::onRequests(
         {
             auto contentEncoding = req->getHeaderBy("content-encoding");
             auto body = req->getBody();
-            if (contentEncoding == "gzip")
+            if(contentEncoding == "")
+            {
+                // NoOP
+            }
+            else if (contentEncoding == "gzip")
             {
                 req->setBody(utils::gzipDecompress(body.data(), body.size()));
+                req->removeHeader("content-encoding");
             }
 #ifdef USE_BROTLI
-            else if (contentEncoding == "br")
+            // only enable brotli decompression if over secure connection. Same logic as browsers only accept
+            // brotli over HTTPS. There are past issues with brotli over plain http.
+            else if (contentEncoding == "br" && req->isOnSecureConnection())
             {
                 req->setBody(utils::brotliDecompress(body.data(), body.size()));
+                req->removeHeader("content-encoding");
             }
 #endif
             else

--- a/lib/src/HttpServer.cc
+++ b/lib/src/HttpServer.cc
@@ -548,7 +548,15 @@ void HttpServer::onRequests(
 #ifdef USE_BROTLI
             else if (contentEncoding == "br")
             {
-                req->setBody(utils::brotliDecompress(body.data(), body.size()));
+                size_t resultingSize = req->decompressBody();
+                // Cannot decompress or the resulting size is too large.
+                if (resultingSize == 0)
+                {
+                    sendForProcessing = false;
+                    auto resp = HttpResponse::newHttpResponse();
+                    resp->setStatusCode(k413RequestEntityTooLarge);
+                    handleResponse(resp);
+                }
                 req->removeHeader("content-encoding");
             }
 #endif

--- a/lib/src/HttpServer.cc
+++ b/lib/src/HttpServer.cc
@@ -530,9 +530,9 @@ void HttpServer::onRequests(
             }
         };
 
-        const bool decompress = true;
+        const bool enableDecompression = app().isCompressedRequestEnabled();
         bool sendForProcessing = true;
-        if (decompress)
+        if (enableDecompression)
         {
             auto contentEncoding = req->getHeaderBy("content-encoding");
             auto body = req->getBody();

--- a/lib/tests/integration_test/client/main.cc
+++ b/lib/tests/integration_test/client/main.cc
@@ -986,17 +986,33 @@ void doTest(const HttpClientPtr &client, std::shared_ptr<test::Case> TEST_CTX)
     // Post compressed data
     req = HttpRequest::newHttpRequest();
     std::string deadbeef = "deadbeef";
-    req->setPath("/api/v1/ApiTest/gzipCompressedTest");
+    req->setPath("/api/v1/ApiTest/echoBody");
     req->addHeader("Content-Encoding", "gzip");
     req->setMethod(drogon::Post);
     req->setBody(utils::gzipCompress(deadbeef.c_str(), deadbeef.size()));
     client->sendRequest(req,
                         [deadbeef, TEST_CTX](ReqResult result,
-                                        const HttpResponsePtr &resp) {
+                                             const HttpResponsePtr &resp) {
                             REQUIRE(result == ReqResult::Ok);
                             CHECK(resp->getStatusCode() == k200OK);
                             CHECK(resp->body() == deadbeef);
                         });
+
+#ifdef USE_BROTLI
+    // Post compressed data
+    req = HttpRequest::newHttpRequest();
+    req->setPath("/api/v1/ApiTest/echoBody");
+    req->addHeader("Content-Encoding", "br");
+    req->setMethod(drogon::Post);
+    req->setBody(utils::brotliCompress(deadbeef.c_str(), deadbeef.size()));
+    client->sendRequest(req,
+                        [deadbeef, TEST_CTX](ReqResult result,
+                                             const HttpResponsePtr &resp) {
+                            REQUIRE(result == ReqResult::Ok);
+                            CHECK(resp->getStatusCode() == k200OK);
+                            CHECK(resp->body() == deadbeef);
+                        });
+#endif
 
 #if defined(__cpp_impl_coroutine)
     sync_wait([client, TEST_CTX]() -> Task<> {

--- a/lib/tests/integration_test/client/main.cc
+++ b/lib/tests/integration_test/client/main.cc
@@ -983,6 +983,21 @@ void doTest(const HttpClientPtr &client, std::shared_ptr<test::Case> TEST_CTX)
                             CHECK(resp->getStatusCode() == k404NotFound);
                         });
 
+    // Post compressed data
+    req = HttpRequest::newHttpRequest();
+    std::string deadbeef = "deadbeef";
+    req->setPath("/api/v1/ApiTest/gzipCompressedTest");
+    req->addHeader("Content-Encoding", "gzip");
+    req->setMethod(drogon::Post);
+    req->setBody(utils::gzipCompress(deadbeef.c_str(), deadbeef.size()));
+    client->sendRequest(req,
+                        [deadbeef, TEST_CTX](ReqResult result,
+                                        const HttpResponsePtr &resp) {
+                            REQUIRE(result == ReqResult::Ok);
+                            CHECK(resp->getStatusCode() == k200OK);
+                            CHECK(resp->body() == deadbeef);
+                        });
+
 #if defined(__cpp_impl_coroutine)
     sync_wait([client, TEST_CTX]() -> Task<> {
         // Test coroutine requests

--- a/lib/tests/integration_test/server/api_v1_ApiTest.cc
+++ b/lib/tests/integration_test/server/api_v1_ApiTest.cc
@@ -508,3 +508,11 @@ void ApiTest::cacheTestRegex(
     callback(resp);
     callCount++;
 }
+
+void ApiTest::gzipRequestTest(const HttpRequestPtr &req,
+                              std::function<void(const HttpResponsePtr &)> &&callback)
+{
+    auto resp = HttpResponse::newHttpResponse();
+    resp->setBody(std::string(req->body()));
+    callback(resp);
+}

--- a/lib/tests/integration_test/server/api_v1_ApiTest.cc
+++ b/lib/tests/integration_test/server/api_v1_ApiTest.cc
@@ -509,8 +509,8 @@ void ApiTest::cacheTestRegex(
     callCount++;
 }
 
-void ApiTest::gzipRequestTest(const HttpRequestPtr &req,
-                              std::function<void(const HttpResponsePtr &)> &&callback)
+void ApiTest::echoBody(const HttpRequestPtr &req,
+                       std::function<void(const HttpResponsePtr &)> &&callback)
 {
     auto resp = HttpResponse::newHttpResponse();
     resp->setBody(std::string(req->body()));

--- a/lib/tests/integration_test/server/api_v1_ApiTest.h
+++ b/lib/tests/integration_test/server/api_v1_ApiTest.h
@@ -42,6 +42,7 @@ class ApiTest : public drogon::HttpController<ApiTest>
     ADD_METHOD_VIA_REGEX(ApiTest::cacheTestRegex,
                          "/cacheTestRegex/[a-y]+",
                          Get);
+    METHOD_ADD(ApiTest::gzipRequestTest, "/gzipCompressedTest", Post);
     METHOD_LIST_END
 
     void get(const HttpRequestPtr &req,
@@ -85,7 +86,8 @@ class ApiTest : public drogon::HttpController<ApiTest>
     void cacheTestRegex(
         const HttpRequestPtr &req,
         std::function<void(const HttpResponsePtr &)> &&callback);
-
+    void gzipRequestTest(const HttpRequestPtr &req,
+                         std::function<void(const HttpResponsePtr &)> &&callback);
   public:
     ApiTest()
     {

--- a/lib/tests/integration_test/server/api_v1_ApiTest.h
+++ b/lib/tests/integration_test/server/api_v1_ApiTest.h
@@ -42,7 +42,7 @@ class ApiTest : public drogon::HttpController<ApiTest>
     ADD_METHOD_VIA_REGEX(ApiTest::cacheTestRegex,
                          "/cacheTestRegex/[a-y]+",
                          Get);
-    METHOD_ADD(ApiTest::gzipRequestTest, "/gzipCompressedTest", Post);
+    METHOD_ADD(ApiTest::echoBody, "/echoBody", Post);
     METHOD_LIST_END
 
     void get(const HttpRequestPtr &req,
@@ -86,8 +86,9 @@ class ApiTest : public drogon::HttpController<ApiTest>
     void cacheTestRegex(
         const HttpRequestPtr &req,
         std::function<void(const HttpResponsePtr &)> &&callback);
-    void gzipRequestTest(const HttpRequestPtr &req,
-                         std::function<void(const HttpResponsePtr &)> &&callback);
+    void echoBody(const HttpRequestPtr &req,
+                  std::function<void(const HttpResponsePtr &)> &&callback);
+
   public:
     ApiTest()
     {

--- a/lib/tests/integration_test/server/main.cc
+++ b/lib/tests/integration_test/server/main.cc
@@ -356,6 +356,7 @@ int main()
     resp->setExpiredTime(0);
     app().setCustom404Page(resp);
     app().addListener("0.0.0.0", 0);
+    app().enableCompressedRequest(true);
     app().registerBeginningAdvice([]() {
         auto addresses = app().getListeners();
         for (auto &address : addresses)


### PR DESCRIPTION
This PR adds server side support for #832. Currently `defalte` and `compress` is not supported (since on one uses them).

Other changes includes
* `app()` has interface to enable/query support for compressed request
* Sends a 415 response if server can't automatically decompress
* 422 if failed to decompress
* 413 if the decompressed result is larger than the max body size
* Config option to enabled compressed request
* Compressed requests has to be enabled manually for security reasons
  * Only enable this in secure environments. Otherwise possibility of DoS
* Tests
