### PR TITLE
Implement `toJson` to convert std::vector to Json::Value`

### DIFF
--- a/orm_lib/inc/drogon/orm/Mapper.h
+++ b/orm_lib/inc/drogon/orm/Mapper.h
@@ -1821,5 +1821,22 @@ inline std::future<size_t> Mapper<T>::deleteFutureByPrimaryKey(
     return prom->get_future();
 }
 
+/**
+ * @brief Convert std::vector<Value> where Value can be JSON to JSON.
+ *
+ * @param container The container to be converted.
+ * @return Json::Value The JSON value converted.
+ */
+template <typename Value>
+inline Json::Value toJson(const std::vector<Value> &container)
+{
+    Json::Value values(Json::arrayValue);
+    for (const Value &c : container)
+    {
+        values.append(c.toJson());
+    }
+    return values;
+}
+
 }  // namespace orm
 }  // namespace drogon


### PR DESCRIPTION
Some functions in `drogon/orm/Mapper.h`, such as `findBy`, return `std::vector`, and the classes generated by `drogon_ctl create model <dir>` will provide `toJson` method.

It would be a bit noisy to wrap conversion in for loop every Mapper returns `std::vector` like the following.

```cpp
std::vector<Object> result = mp.findBy(drogon::orm::Criteria(
    Object::Cols::_name, drogon::orm::CompareOperator::Like,
    "%" + query.asString() + "%"
));

Json::Value objects(Json::arrayValue);
for (const Object& row : result) {
  objects.append(row.toJson());
}
callback(drogon::HttpResponse::newHttpJsonResponse(objects));
```

Thus, I created a helper function that converts `std::vector` to `Json::Value`.

```cpp
std::vector<Object> result = mp.findBy(drogon::orm::Criteria(
    Object::Cols::_name, drogon::orm::CompareOperator::Like,
    "%" + query.asString() + "%"
));

callback(drogon::HttpResponse::newHttpJsonResponse(drogon::orm::toJson(result)));
```