### PR TITLE
Omit redundant virtual specifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ using namespace drogon;
 class TestCtrl:public drogon::HttpSimpleController<TestCtrl>
 {
 public:
-    virtual void asyncHandleHttpRequest(const HttpRequestPtr& req, std::function<void (const HttpResponsePtr &)> &&callback) override;
+    void asyncHandleHttpRequest(const HttpRequestPtr& req, std::function<void (const HttpResponsePtr &)> &&callback) override;
     PATH_LIST_BEGIN
     PATH_ADD("/test",Get);
     PATH_LIST_END
@@ -127,7 +127,7 @@ using namespace drogon;
 class JsonCtrl : public drogon::HttpSimpleController<JsonCtrl>
 {
   public:
-    virtual void asyncHandleHttpRequest(const HttpRequestPtr &req, std::function<void(const HttpResponsePtr &)> &&callback) override;
+    void asyncHandleHttpRequest(const HttpRequestPtr &req, std::function<void(const HttpResponsePtr &)> &&callback) override;
     PATH_LIST_BEGIN
     //list path definitions here;
     PATH_ADD("/json", Get);

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -99,7 +99,7 @@ using namespace drogon;
 class TestCtrl:public drogon::HttpSimpleController<TestCtrl>
 {
 public:
-    virtual void asyncHandleHttpRequest(const HttpRequestPtr& req, std::function<void (const HttpResponsePtr &)> &&callback) override;
+    void asyncHandleHttpRequest(const HttpRequestPtr& req, std::function<void (const HttpResponsePtr &)> &&callback) override;
     PATH_LIST_BEGIN
     PATH_ADD("/test",Get);
     PATH_LIST_END
@@ -130,7 +130,7 @@ using namespace drogon;
 class JsonCtrl : public drogon::HttpSimpleController<JsonCtrl>
 {
   public:
-    virtual void asyncHandleHttpRequest(const HttpRequestPtr &req, std::function<void(const HttpResponsePtr &)> &&callback) override;
+    void asyncHandleHttpRequest(const HttpRequestPtr &req, std::function<void(const HttpResponsePtr &)> &&callback) override;
     PATH_LIST_BEGIN
     //list path definitions here;
     PATH_ADD("/json", Get);

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -99,7 +99,7 @@ using namespace drogon;
 class TestCtrl:public drogon::HttpSimpleController<TestCtrl>
 {
 public:
-    virtual void asyncHandleHttpRequest(const HttpRequestPtr& req, std::function<void (const HttpResponsePtr &)> &&callback) override;
+    void asyncHandleHttpRequest(const HttpRequestPtr& req, std::function<void (const HttpResponsePtr &)> &&callback) override;
     PATH_LIST_BEGIN
     PATH_ADD("/test",Get);
     PATH_LIST_END
@@ -130,7 +130,7 @@ using namespace drogon;
 class JsonCtrl : public drogon::HttpSimpleController<JsonCtrl>
 {
   public:
-    virtual void asyncHandleHttpRequest(const HttpRequestPtr &req, std::function<void(const HttpResponsePtr &)> &&callback) override;
+    void asyncHandleHttpRequest(const HttpRequestPtr &req, std::function<void(const HttpResponsePtr &)> &&callback) override;
     PATH_LIST_BEGIN
     //list path definitions here;
     PATH_ADD("/json", Get);

--- a/drogon_ctl/create.h
+++ b/drogon_ctl/create.h
@@ -22,16 +22,16 @@ namespace drogon_ctl
 class create : public DrObject<create>, public CommandHandler
 {
   public:
-    virtual void handleCommand(std::vector<std::string> &parameters) override;
-    virtual std::string script() override
+    void handleCommand(std::vector<std::string> &parameters) override;
+    std::string script() override
     {
         return "create some source files(Use 'drogon_ctl help create' for more "
                "information)";
     }
-    virtual bool isTopCommand() override
+    bool isTopCommand() override
     {
         return true;
     }
-    virtual std::string detail() override;
+    std::string detail() override;
 };
 }  // namespace drogon_ctl

--- a/drogon_ctl/create_controller.h
+++ b/drogon_ctl/create_controller.h
@@ -24,8 +24,8 @@ class create_controller : public DrObject<create_controller>,
                           public CommandHandler
 {
   public:
-    virtual void handleCommand(std::vector<std::string> &parameters) override;
-    virtual std::string script() override
+    void handleCommand(std::vector<std::string> &parameters) override;
+    std::string script() override
     {
         return "create controller files";
     }

--- a/drogon_ctl/create_filter.h
+++ b/drogon_ctl/create_filter.h
@@ -22,8 +22,8 @@ namespace drogon_ctl
 class create_filter : public DrObject<create_filter>, public CommandHandler
 {
   public:
-    virtual void handleCommand(std::vector<std::string> &parameters) override;
-    virtual std::string script() override
+    void handleCommand(std::vector<std::string> &parameters) override;
+    std::string script() override
     {
         return "create filter class files";
     }

--- a/drogon_ctl/create_model.h
+++ b/drogon_ctl/create_model.h
@@ -337,8 +337,8 @@ class Relationship
 class create_model : public DrObject<create_model>, public CommandHandler
 {
   public:
-    virtual void handleCommand(std::vector<std::string> &parameters) override;
-    virtual std::string script() override
+    void handleCommand(std::vector<std::string> &parameters) override;
+    std::string script() override
     {
         return "create Model classes files";
     }

--- a/drogon_ctl/create_plugin.h
+++ b/drogon_ctl/create_plugin.h
@@ -22,8 +22,8 @@ namespace drogon_ctl
 class create_plugin : public DrObject<create_plugin>, public CommandHandler
 {
   public:
-    virtual void handleCommand(std::vector<std::string> &parameters) override;
-    virtual std::string script() override
+    void handleCommand(std::vector<std::string> &parameters) override;
+    std::string script() override
     {
         return "create plugin class files";
     }

--- a/drogon_ctl/create_project.h
+++ b/drogon_ctl/create_project.h
@@ -21,8 +21,8 @@ namespace drogon_ctl
 class create_project : public DrObject<create_project>, public CommandHandler
 {
   public:
-    virtual void handleCommand(std::vector<std::string> &parameters) override;
-    virtual std::string script() override
+    void handleCommand(std::vector<std::string> &parameters) override;
+    std::string script() override
     {
         return "create a project";
     }

--- a/drogon_ctl/create_view.h
+++ b/drogon_ctl/create_view.h
@@ -22,8 +22,8 @@ namespace drogon_ctl
 class create_view : public DrObject<create_view>, public CommandHandler
 {
   public:
-    virtual void handleCommand(std::vector<std::string> &parameters) override;
-    virtual std::string script() override
+    void handleCommand(std::vector<std::string> &parameters) override;
+    std::string script() override
     {
         return "create view class files";
     }

--- a/drogon_ctl/help.h
+++ b/drogon_ctl/help.h
@@ -22,12 +22,12 @@ namespace drogon_ctl
 class help : public DrObject<help>, public CommandHandler
 {
   public:
-    virtual void handleCommand(std::vector<std::string> &parameters) override;
-    virtual std::string script() override
+    void handleCommand(std::vector<std::string> &parameters) override;
+    std::string script() override
     {
         return "display this message";
     }
-    virtual bool isTopCommand() override
+    bool isTopCommand() override
     {
         return true;
     }

--- a/drogon_ctl/press.h
+++ b/drogon_ctl/press.h
@@ -42,17 +42,17 @@ struct Statistics
 class press : public DrObject<press>, public CommandHandler
 {
   public:
-    virtual void handleCommand(std::vector<std::string> &parameters) override;
-    virtual std::string script() override
+    void handleCommand(std::vector<std::string> &parameters) override;
+    std::string script() override
     {
         return "Do stress testing(Use 'drogon_ctl help press' for more "
                "information)";
     }
-    virtual bool isTopCommand() override
+    bool isTopCommand() override
     {
         return true;
     }
-    virtual std::string detail() override;
+    std::string detail() override;
 
   private:
     size_t numOfThreads_{1};

--- a/drogon_ctl/version.h
+++ b/drogon_ctl/version.h
@@ -22,12 +22,12 @@ namespace drogon_ctl
 class version : public DrObject<version>, public CommandHandler
 {
   public:
-    virtual void handleCommand(std::vector<std::string> &parameters) override;
-    virtual std::string script() override
+    void handleCommand(std::vector<std::string> &parameters) override;
+    std::string script() override
     {
         return "display version of this tool";
     }
-    virtual bool isTopCommand() override
+    bool isTopCommand() override
     {
         return true;
     }

--- a/examples/simple_reverse_proxy/plugins/SimpleReverseProxy.h
+++ b/examples/simple_reverse_proxy/plugins/SimpleReverseProxy.h
@@ -21,11 +21,11 @@ class SimpleReverseProxy : public drogon::Plugin<SimpleReverseProxy>
     }
     /// This method must be called by drogon to initialize and start the plugin.
     /// It must be implemented by the user.
-    virtual void initAndStart(const Json::Value &config) override;
+    void initAndStart(const Json::Value &config) override;
 
     /// This method must be called by drogon to shutdown the plugin.
     /// It must be implemented by the user.
-    virtual void shutdown() override;
+    void shutdown() override;
 
   private:
     // Create 'connectionFactor_' HTTP clients for every backend in every IO

--- a/lib/inc/drogon/DrObject.h
+++ b/lib/inc/drogon/DrObject.h
@@ -64,7 +64,7 @@ template <typename T>
 class DrObject : public virtual DrObjectBase
 {
   public:
-    virtual const std::string &className() const override
+    const std::string &className() const override
     {
         return alloc_.className();
     }
@@ -73,7 +73,7 @@ class DrObject : public virtual DrObjectBase
         return alloc_.className();
     }
 
-    virtual bool isClass(const std::string &class_name) const override
+    bool isClass(const std::string &class_name) const override
     {
         return (className() == class_name);
     }

--- a/lib/inc/drogon/LocalHostFilter.h
+++ b/lib/inc/drogon/LocalHostFilter.h
@@ -28,8 +28,8 @@ class DROGON_EXPORT LocalHostFilter : public HttpFilter<LocalHostFilter>
     LocalHostFilter()
     {
     }
-    virtual void doFilter(const HttpRequestPtr &req,
-                          FilterCallback &&fcb,
-                          FilterChainCallback &&fccb) override;
+    void doFilter(const HttpRequestPtr &req,
+                  FilterCallback &&fcb,
+                  FilterChainCallback &&fccb) override;
 };
 }  // namespace drogon

--- a/lib/inc/drogon/NotFound.h
+++ b/lib/inc/drogon/NotFound.h
@@ -29,6 +29,6 @@ class DROGON_EXPORT NotFound final : public drogon::DrTemplate<NotFound>
     NotFound()
     {
     }
-    virtual std::string genText(const drogon::HttpViewData &) override;
+    std::string genText(const drogon::HttpViewData &) override;
 };
 }  // namespace drogon

--- a/lib/inc/drogon/plugins/SecureSSLRedirector.h
+++ b/lib/inc/drogon/plugins/SecureSSLRedirector.h
@@ -50,11 +50,11 @@ class DROGON_EXPORT SecureSSLRedirector
     }
     /// This method must be called by drogon to initialize and start the plugin.
     /// It must be implemented by the user.
-    virtual void initAndStart(const Json::Value &config) override;
+    void initAndStart(const Json::Value &config) override;
 
     /// This method must be called by drogon to shutdown the plugin.
     /// It must be implemented by the user.
-    virtual void shutdown() override;
+    void shutdown() override;
 
   private:
     HttpResponsePtr redirectingAdvice(const HttpRequestPtr &) const;

--- a/lib/inc/drogon/utils/FunctionTraits.h
+++ b/lib/inc/drogon/utils/FunctionTraits.h
@@ -48,9 +48,8 @@ struct FunctionTraits;
 
 // functor,lambda,std::function...
 template <typename Function>
-struct FunctionTraits
-    : public FunctionTraits<
-          decltype(&std::remove_reference<Function>::type::operator())>
+struct FunctionTraits : public FunctionTraits<decltype(
+                            &std::remove_reference<Function>::type::operator())>
 {
     static const bool isClassFunction = false;
     static const bool isDrObjectClass = false;

--- a/lib/inc/drogon/utils/FunctionTraits.h
+++ b/lib/inc/drogon/utils/FunctionTraits.h
@@ -48,8 +48,9 @@ struct FunctionTraits;
 
 // functor,lambda,std::function...
 template <typename Function>
-struct FunctionTraits : public FunctionTraits<decltype(
-                            &std::remove_reference<Function>::type::operator())>
+struct FunctionTraits
+    : public FunctionTraits<
+          decltype(&std::remove_reference<Function>::type::operator())>
 {
     static const bool isClassFunction = false;
     static const bool isDrObjectClass = false;

--- a/lib/src/HttpMessageBody.h
+++ b/lib/src/HttpMessageBody.h
@@ -71,27 +71,27 @@ class HttpMessageStringBody : public HttpMessageBody
     {
         type_ = BodyType::kString;
     }
-    virtual const char *data() const override
+    const char *data() const override
     {
         return body_.data();
     }
-    virtual char *data() override
+    char *data() override
     {
         return const_cast<char *>(body_.data());
     }
-    virtual size_t length() const override
+    size_t length() const override
     {
         return body_.length();
     }
-    virtual const std::string &getString() const override
+    const std::string &getString() const override
     {
         return body_;
     }
-    virtual std::string &getString() override
+    std::string &getString() override
     {
         return body_;
     }
-    virtual void append(const char *buf, size_t len) override
+    void append(const char *buf, size_t len) override
     {
         body_.append(buf, len);
     }
@@ -107,19 +107,19 @@ class HttpMessageStringViewBody : public HttpMessageBody
     {
         type_ = BodyType::kStringView;
     }
-    virtual const char *data() const override
+    const char *data() const override
     {
         return body_.data();
     }
-    virtual char *data() override
+    char *data() override
     {
         return const_cast<char *>(body_.data());
     }
-    virtual size_t length() const override
+    size_t length() const override
     {
         return body_.length();
     }
-    virtual const std::string &getString() const override
+    const std::string &getString() const override
     {
         if (!bodyString_)
         {
@@ -135,7 +135,7 @@ class HttpMessageStringViewBody : public HttpMessageBody
         }
         return *bodyString_;
     }
-    virtual std::string &getString() override
+    std::string &getString() override
     {
         if (!bodyString_)
         {

--- a/lib/src/HttpRequestImpl.h
+++ b/lib/src/HttpRequestImpl.h
@@ -89,12 +89,12 @@ class HttpRequestImpl : public HttpRequest
         }
     }
 
-    virtual Version version() const override
+    Version version() const override
     {
         return version_;
     }
 
-    virtual const char *versionString() const override;
+    const char *versionString() const override;
 
     bool setMethod(const char *start, const char *end);
     void setSecure(bool secure)
@@ -102,18 +102,18 @@ class HttpRequestImpl : public HttpRequest
         isOnSecureConnection_ = secure;
     }
 
-    virtual void setMethod(const HttpMethod method) override
+    void setMethod(const HttpMethod method) override
     {
         method_ = method;
         return;
     }
 
-    virtual HttpMethod method() const override
+    HttpMethod method() const override
     {
         return method_;
     }
 
-    virtual const char *methodString() const override;
+    const char *methodString() const override;
 
     void setPath(const char *start, const char *end)
     {
@@ -127,7 +127,7 @@ class HttpRequestImpl : public HttpRequest
         }
     }
 
-    virtual void setPath(const std::string &path) override
+    void setPath(const std::string &path) override
     {
         path_ = path;
     }
@@ -137,15 +137,14 @@ class HttpRequestImpl : public HttpRequest
         pathEncode_ = pathEncode;
     }
 
-    virtual const std::unordered_map<std::string, std::string> &parameters()
+    const std::unordered_map<std::string, std::string> &parameters()
         const override
     {
         parseParametersOnce();
         return parameters_;
     }
 
-    virtual const std::string &getParameter(
-        const std::string &key) const override
+    const std::string &getParameter(const std::string &key) const override
     {
         const static std::string defaultVal;
         parseParametersOnce();
@@ -155,7 +154,7 @@ class HttpRequestImpl : public HttpRequest
         return defaultVal;
     }
 
-    virtual const std::string &path() const override
+    const std::string &path() const override
     {
         return path_;
     }
@@ -178,7 +177,7 @@ class HttpRequestImpl : public HttpRequest
         }
         return content_;
     }
-    virtual const char *bodyData() const override
+    const char *bodyData() const override
     {
         if (cacheFilePtr_)
         {
@@ -186,7 +185,7 @@ class HttpRequestImpl : public HttpRequest
         }
         return content_.data();
     }
-    virtual size_t bodyLength() const override
+    size_t bodyLength() const override
     {
         if (cacheFilePtr_)
         {
@@ -211,22 +210,22 @@ class HttpRequestImpl : public HttpRequest
         return content_;
     }
 
-    virtual const std::string &query() const override
+    const std::string &query() const override
     {
         return query_;
     }
 
-    virtual const trantor::InetAddress &peerAddr() const override
+    const trantor::InetAddress &peerAddr() const override
     {
         return peer_;
     }
 
-    virtual const trantor::InetAddress &localAddr() const override
+    const trantor::InetAddress &localAddr() const override
     {
         return local_;
     }
 
-    virtual const trantor::Date &creationDate() const override
+    const trantor::Date &creationDate() const override
     {
         return creationDate_;
     }
@@ -248,7 +247,7 @@ class HttpRequestImpl : public HttpRequest
 
     void addHeader(const char *start, const char *colon, const char *end);
 
-    virtual void removeHeader(std::string key) override
+    void removeHeader(std::string key) override
     {
         transform(key.begin(), key.end(), key.begin(), [](unsigned char c) {
             return tolower(c);
@@ -302,8 +301,7 @@ class HttpRequestImpl : public HttpRequest
         return cookies_;
     }
 
-    virtual void setParameter(const std::string &key,
-                              const std::string &value) override
+    void setParameter(const std::string &key, const std::string &value) override
     {
         flagForParsingParameters_ = true;
         parameters_[key] = value;
@@ -321,17 +319,17 @@ class HttpRequestImpl : public HttpRequest
         content_ = content;
     }
 
-    virtual void setBody(const std::string &body) override
+    void setBody(const std::string &body) override
     {
         content_ = body;
     }
 
-    virtual void setBody(std::string &&body) override
+    void setBody(std::string &&body) override
     {
         content_ = std::move(body);
     }
 
-    virtual void addHeader(std::string field, const std::string &value) override
+    void addHeader(std::string field, const std::string &value) override
     {
         transform(field.begin(),
                   field.end(),
@@ -340,7 +338,7 @@ class HttpRequestImpl : public HttpRequest
         headers_[std::move(field)] = value;
     }
 
-    virtual void addHeader(std::string field, std::string &&value) override
+    void addHeader(std::string field, std::string &&value) override
     {
         transform(field.begin(),
                   field.end(),
@@ -349,13 +347,12 @@ class HttpRequestImpl : public HttpRequest
         headers_[std::move(field)] = std::move(value);
     }
 
-    virtual void addCookie(const std::string &key,
-                           const std::string &value) override
+    void addCookie(const std::string &key, const std::string &value) override
     {
         cookies_[key] = value;
     }
 
-    virtual void setPassThrough(bool flag) override
+    void setPassThrough(bool flag) override
     {
         passThrough_ = flag;
     }
@@ -367,7 +364,7 @@ class HttpRequestImpl : public HttpRequest
 
     void appendToBuffer(trantor::MsgBuffer *output) const;
 
-    virtual const SessionPtr &session() const override
+    const SessionPtr &session() const override
     {
         return sessionPtr_;
     }
@@ -377,7 +374,7 @@ class HttpRequestImpl : public HttpRequest
         sessionPtr_ = session;
     }
 
-    virtual const AttributesPtr &attributes() const override
+    const AttributesPtr &attributes() const override
     {
         if (!attributesPtr_)
         {
@@ -386,7 +383,7 @@ class HttpRequestImpl : public HttpRequest
         return attributesPtr_;
     }
 
-    virtual const std::shared_ptr<Json::Value> &jsonObject() const override
+    const std::shared_ptr<Json::Value> &jsonObject() const override
     {
         // Not multi-thread safe but good, because we basically call this
         // function in a single thread
@@ -398,7 +395,7 @@ class HttpRequestImpl : public HttpRequest
         return jsonPtr_;
     }
 
-    virtual void setCustomContentTypeString(const std::string &type) override
+    void setCustomContentTypeString(const std::string &type) override
     {
         contentType_ = CT_NONE;
         flagForParsingContentType_ = true;
@@ -413,7 +410,7 @@ class HttpRequestImpl : public HttpRequest
         contentTypeString_ = std::string(type.begin() + (haveHeader ? 14 : 0),
                                          type.end() - endOffset);
     }
-    virtual void setContentTypeCode(const ContentType type) override
+    void setContentTypeCode(const ContentType type) override
     {
         contentType_ = type;
         flagForParsingContentType_ = true;
@@ -424,24 +421,24 @@ class HttpRequestImpl : public HttpRequest
     void setContentTypeString(const char *typeString,
                               size_t typeStringLength) override;
 
-    // virtual void setContentTypeCodeAndCharacterSet(ContentType type, const
+    // void setContentTypeCodeAndCharacterSet(ContentType type, const
     // std::string &charSet = "utf-8") override
     // {
     //     contentType_ = type;
     //     setContentType(webContentTypeAndCharsetToString(type, charSet));
     // }
 
-    virtual ContentType contentType() const override
+    ContentType contentType() const override
     {
         parseContentTypeAndString();
         return contentType_;
     }
 
-    virtual const char *matchedPathPatternData() const override
+    const char *matchedPathPatternData() const override
     {
         return matchedPathPattern_.data();
     }
-    virtual size_t matchedPathPatternLength() const override
+    size_t matchedPathPatternLength() const override
     {
         return matchedPathPattern_.length();
     }
@@ -461,11 +458,11 @@ class HttpRequestImpl : public HttpRequest
     {
         return keepAlive_;
     }
-    virtual bool isOnSecureConnection() const noexcept override
+    bool isOnSecureConnection() const noexcept override
     {
         return isOnSecureConnection_;
     }
-    virtual const std::string &getJsonError() const override
+    const std::string &getJsonError() const override
     {
         const static std::string none{""};
         if (jsonParsingErrorPtr_)

--- a/lib/src/HttpResponseImpl.h
+++ b/lib/src/HttpResponseImpl.h
@@ -81,7 +81,7 @@ class DROGON_EXPORT HttpResponseImpl : public HttpResponse
         return version_;
     }
 
-    virtual const char *versionString() const override;
+    const char *versionString() const override;
 
     void setCloseConnection(bool on) override
     {

--- a/lib/tests/integration_test/server/DoNothingPlugin.h
+++ b/lib/tests/integration_test/server/DoNothingPlugin.h
@@ -17,9 +17,9 @@ class DoNothingPlugin : public Plugin<DoNothingPlugin>
     }
     /// This method must be called by drogon to initialize and start the plugin.
     /// It must be implemented by the user.
-    virtual void initAndStart(const Json::Value &config) override;
+    void initAndStart(const Json::Value &config) override;
 
     /// This method must be called by drogon to shutdown the plugin.
     /// It must be implemented by the user.
-    virtual void shutdown() override;
+    void shutdown() override;
 };

--- a/lib/tests/integration_test/server/TestPlugin.h
+++ b/lib/tests/integration_test/server/TestPlugin.h
@@ -17,11 +17,11 @@ class TestPlugin : public Plugin<TestPlugin>
     }
     /// This method must be called by drogon to initialize and start the plugin.
     /// It must be implemented by the user.
-    virtual void initAndStart(const Json::Value &config) override;
+    void initAndStart(const Json::Value &config) override;
 
     /// This method must be called by drogon to shutdown the plugin.
     /// It must be implemented by the user.
-    virtual void shutdown() override;
+    void shutdown() override;
 
   private:
     std::thread workThread_;

--- a/lib/tests/integration_test/server/a-directory/page.html
+++ b/lib/tests/integration_test/server/a-directory/page.html
@@ -127,7 +127,7 @@ using namespace drogon;
 class JsonCtrl : public drogon::HttpSimpleController<jsonctrl>
 {
   public:
-    virtual void asyncHandleHttpRequest(const HttpRequestPtr &amp;req, const std::function&lt;void(const HttpResponsePtr &amp;)&gt; &amp;callback) override;
+    void asyncHandleHttpRequest(const HttpRequestPtr &amp;req, const std::function&lt;void(const HttpResponsePtr &amp;)&gt; &amp;callback) override;
     PATH_LIST_BEGIN
     //list path definitions here;
     PATH_ADD("/json", Get);

--- a/lib/tests/integration_test/server/index.html
+++ b/lib/tests/integration_test/server/index.html
@@ -127,7 +127,7 @@ using namespace drogon;
 class JsonCtrl : public drogon::HttpSimpleController<jsonctrl>
 {
   public:
-    virtual void asyncHandleHttpRequest(const HttpRequestPtr &amp;req, const std::function&lt;void(const HttpResponsePtr &amp;)&gt; &amp;callback) override;
+    void asyncHandleHttpRequest(const HttpRequestPtr &amp;req, const std::function&lt;void(const HttpResponsePtr &amp;)&gt; &amp;callback) override;
     PATH_LIST_BEGIN
     //list path definitions here;
     PATH_ADD("/json", Get);

--- a/orm_lib/inc/drogon/orm/Exception.h
+++ b/orm_lib/inc/drogon/orm/Exception.h
@@ -91,7 +91,7 @@ class DROGON_EXPORT DrogonDbException
 /// std::runtime_error
 class Failure : public DrogonDbException, public std::runtime_error
 {
-    virtual const std::exception &base() const noexcept override
+    const std::exception &base() const noexcept override
     {
         return *this;
     }
@@ -200,7 +200,7 @@ class DeadlockDetected : public TransactionRollback
 /// Internal error in internal library
 class InternalError : public DrogonDbException, public std::logic_error
 {
-    virtual const std::exception &base() const noexcept override
+    const std::exception &base() const noexcept override
     {
         return *this;
     }
@@ -212,7 +212,7 @@ class InternalError : public DrogonDbException, public std::logic_error
 /// Timeout error in when executing the SQL statement.
 class TimeoutError : public DrogonDbException, public std::logic_error
 {
-    virtual const std::exception &base() const noexcept override
+    const std::exception &base() const noexcept override
     {
         return *this;
     }
@@ -224,7 +224,7 @@ class TimeoutError : public DrogonDbException, public std::logic_error
 /// Error in usage of drogon orm library, similar to std::logic_error
 class UsageError : public DrogonDbException, public std::logic_error
 {
-    virtual const std::exception &base() const noexcept override
+    const std::exception &base() const noexcept override
     {
         return *this;
     }
@@ -236,7 +236,7 @@ class UsageError : public DrogonDbException, public std::logic_error
 /// Invalid argument passed to drogon orm lib, similar to std::invalid_argument
 class ArgumentError : public DrogonDbException, public std::invalid_argument
 {
-    virtual const std::exception &base() const noexcept override
+    const std::exception &base() const noexcept override
     {
         return *this;
     }
@@ -248,7 +248,7 @@ class ArgumentError : public DrogonDbException, public std::invalid_argument
 /// Value conversion failed, e.g. when converting "Hello" to int.
 class ConversionError : public DrogonDbException, public std::domain_error
 {
-    virtual const std::exception &base() const noexcept override
+    const std::exception &base() const noexcept override
     {
         return *this;
     }
@@ -260,7 +260,7 @@ class ConversionError : public DrogonDbException, public std::domain_error
 /// Something is out of range, similar to std::out_of_range
 class RangeError : public DrogonDbException, public std::out_of_range
 {
-    virtual const std::exception &base() const noexcept override
+    const std::exception &base() const noexcept override
     {
         return *this;
     }
@@ -272,7 +272,7 @@ class RangeError : public DrogonDbException, public std::out_of_range
 /// Query returned an unexpected number of rows.
 class UnexpectedRows : public RangeError
 {
-    virtual const std::exception &base() const noexcept override
+    const std::exception &base() const noexcept override
     {
         return *this;
     }

--- a/orm_lib/inc/drogon/orm/FunctionTraits.h
+++ b/orm_lib/inc/drogon/orm/FunctionTraits.h
@@ -41,9 +41,8 @@ struct FunctionTraits<void (*)()>
 };
 // functor,lambda
 template <typename Function>
-struct FunctionTraits
-    : public FunctionTraits<
-          decltype(&std::remove_reference<Function>::type::operator())>
+struct FunctionTraits : public FunctionTraits<decltype(
+                            &std::remove_reference<Function>::type::operator())>
 {
 };
 

--- a/orm_lib/inc/drogon/orm/FunctionTraits.h
+++ b/orm_lib/inc/drogon/orm/FunctionTraits.h
@@ -41,8 +41,9 @@ struct FunctionTraits<void (*)()>
 };
 // functor,lambda
 template <typename Function>
-struct FunctionTraits : public FunctionTraits<decltype(
-                            &std::remove_reference<Function>::type::operator())>
+struct FunctionTraits
+    : public FunctionTraits<
+          decltype(&std::remove_reference<Function>::type::operator())>
 {
 };
 

--- a/orm_lib/src/mysql_impl/MysqlConnection.h
+++ b/orm_lib/src/mysql_impl/MysqlConnection.h
@@ -80,12 +80,12 @@ class MysqlConnection : public DbConnection,
                 });
         }
     }
-    virtual void batchSql(std::deque<std::shared_ptr<SqlCmd>> &&) override
+    void batchSql(std::deque<std::shared_ptr<SqlCmd>> &&) override
     {
         LOG_FATAL << "The mysql library does not support batch mode";
         exit(1);
     }
-    virtual void disconnect() override;
+    void disconnect() override;
 
   private:
     void execSqlInLoop(

--- a/orm_lib/src/mysql_impl/MysqlResultImpl.h
+++ b/orm_lib/src/mysql_impl/MysqlResultImpl.h
@@ -70,17 +70,15 @@ class MysqlResultImpl : public ResultImpl
             }
         }
     }
-    virtual SizeType size() const noexcept override;
-    virtual RowSizeType columns() const noexcept override;
-    virtual const char *columnName(RowSizeType number) const override;
-    virtual SizeType affectedRows() const noexcept override;
-    virtual RowSizeType columnNumber(const char colName[]) const override;
-    virtual const char *getValue(SizeType row,
-                                 RowSizeType column) const override;
-    virtual bool isNull(SizeType row, RowSizeType column) const override;
-    virtual FieldSizeType getLength(SizeType row,
-                                    RowSizeType column) const override;
-    virtual unsigned long long insertId() const noexcept override;
+    SizeType size() const noexcept override;
+    RowSizeType columns() const noexcept override;
+    const char *columnName(RowSizeType number) const override;
+    SizeType affectedRows() const noexcept override;
+    RowSizeType columnNumber(const char colName[]) const override;
+    const char *getValue(SizeType row, RowSizeType column) const override;
+    bool isNull(SizeType row, RowSizeType column) const override;
+    FieldSizeType getLength(SizeType row, RowSizeType column) const override;
+    unsigned long long insertId() const noexcept override;
 
   private:
     const std::shared_ptr<MYSQL_RES> result_;

--- a/orm_lib/src/postgresql_impl/PgConnection.h
+++ b/orm_lib/src/postgresql_impl/PgConnection.h
@@ -87,7 +87,7 @@ class PgConnection : public DbConnection,
     virtual void batchSql(
         std::deque<std::shared_ptr<SqlCmd>> &&sqlCommands) override;
 
-    virtual void disconnect() override;
+    void disconnect() override;
 
   private:
     std::shared_ptr<PGconn> connectionPtr_;

--- a/orm_lib/src/postgresql_impl/PostgreSQLResultImpl.h
+++ b/orm_lib/src/postgresql_impl/PostgreSQLResultImpl.h
@@ -31,17 +31,15 @@ class PostgreSQLResultImpl : public ResultImpl
         : result_(r)
     {
     }
-    virtual SizeType size() const noexcept override;
-    virtual RowSizeType columns() const noexcept override;
-    virtual const char *columnName(RowSizeType number) const override;
-    virtual SizeType affectedRows() const noexcept override;
-    virtual RowSizeType columnNumber(const char colName[]) const override;
-    virtual const char *getValue(SizeType row,
-                                 RowSizeType column) const override;
-    virtual bool isNull(SizeType row, RowSizeType column) const override;
-    virtual FieldSizeType getLength(SizeType row,
-                                    RowSizeType column) const override;
-    virtual int oid(RowSizeType column) const override;
+    SizeType size() const noexcept override;
+    RowSizeType columns() const noexcept override;
+    const char *columnName(RowSizeType number) const override;
+    SizeType affectedRows() const noexcept override;
+    RowSizeType columnNumber(const char colName[]) const override;
+    const char *getValue(SizeType row, RowSizeType column) const override;
+    bool isNull(SizeType row, RowSizeType column) const override;
+    FieldSizeType getLength(SizeType row, RowSizeType column) const override;
+    int oid(RowSizeType column) const override;
 
   private:
     std::shared_ptr<PGresult> result_;

--- a/orm_lib/src/sqlite3_impl/Sqlite3ResultImpl.h
+++ b/orm_lib/src/sqlite3_impl/Sqlite3ResultImpl.h
@@ -30,17 +30,15 @@ class Sqlite3ResultImpl : public ResultImpl
 {
   public:
     Sqlite3ResultImpl() = default;
-    virtual SizeType size() const noexcept override;
-    virtual RowSizeType columns() const noexcept override;
-    virtual const char *columnName(RowSizeType number) const override;
-    virtual SizeType affectedRows() const noexcept override;
-    virtual RowSizeType columnNumber(const char colName[]) const override;
-    virtual const char *getValue(SizeType row,
-                                 RowSizeType column) const override;
-    virtual bool isNull(SizeType row, RowSizeType column) const override;
-    virtual FieldSizeType getLength(SizeType row,
-                                    RowSizeType column) const override;
-    virtual unsigned long long insertId() const noexcept override;
+    SizeType size() const noexcept override;
+    RowSizeType columns() const noexcept override;
+    const char *columnName(RowSizeType number) const override;
+    SizeType affectedRows() const noexcept override;
+    RowSizeType columnNumber(const char colName[]) const override;
+    const char *getValue(SizeType row, RowSizeType column) const override;
+    bool isNull(SizeType row, RowSizeType column) const override;
+    FieldSizeType getLength(SizeType row, RowSizeType column) const override;
+    unsigned long long insertId() const noexcept override;
 
   private:
     friend class Sqlite3Connection;


### PR DESCRIPTION
As I did on templates on [this PR](https://github.com/drogonframework/drogon/pull/1320), I omitted redundant `virtual` specifiers.