### PR TITLE
Remove the `virtual` specifier from functions marked with `override`

### DIFF
--- a/drogon_ctl/create_controller.cc
+++ b/drogon_ctl/create_controller.cc
@@ -118,7 +118,7 @@ void create_controller::newSimpleControllerHeaderFile(
          << class_name << ">\n";
     file << "{\n";
     file << "  public:\n";
-    file << "    virtual void asyncHandleHttpRequest(const HttpRequestPtr& "
+    file << "    void asyncHandleHttpRequest(const HttpRequestPtr& "
             "req, std::function<void (const HttpResponsePtr &)> &&callback) "
             "override;\n";
 
@@ -187,15 +187,14 @@ void create_controller::newWebsockControllerHeaderFile(
          << class_name << ">\n";
     file << "{\n";
     file << "  public:\n";
-    file
-        << "    virtual void handleNewMessage(const WebSocketConnectionPtr&,\n";
+    file << "     void handleNewMessage(const WebSocketConnectionPtr&,\n";
     file << "                                  std::string &&,\n";
     file << "                                  const WebSocketMessageType &) "
             "override;\n";
-    file << "    virtual void handleNewConnection(const HttpRequestPtr &,\n";
+    file << "    void handleNewConnection(const HttpRequestPtr &,\n";
     file << "                                     const "
             "WebSocketConnectionPtr&) override;\n";
-    file << "    virtual void handleConnectionClosed(const "
+    file << "    void handleConnectionClosed(const "
             "WebSocketConnectionPtr&) override;\n";
     file << "    WS_PATH_LIST_BEGIN\n";
     file << "    // list path definitions here;\n";

--- a/drogon_ctl/templates/filter_h.csp
+++ b/drogon_ctl/templates/filter_h.csp
@@ -22,9 +22,9 @@ class [[className]] : public HttpFilter<[[className]]>
 {
   public:
     [[className]]() {}
-    virtual void doFilter(const HttpRequestPtr &req,
-                          FilterCallback &&fcb,
-                          FilterChainCallback &&fccb) override;
+    void doFilter(const HttpRequestPtr &req,
+                  FilterCallback &&fcb,
+                  FilterChainCallback &&fccb) override;
 };
 
 <%c++for(size_t i=0;i<namespaceVector.size();i++){%>

--- a/drogon_ctl/templates/plugin_h.csp
+++ b/drogon_ctl/templates/plugin_h.csp
@@ -23,11 +23,11 @@ class [[className]] : public drogon::Plugin<[[className]]>
     [[className]]() {}
     /// This method must be called by drogon to initialize and start the plugin.
     /// It must be implemented by the user.
-    virtual void initAndStart(const Json::Value &config) override;
+    void initAndStart(const Json::Value &config) override;
 
     /// This method must be called by drogon to shutdown the plugin.
     /// It must be implemented by the user.
-    virtual void shutdown() override;
+    void shutdown() override;
 };
 
 <%c++for(size_t i=0;i<namespaceVector.size();i++){%>


### PR DESCRIPTION
As `clang-tidy` states, the `virtual` specifier is redundant for a function that is already declared 'override'.

https://releases.llvm.org/12.0.0/tools/clang/tools/extra/docs/clang-tidy/checks/modernize-use-override.html