### PR TITLE
Fix boring cast

### DIFF
--- a/lib/inc/drogon/utils/Utilities.h
+++ b/lib/inc/drogon/utils/Utilities.h
@@ -396,7 +396,7 @@ inline bool fromString<bool>(const std::string &p) noexcept(false)
     }
     std::string l{p};
     std::transform(p.begin(), p.end(), l.begin(), [](unsigned char c) {
-        return tolower(c);
+        return static_cast<char>(tolower(c));
     });
     if (l == "true")
     {


### PR DESCRIPTION
Visual Studio 2022 says:

```
...\build\_deps\drogon-src\lib\inc\drogon/utils/Utilities.h(400): message : see reference to function template instantiation '_OutIt std::transform<std::_String_const_iterator<std::_String_val<std::_Simple_types<_Elem>>>,std::_String_iterator<std::_String_val<std::_Simple_types<_Elem>>>,drogon::utils::fromString::<lambda_1>>(const _InIt,const _InIt,_OutIt,_Fn)' being compiled
          with
          [
              _OutIt=std::_String_iterator<std::_String_val<std::_Simple_types<char>>>,
              _Elem=char,
              _InIt=std::_String_const_iterator<std::_String_val<std::_Simple_types<char>>>,
              _Fn=drogon::utils::fromString::<lambda_1>
          ]
C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.32.31326\include\algorithm(3024,1): warning C4242: '=': conversion from 'int' to 'char', possible loss of data
```