### PR TITLE
Refactor orm::SqlBinder

### DIFF
--- a/orm_lib/src/SqlBinder.cc
+++ b/orm_lib/src/SqlBinder.cc
@@ -17,14 +17,14 @@
 #include <drogon/orm/SqlBinder.h>
 #include <drogon/utils/Utilities.h>
 #include <future>
-#include <iostream>
 #include <regex>
-#include <stdio.h>
 #if USE_MYSQL
 #include <mysql.h>
 #endif
+
 using namespace drogon::orm;
 using namespace drogon::orm::internal;
+
 void SqlBinder::exec()
 {
     execed_ = true;
@@ -239,11 +239,10 @@ SqlBinder &SqlBinder::operator<<(double f)
     return operator<<(std::to_string(f));
 }
 
-SqlBinder &SqlBinder::operator<<(std::nullptr_t nullp)
+SqlBinder &SqlBinder::operator<<(std::nullptr_t)
 {
-    (void)nullp;
     ++parametersNumber_;
-    parameters_.push_back(NULL);
+    parameters_.push_back(nullptr);
     lengths_.push_back(0);
     if (type_ == ClientType::PostgreSQL)
     {
@@ -291,7 +290,7 @@ SqlBinder &SqlBinder::operator<<(DefaultValue dv)
     else if (type_ == ClientType::Mysql)
     {
         ++parametersNumber_;
-        parameters_.push_back(NULL);
+        parameters_.push_back(nullptr);
         lengths_.push_back(0);
         formats_.push_back(DrogonDefaultValue);
     }
@@ -324,9 +323,8 @@ int SqlBinder::getMysqlTypeBySize(size_t size)
             return 0;
     }
 #else
+    static_cast<void>(size);
     LOG_FATAL << "Mysql is not supported!";
     exit(1);
-    return 0;
-    (void)(size);
 #endif
 }


### PR DESCRIPTION
What I did:

* A destructor that has an empty body can be declared with `= default`
* Use `override` instead of `virtual` when overriding the inherited method
* Mark a constructor that has a single argument as `explicit`
* Replace `.size() == 0` with `.empty()`
* Fix misuse of `constexpr if`
  * `constexpr if` is a function to suppress template evaluation of unselected branches in the context of template.
  * However, the `if constexpr` that was used is not in the context of template.
  * (FYI: https://github.com/EzoeRyou/cpp17book/blob/master/028-cpp17-core-constexpr-if.md, this is written in Japanese but useful)
* `getMysqlTypeBySize` can be `static`
* Replace `NULL` with `nullptr`
* Codes after the call of `exit` are unreachable