### PR TITLE
Refactor db_test.cc

### DIFF
--- a/orm_lib/tests/db_test.cc
+++ b/orm_lib/tests/db_test.cc
@@ -49,31 +49,29 @@ DROGON_TEST(PostgreTest)
         SUCCESS();
         clientPtr->execSqlAsync(
             "select 1 as result",
-            [TEST_CTX](const drogon::orm::Result &r) {
-                MANDATE(r.size() == 1);
-            },
+            [TEST_CTX](const Result &r) { MANDATE(r.size() == 1); },
             expFunction);
     } >> [TEST_CTX](const DrogonDbException &e) {
-        FAULT("postgresql - Prepare the test environment(0) what():" +
-              std::string(e.base().what()));
+        FAULT("postgresql - Prepare the test environment(0) what():",
+              e.base().what());
     };
-    *clientPtr << "CREATE TABLE users \
-        (\
-            user_id character varying(32),\
-            user_name character varying(64),\
-            password character varying(64),\
-            org_name character varying(20),\
-            signature character varying(50),\
-            avatar_id character varying(32),\
-            id serial PRIMARY KEY,\
-            salt character varying(20),\
-            admin boolean DEFAULT false,\
-            CONSTRAINT user_id_org UNIQUE(user_id, org_name)\
-        )" >>
+    *clientPtr << "CREATE TABLE users "
+                  "("
+                  "    user_id character varying(32),"
+                  "    user_name character varying(64),"
+                  "    password character varying(64),"
+                  "    org_name character varying(20),"
+                  "    signature character varying(50),"
+                  "    avatar_id character varying(32),"
+                  "    id serial PRIMARY KEY,"
+                  "    salt character varying(20),"
+                  "    admin boolean DEFAULT false,"
+                  "    CONSTRAINT user_id_org UNIQUE(user_id, org_name)"
+                  ")" >>
         [TEST_CTX](const Result &r) { SUCCESS(); } >>
         [TEST_CTX](const DrogonDbException &e) {
-            FAULT("postgresql - Prepare the test environment(1) what():" +
-                  std::string(e.base().what()));
+            FAULT("postgresql - Prepare the test environment(1) what():",
+                  e.base().what());
         };
     /// Test1:DbClient streaming-type interface
     /// 1.1 insert,non-blocking
@@ -88,37 +86,37 @@ DROGON_TEST(PostgreTest)
             MANDATE(r[0]["id"].as<int64_t>() == 1);
         } >>
         [TEST_CTX](const DrogonDbException &e) {
-            FAULT("postgresql - DbClient streaming-type interface(0) what():" +
-                  std::string(e.base().what()));
+            FAULT("postgresql - DbClient streaming-type interface(0) what():",
+                  e.base().what());
         };
     /// 1.2 insert,blocking
     *clientPtr
             << "insert into users (user_id,user_name,admin,password,org_name) "
                "values($1,$2,$3,$4,$5) returning *"
             << "pg1"
-            << "postgresql1" << drogon::orm::DefaultValue{} << "123"
+            << "postgresql1" << DefaultValue{} << "123"
             << "default" << Mode::Blocking >>
         [TEST_CTX](const Result &r) {
             // std::cout << "id=" << r[0]["id"].as<int64_t>() << std::endl;
             MANDATE(r[0]["id"].as<int64_t>() == 2);
         } >>
         [TEST_CTX](const DrogonDbException &e) {
-            FAULT("postgresql - DbClient streaming-type interface(1) what():" +
-                  std::string(e.base().what()));
+            FAULT("postgresql - DbClient streaming-type interface(1) what():",
+                  e.base().what());
         };
     /// 1.3 query,no-blocking
     *clientPtr << "select * from users where 1 = 1" << Mode::NonBlocking >>
         [TEST_CTX](const Result &r) { MANDATE(r.size() == 2); } >>
         [TEST_CTX](const DrogonDbException &e) {
-            FAULT("postgresql - DbClient streaming-type interface(2) what():" +
-                  std::string(e.base().what()));
+            FAULT("postgresql - DbClient streaming-type interface(2) what():",
+                  e.base().what());
         };
     /// 1.4 query,blocking
     *clientPtr << "select * from users where 1 = 1" << Mode::Blocking >>
         [TEST_CTX](const Result &r) { MANDATE(r.size() == 2); } >>
         [TEST_CTX](const DrogonDbException &e) {
-            FAULT("postgresql - DbClient streaming-type interface(3) what():" +
-                  std::string(e.base().what()));
+            FAULT("postgresql - DbClient streaming-type interface(3) what():",
+                  e.base().what());
         };
     /// 1.5 query,blocking
     int count = 0;
@@ -131,20 +129,18 @@ DROGON_TEST(PostgreTest)
             if (!isNull)
                 ++count;
             else
-            {
                 MANDATE(count == 2);
-            }
         } >>
         [TEST_CTX](const DrogonDbException &e) {
-            FAULT("postgresql - DbClient streaming-type interface(4) what():" +
-                  std::string(e.base().what()));
+            FAULT("postgresql - DbClient streaming-type interface(4) what():",
+                  e.base().what());
         };
     /// 1.6 query, parameter binding
     *clientPtr << "select * from users where id = $1" << 1 >>
         [TEST_CTX](const Result &r) { MANDATE(r.size() == 1); } >>
         [TEST_CTX](const DrogonDbException &e) {
-            FAULT("postgresql - DbClient streaming-type interface(5) what():" +
-                  std::string(e.base().what()));
+            FAULT("postgresql - DbClient streaming-type interface(5) what():",
+                  e.base().what());
         };
     /// 1.7 query, parameter binding
     *clientPtr << "select * from users where user_id = $1 and user_name = $2"
@@ -152,8 +148,8 @@ DROGON_TEST(PostgreTest)
                << "postgresql1" >>
         [TEST_CTX](const Result &r) { MANDATE(r.size() == 1); } >>
         [TEST_CTX](const DrogonDbException &e) {
-            FAULT("postgresql - DbClient streaming-type interface(6) what():" +
-                  std::string(e.base().what()));
+            FAULT("postgresql - DbClient streaming-type interface(6) what():",
+                  e.base().what());
         };
     /// 1.8 delete
     *clientPtr << "delete from users where user_id = $1 and user_name = $2"
@@ -161,8 +157,8 @@ DROGON_TEST(PostgreTest)
                << "postgresql1" >>
         [TEST_CTX](const Result &r) { MANDATE(r.affectedRows() == 1); } >>
         [TEST_CTX](const DrogonDbException &e) {
-            FAULT("postgresql - DbClient streaming-type interface(7) what():" +
-                  std::string(e.base().what()));
+            FAULT("postgresql - DbClient streaming-type interface(7) what():",
+                  e.base().what());
         };
     /// 1.9 update
     *clientPtr << "update users set user_id = $1, user_name = $2 where user_id "
@@ -173,29 +169,29 @@ DROGON_TEST(PostgreTest)
                << "postgresql" >>
         [TEST_CTX](const Result &r) { MANDATE(r.affectedRows() == 1); } >>
         [TEST_CTX](const DrogonDbException &e) {
-            FAULT("postgresql - DbClient streaming-type interface(8) what():" +
-                  std::string(e.base().what()));
+            FAULT("postgresql - DbClient streaming-type interface(8) what():",
+                  e.base().what());
         };
     /// 1.10 clean up
     *clientPtr << "truncate table users restart identity" >>
         [TEST_CTX](const Result &r) { SUCCESS(); } >>
         [TEST_CTX](const DrogonDbException &e) {
-            FAULT("postgresql - DbClient streaming-type interface(9) what():" +
-                  std::string(e.base().what()));
+            FAULT("postgresql - DbClient streaming-type interface(9) what():",
+                  e.base().what());
         };
     /// Test asynchronous method
     /// 2.1 insert
     clientPtr->execSqlAsync(
-        "insert into users \
-        (user_id,user_name,password,org_name) \
-        values($1,$2,$3,$4) returning *",
+        "insert into users "
+        "(user_id,user_name,password,org_name) "
+        "values($1,$2,$3,$4) returning *",
         [TEST_CTX](const Result &r) {
             // std::cout << "id=" << r[0]["id"].as<int64_t>() << std::endl;
             MANDATE(r[0]["id"].as<int64_t>() == 1);
         },
         [TEST_CTX](const DrogonDbException &e) {
-            FAULT("postgresql - DbClient asynchronous interface(0) what():" +
-                  std::string(e.base().what()));
+            FAULT("postgresql - DbClient asynchronous interface(0) what():",
+                  e.base().what());
         },
         "pg",
         "postgresql",
@@ -203,16 +199,16 @@ DROGON_TEST(PostgreTest)
         "default");
     /// 2.2 insert
     clientPtr->execSqlAsync(
-        "insert into users \
-        (user_id,user_name,password,org_name) \
-        values($1,$2,$3,$4)",
+        "insert into users "
+        "(user_id,user_name,password,org_name) "
+        "values($1,$2,$3,$4)",
         [TEST_CTX](const Result &r) {
             // std::cout << "id=" << r[0]["id"].as<int64_t>() << std::endl;
             MANDATE(r.affectedRows() == 1);
         },
         [TEST_CTX](const DrogonDbException &e) {
-            FAULT("postgresql - DbClient asynchronous interface(1) what():" +
-                  std::string(e.base().what()));
+            FAULT("postgresql - DbClient asynchronous interface(1) what():",
+                  e.base().what());
         },
         "pg1",
         "postgresql1",
@@ -223,16 +219,16 @@ DROGON_TEST(PostgreTest)
         "select * from users where 1 = 1",
         [TEST_CTX](const Result &r) { MANDATE(r.size() == 2); },
         [TEST_CTX](const DrogonDbException &e) {
-            FAULT("postgresql - DbClient asynchronous interface(2) what():" +
-                  std::string(e.base().what()));
+            FAULT("postgresql - DbClient asynchronous interface(2) what():",
+                  e.base().what());
         });
     /// 2.2 query, parameter binding
     clientPtr->execSqlAsync(
         "select * from users where id = $1",
         [TEST_CTX](const Result &r) { MANDATE(r.size() == 1); },
         [TEST_CTX](const DrogonDbException &e) {
-            FAULT("postgresql - DbClient asynchronous interface(3) what():" +
-                  std::string(e.base().what()));
+            FAULT("postgresql - DbClient asynchronous interface(3) what():",
+                  e.base().what());
         },
         1);
     /// 2.3 query, parameter binding
@@ -240,8 +236,8 @@ DROGON_TEST(PostgreTest)
         "select * from users where user_id = $1 and user_name = $2",
         [TEST_CTX](const Result &r) { MANDATE(r.size() == 1); },
         [TEST_CTX](const DrogonDbException &e) {
-            FAULT("postgresql - DbClient asynchronous interface(4) what():" +
-                  std::string(e.base().what()));
+            FAULT("postgresql - DbClient asynchronous interface(4) what():",
+                  e.base().what());
         },
         "pg1",
         "postgresql1");
@@ -250,8 +246,8 @@ DROGON_TEST(PostgreTest)
         "delete from users where user_id = $1 and user_name = $2",
         [TEST_CTX](const Result &r) { MANDATE(r.affectedRows() == 1); },
         [TEST_CTX](const DrogonDbException &e) {
-            FAULT("postgresql - DbClient asynchronous interface(5) what():" +
-                  std::string(e.base().what()));
+            FAULT("postgresql - DbClient asynchronous interface(5) what():",
+                  e.base().what());
         },
         "pg1",
         "postgresql1");
@@ -261,8 +257,8 @@ DROGON_TEST(PostgreTest)
         "= $3 and user_name = $4",
         [TEST_CTX](const Result &r) { MANDATE(r.affectedRows() == 1); },
         [TEST_CTX](const DrogonDbException &e) {
-            FAULT("postgresql - DbClient asynchronous interface(6) what():" +
-                  std::string(e.base().what()));
+            FAULT("postgresql - DbClient asynchronous interface(6) what():",
+                  e.base().what());
         },
         "pg1",
         "postgresql1",
@@ -273,8 +269,8 @@ DROGON_TEST(PostgreTest)
         "truncate table users restart identity",
         [TEST_CTX](const Result &r) { SUCCESS(); },
         [TEST_CTX](const DrogonDbException &e) {
-            FAULT("postgresql - DbClient asynchronous interface(7) what():" +
-                  std::string(e.base().what()));
+            FAULT("postgresql - DbClient asynchronous interface(7) what():",
+                  e.base().what());
         });
 
     /// Test synchronous method
@@ -292,8 +288,8 @@ DROGON_TEST(PostgreTest)
     }
     catch (const DrogonDbException &e)
     {
-        FAULT("postgresql - DbClient asynchronous interface(0) what():" +
-              std::string(e.base().what()));
+        FAULT("postgresql - DbClient asynchronous interface(0) what():",
+              e.base().what());
     }
     /// 3.2 insert
     try
@@ -309,8 +305,8 @@ DROGON_TEST(PostgreTest)
     }
     catch (const DrogonDbException &e)
     {
-        FAULT("postgresql - DbClient asynchronous interface(1) what():" +
-              std::string(e.base().what()));
+        FAULT("postgresql - DbClient asynchronous interface(1) what():",
+              e.base().what());
     }
     /// 3.3 query
     try
@@ -323,8 +319,8 @@ DROGON_TEST(PostgreTest)
     }
     catch (const DrogonDbException &e)
     {
-        FAULT("postgresql - DbClient asynchronous interface(2) what():" +
-              std::string(e.base().what()));
+        FAULT("postgresql - DbClient asynchronous interface(2) what():",
+              e.base().what());
     }
     /// 3.4 query for none
     try
@@ -337,8 +333,8 @@ DROGON_TEST(PostgreTest)
     }
     catch (const DrogonDbException &e)
     {
-        FAULT("postgresql - DbClient asynchronous interface(3) what():" +
-              std::string(e.base().what()));
+        FAULT("postgresql - DbClient asynchronous interface(3) what():",
+              e.base().what());
     }
     /// 3.5 bad sql
     try
@@ -362,8 +358,8 @@ DROGON_TEST(PostgreTest)
     }
     catch (const DrogonDbException &e)
     {
-        FAULT("postgresql - DbClient asynchronous interface(5) what():" +
-              std::string(e.base().what()));
+        FAULT("postgresql - DbClient asynchronous interface(5) what():",
+              e.base().what());
     }
     /// Test future interface
     /// 4.1 insert
@@ -381,8 +377,8 @@ DROGON_TEST(PostgreTest)
     }
     catch (const DrogonDbException &e)
     {
-        FAULT("postgresql - DbClient future interface(0) what():" +
-              std::string(e.base().what()));
+        FAULT("postgresql - DbClient future interface(0) what():",
+              e.base().what());
     }
     /// 4.2 insert
     f = clientPtr->execSqlAsyncFuture(
@@ -399,8 +395,8 @@ DROGON_TEST(PostgreTest)
     }
     catch (const DrogonDbException &e)
     {
-        FAULT("postgresql - DbClient future interface(1) what():" +
-              std::string(e.base().what()));
+        FAULT("postgresql - DbClient future interface(1) what():",
+              e.base().what());
     }
     /// 4.3 query
     f = clientPtr->execSqlAsyncFuture(
@@ -414,8 +410,8 @@ DROGON_TEST(PostgreTest)
     }
     catch (const DrogonDbException &e)
     {
-        FAULT("postgresql - DbClient future interface(2) what():" +
-              std::string(e.base().what()));
+        FAULT("postgresql - DbClient future interface(2) what():",
+              e.base().what());
     }
     /// 4.4 query for none
     f = clientPtr->execSqlAsyncFuture(
@@ -429,8 +425,8 @@ DROGON_TEST(PostgreTest)
     }
     catch (const DrogonDbException &e)
     {
-        FAULT("postgresql - DbClient future interface(3) what():" +
-              std::string(e.base().what()));
+        FAULT("postgresql - DbClient future interface(3) what():",
+              e.base().what());
     }
     /// 4.5 bad sql
     f = clientPtr->execSqlAsyncFuture(
@@ -455,8 +451,8 @@ DROGON_TEST(PostgreTest)
     }
     catch (const DrogonDbException &e)
     {
-        FAULT("postgresql - DbClient future interface(5) what():" +
-              std::string(e.base().what()));
+        FAULT("postgresql - DbClient future interface(5) what():",
+              e.base().what());
     }
 
     /// 5 Test Result and Row exception throwing
@@ -488,8 +484,8 @@ DROGON_TEST(PostgreTest)
     }
     catch (const DrogonDbException &e)
     {
-        FAULT("postgresql - Row throwing exceptions(0) what():" +
-              std::string(e.base().what()));
+        FAULT("postgresql - Row throwing exceptions(0) what():",
+              e.base().what());
     }
 
     // 5.3 try to access nonexistent column by name
@@ -527,14 +523,14 @@ DROGON_TEST(PostgreTest)
     }
     catch (const DrogonDbException &e)
     {
-        FAULT("postgresql -  Row throwing exceptions(3) what():" +
-              std::string(e.base().what()));
+        FAULT("postgresql - Row throwing exceptions(3) what():",
+              e.base().what());
     }
 
     /// Test ORM mapper
     /// 6.1 insert, noneblocking
     using namespace drogon_model::postgres;
-    drogon::orm::Mapper<Users> mapper(clientPtr);
+    Mapper<Users> mapper(clientPtr);
     Users user;
     user.setUserId("pg");
     user.setUserName("postgres");
@@ -544,8 +540,8 @@ DROGON_TEST(PostgreTest)
         user,
         [TEST_CTX](Users ret) { MANDATE(ret.getPrimaryKey() == 1); },
         [TEST_CTX](const DrogonDbException &e) {
-            FAULT("postgresql - ORM mapper asynchronous interface(0) what():" +
-                  std::string(e.base().what()));
+            FAULT("postgresql - ORM mapper asynchronous interface(0) what():",
+                  e.base().what());
         });
 
     /// 6.1.5 insert future
@@ -559,8 +555,8 @@ DROGON_TEST(PostgreTest)
     catch (const DrogonDbException &e)
     {
         FAULT(
-            "postgresql - ORM mapper asynchronous future interface(0) what():" +
-            std::string(e.base().what()));
+            "postgresql - ORM mapper asynchronous future interface(0) what():",
+            e.base().what());
     }
 
     /// 6.2 insert
@@ -570,8 +566,8 @@ DROGON_TEST(PostgreTest)
         user,
         [TEST_CTX](Users ret) { MANDATE(ret.getPrimaryKey() == 3); },
         [TEST_CTX](const DrogonDbException &e) {
-            FAULT("postgresql - ORM mapper asynchronous interface(1) what():" +
-                  std::string(e.base().what()));
+            FAULT("postgresql - ORM mapper asynchronous interface(1) what():",
+                  e.base().what());
         });
     /// 6.3 select where in
     mapper.findBy(
@@ -580,31 +576,31 @@ DROGON_TEST(PostgreTest)
                  std::vector<int32_t>{2, 200}),
         [TEST_CTX](std::vector<Users> users) { MANDATE(users.size() == 1); },
         [TEST_CTX](const DrogonDbException &e) {
-            FAULT("postgresql - ORM mapper asynchronous interface(2) what():" +
-                  std::string(e.base().what()));
+            FAULT("postgresql - ORM mapper asynchronous interface(2) what():",
+                  e.base().what());
         });
     /// 6.3.5 count
     mapper.count(
-        drogon::orm::Criteria(Users::Cols::_id, CompareOperator::EQ, 2020),
+        Criteria(Users::Cols::_id, CompareOperator::EQ, 2020),
         [TEST_CTX](const size_t c) { MANDATE(c == 0); },
         [TEST_CTX](const DrogonDbException &e) {
-            FAULT("postgresql - ORM mapper asynchronous interface(3) what():" +
-                  std::string(e.base().what()));
+            FAULT("postgresql - ORM mapper asynchronous interface(3) what():",
+                  e.base().what());
         });
     /// 6.3.6 custom where query
     mapper.findBy(
         Criteria("id <@ int4range($?, null)"_sql, 3),
         [TEST_CTX](std::vector<Users> users) { MANDATE(users.size() == 1); },
         [TEST_CTX](const DrogonDbException &e) {
-            FAULT("postgresql - ORM mapper asynchronous interface(4) what():" +
-                  std::string(e.base().what()));
+            FAULT("postgresql - ORM mapper asynchronous interface(4) what():",
+                  e.base().what());
         });
     /// 6.3.7 pagination
     mapper.paginate(2, 1).findAll(
         [TEST_CTX](std::vector<Users> users) { MANDATE(users.size() == 1); },
         [TEST_CTX](const DrogonDbException &e) {
-            FAULT("postgresql - ORM mapper asynchronous interface(5) what():" +
-                  std::string(e.base().what()));
+            FAULT("postgresql - ORM mapper asynchronous interface(5) what():",
+                  e.base().what());
         });
     /// 6.4 find by primary key. blocking
     try
@@ -619,8 +615,8 @@ DROGON_TEST(PostgreTest)
     }
     catch (const DrogonDbException &e)
     {
-        FAULT("postgresql - ORM mapper synchronous interface(0) what():" +
-              std::string(e.base().what()));
+        FAULT("postgresql - ORM mapper synchronous interface(0) what():",
+              e.base().what());
     }
     /// 6.5.1 update by criteria. blocking
     try
@@ -650,8 +646,8 @@ DROGON_TEST(PostgreTest)
     }
     catch (const DrogonDbException &e)
     {
-        FAULT("postgresql - ORM mapper synchronous interface(1) what():" +
-              std::string(e.base().what()));
+        FAULT("postgresql - ORM mapper synchronous interface(1) what():",
+              e.base().what());
     }
 
     /// 6.5.2 update by criteria. asynchronous
@@ -665,8 +661,8 @@ DROGON_TEST(PostgreTest)
                 FAULT(
                     "postgresql - ORM mapper asynchronous updateBy "
                     "interface(0) "
-                    "what():" +
-                    std::string(e.base().what()));
+                    "what():",
+                    e.base().what());
             },
             Criteria(Users::Cols::_user_id, CompareOperator::EQ, "pg"),
             "avatar of pg",
@@ -687,8 +683,8 @@ DROGON_TEST(PostgreTest)
         }
         catch (const DrogonDbException &e)
         {
-            FAULT("postgresql - DbClient coroutine interface(0) what():" +
-                  std::string(e.base().what()));
+            FAULT("postgresql - DbClient coroutine interface(0) what():",
+                  e.base().what());
         }
         /// 7.2 Parameter binding
         try
@@ -699,8 +695,8 @@ DROGON_TEST(PostgreTest)
         }
         catch (const DrogonDbException &e)
         {
-            FAULT("postgresql - DbClient coroutine interface(1) what():" +
-                  std::string(e.base().what()));
+            FAULT("postgresql - DbClient coroutine interface(1) what():",
+                  e.base().what());
         }
         /// 7.3 CoroMapper
         try
@@ -711,8 +707,8 @@ DROGON_TEST(PostgreTest)
         }
         catch (const DrogonDbException &e)
         {
-            FAULT("postgresql - ORM mapper coroutine interface(0) what():" +
-                  std::string(e.base().what()));
+            FAULT("postgresql - ORM mapper coroutine interface(0) what():",
+                  e.base().what());
         }
         try
         {
@@ -746,8 +742,8 @@ DROGON_TEST(PostgreTest)
         }
         catch (const DrogonDbException &e)
         {
-            FAULT("postgresql - ORM mapper coroutine interface(2) what():" +
-                  std::string(e.base().what()));
+            FAULT("postgresql - ORM mapper coroutine interface(2) what():",
+                  e.base().what());
         }
         // CoroMapper::update
         try
@@ -764,8 +760,8 @@ DROGON_TEST(PostgreTest)
         }
         catch (const DrogonDbException &e)
         {
-            FAULT("postgresql - ORM mapper coroutine interface(3) what():" +
-                  std::string(e.base().what()));
+            FAULT("postgresql - ORM mapper coroutine interface(3) what():",
+                  e.base().what());
         }
         // CoroMapper::updateBy
         try
@@ -801,8 +797,8 @@ DROGON_TEST(PostgreTest)
         }
         catch (const DrogonDbException &e)
         {
-            FAULT("postgresql - ORM mapper coroutine interface(4) what():" +
-                  std::string(e.base().what()));
+            FAULT("postgresql - ORM mapper coroutine interface(4) what():",
+                  e.base().what());
         }
         /// 7.4 Transactions
         try
@@ -817,8 +813,8 @@ DROGON_TEST(PostgreTest)
         {
             FAULT(
                 "postgresql - DbClient coroutine transaction interface(0) "
-                "what():" +
-                std::string(e.base().what()));
+                "what():",
+                e.base().what());
         }
     };
     drogon::sync_wait(coro_test());
@@ -839,45 +835,43 @@ DROGON_TEST(MySQLTest)
             SUCCESS();
             clientPtr->execSqlAsync(
                 "select 1 as result",
-                [TEST_CTX](const drogon::orm::Result &r) {
-                    MANDATE(r.size() == 1);
-                },
+                [TEST_CTX](const Result &r) { MANDATE(r.size() == 1); },
                 expFunction);
         } >>
         [TEST_CTX](const DrogonDbException &e) {
-            FAULT("mysql - Prepare the test environment(0) what():" +
-                  std::string(e.base().what()));
+            FAULT("mysql - Prepare the test environment(0) what():",
+                  e.base().what());
         };
     *clientPtr << "USE drogonTestMysql" >> [TEST_CTX](const Result &r) {
         SUCCESS();
     } >> [TEST_CTX](const DrogonDbException &e) {
-        FAULT("mysql - Prepare the test environment(0) what():" +
-              std::string(e.base().what()));
+        FAULT("mysql - Prepare the test environment(0) what():",
+              e.base().what());
     };
     // mysql is case sensitive
     *clientPtr << "DROP TABLE IF EXISTS users" >> [TEST_CTX](const Result &r) {
         SUCCESS();
     } >> [TEST_CTX](const DrogonDbException &e) {
-        FAULT("mysql - Prepare the test environment(1) what():" +
-              std::string(e.base().what()));
+        FAULT("mysql - Prepare the test environment(1) what():",
+              e.base().what());
     };
-    *clientPtr << "CREATE TABLE users \
-        (\
-            id int(11) auto_increment PRIMARY KEY,\
-            user_id varchar(32),\
-            user_name varchar(64),\
-            password varchar(64),\
-            org_name varchar(20),\
-            signature varchar(50),\
-            avatar_id varchar(32),\
-            salt character varying(20),\
-            admin boolean DEFAULT false,\
-            CONSTRAINT user_id_org UNIQUE(user_id, org_name)\
-        )" >>
+    *clientPtr << "CREATE TABLE users "
+                  "("
+                  "    id int(11) auto_increment PRIMARY KEY,"
+                  "    user_id varchar(32),"
+                  "    user_name varchar(64),"
+                  "    password varchar(64),"
+                  "    org_name varchar(20),"
+                  "    signature varchar(50),"
+                  "    avatar_id varchar(32),"
+                  "    salt character varying(20),"
+                  "    admin boolean DEFAULT false,"
+                  "    CONSTRAINT user_id_org UNIQUE(user_id, org_name)"
+                  ")" >>
         [TEST_CTX](const Result &r) { SUCCESS(); } >>
         [TEST_CTX](const DrogonDbException &e) {
-            FAULT("mysql - Prepare the test environment(2) what():" +
-                  std::string(e.base().what()));
+            FAULT("mysql - Prepare the test environment(2) what():",
+                  e.base().what());
         };
     /// Test1:DbClient streaming-type interface
     /// 1.1 insert,non-blocking
@@ -887,11 +881,11 @@ DROGON_TEST(MySQLTest)
             << "pg"
             << "postgresql"
             << "123"
-            << "default" << drogon::orm::DefaultValue{} >>
+            << "default" << DefaultValue{} >>
         [TEST_CTX](const Result &r) { MANDATE(r.insertId() == 1); } >>
         [TEST_CTX](const DrogonDbException &e) {
-            FAULT("mysql - DbClient streaming-type interface(0) what():" +
-                  std::string(e.base().what()));
+            FAULT("mysql - DbClient streaming-type interface(0) what():",
+                  e.base().what());
         };
     /// 1.2 insert,blocking
     *clientPtr << "insert into users (user_id,user_name,password,org_name) "
@@ -902,22 +896,22 @@ DROGON_TEST(MySQLTest)
                << "default" << Mode::Blocking >>
         [TEST_CTX](const Result &r) { MANDATE(r.insertId() == 2); } >>
         [TEST_CTX](const DrogonDbException &e) {
-            FAULT("mysql - DbClient streaming-type interface(1) what():" +
-                  std::string(e.base().what()));
+            FAULT("mysql - DbClient streaming-type interface(1) what():",
+                  e.base().what());
         };
     /// 1.3 query,no-blocking
     *clientPtr << "select * from users where 1 = 1" << Mode::NonBlocking >>
         [TEST_CTX](const Result &r) { MANDATE(r.size() == 2); } >>
         [TEST_CTX](const DrogonDbException &e) {
-            FAULT("mysql - DbClient streaming-type interface(2) what():" +
-                  std::string(e.base().what()));
+            FAULT("mysql - DbClient streaming-type interface(2) what():",
+                  e.base().what());
         };
     /// 1.4 query,blocking
     *clientPtr << "select * from users where 1 = 1" << Mode::Blocking >>
         [TEST_CTX](const Result &r) { MANDATE(r.size() == 2); } >>
         [TEST_CTX](const DrogonDbException &e) {
-            FAULT("mysql - DbClient streaming-type interface(3) what():" +
-                  std::string(e.base().what()));
+            FAULT("mysql - DbClient streaming-type interface(3) what():",
+                  e.base().what());
         };
     /// 1.5 query,blocking
     int count = 0;
@@ -930,20 +924,18 @@ DROGON_TEST(MySQLTest)
             if (!isNull)
                 ++count;
             else
-            {
                 MANDATE(count == 2);
-            }
         } >>
         [TEST_CTX](const DrogonDbException &e) {
-            FAULT("mysql - DbClient streaming-type interface(4) what():" +
-                  std::string(e.base().what()));
+            FAULT("mysql - DbClient streaming-type interface(4) what():",
+                  e.base().what());
         };
     /// 1.6 query, parameter binding
     *clientPtr << "select * from users where id = ?" << 1 >>
         [TEST_CTX](const Result &r) { MANDATE(r.size() == 1); } >>
         [TEST_CTX](const DrogonDbException &e) {
-            FAULT("mysql - DbClient streaming-type interface(5) what():" +
-                  std::string(e.base().what()));
+            FAULT("mysql - DbClient streaming-type interface(5) what():",
+                  e.base().what());
         };
     /// 1.7 query, parameter binding
     *clientPtr << "select * from users where user_id = ? and user_name = ?"
@@ -951,8 +943,8 @@ DROGON_TEST(MySQLTest)
                << "postgresql1" >>
         [TEST_CTX](const Result &r) { MANDATE(r.size() == 1); } >>
         [TEST_CTX](const DrogonDbException &e) {
-            FAULT("mysql - DbClient streaming-type interface(6) what():" +
-                  std::string(e.base().what()));
+            FAULT("mysql - DbClient streaming-type interface(6) what():",
+                  e.base().what());
         };
     /// 1.8 delete
     *clientPtr << "delete from users where user_id = ? and user_name = ?"
@@ -960,8 +952,8 @@ DROGON_TEST(MySQLTest)
                << "postgresql1" >>
         [TEST_CTX](const Result &r) { MANDATE(r.affectedRows() == 1); } >>
         [TEST_CTX](const DrogonDbException &e) {
-            FAULT("mysql - DbClient streaming-type interface(7) what():" +
-                  std::string(e.base().what()));
+            FAULT("mysql - DbClient streaming-type interface(7) what():",
+                  e.base().what());
         };
     /// 1.9 update
     *clientPtr << "update users set user_id = ?, user_name = ? where user_id "
@@ -972,26 +964,26 @@ DROGON_TEST(MySQLTest)
                << "postgresql" >>
         [TEST_CTX](const Result &r) { MANDATE(r.affectedRows() == 1); } >>
         [TEST_CTX](const DrogonDbException &e) {
-            FAULT("mysql - DbClient streaming-type interface(8) what():" +
-                  std::string(e.base().what()));
+            FAULT("mysql - DbClient streaming-type interface(8) what():",
+                  e.base().what());
         };
     /// 1.10 truncate
     *clientPtr << "truncate table users" >> [TEST_CTX](const Result &r) {
         SUCCESS();
     } >> [TEST_CTX](const DrogonDbException &e) {
-        FAULT("mysql - DbClient streaming-type interface(9) what():" +
-              std::string(e.base().what()));
+        FAULT("mysql - DbClient streaming-type interface(9) what():",
+              e.base().what());
     };
     /// Test asynchronous method
     /// 2.1 insert
     clientPtr->execSqlAsync(
-        "insert into users \
-        (user_id,user_name,password,org_name) \
-        values(?,?,?,?)",
+        "insert into users "
+        "(user_id,user_name,password,org_name) "
+        "values(?,?,?,?)",
         [TEST_CTX](const Result &r) { MANDATE(r.insertId() != 0); },
         [TEST_CTX](const DrogonDbException &e) {
-            FAULT("mysql - DbClient asynchronous interface(0) what():" +
-                  std::string(e.base().what()));
+            FAULT("mysql - DbClient asynchronous interface(0) what():",
+                  e.base().what());
         },
         "pg",
         "postgresql",
@@ -999,13 +991,13 @@ DROGON_TEST(MySQLTest)
         "default");
     /// 2.2 insert
     clientPtr->execSqlAsync(
-        "insert into users \
-        (user_id,user_name,password,org_name) \
-        values(?,?,?,?)",
+        "insert into users "
+        "(user_id,user_name,password,org_name) "
+        "values(?,?,?,?)",
         [TEST_CTX](const Result &r) { MANDATE(r.affectedRows() == 1); },
         [TEST_CTX](const DrogonDbException &e) {
-            FAULT("mysql - DbClient asynchronous interface(1) what():" +
-                  std::string(e.base().what()));
+            FAULT("mysql - DbClient asynchronous interface(1) what():",
+                  e.base().what());
         },
         "pg1",
         "postgresql1",
@@ -1016,8 +1008,8 @@ DROGON_TEST(MySQLTest)
         "select * from users where 1 = 1",
         [TEST_CTX](const Result &r) { MANDATE(r.size() == 2); },
         [TEST_CTX](const DrogonDbException &e) {
-            FAULT("mysql - DbClient asynchronous interface(2) what():" +
-                  std::string(e.base().what()));
+            FAULT("mysql - DbClient asynchronous interface(2) what():",
+                  e.base().what());
         });
     /// 2.2 query, parameter binding
     clientPtr->execSqlAsync(
@@ -1027,8 +1019,8 @@ DROGON_TEST(MySQLTest)
             MANDATE(r.size() == 1);
         },
         [TEST_CTX](const DrogonDbException &e) {
-            FAULT("mysql - DbClient asynchronous interface(3) what():" +
-                  std::string(e.base().what()));
+            FAULT("mysql - DbClient asynchronous interface(3) what():",
+                  e.base().what());
         },
         1);
     /// 2.3 query, parameter binding
@@ -1036,8 +1028,8 @@ DROGON_TEST(MySQLTest)
         "select * from users where user_id = ? and user_name = ?",
         [TEST_CTX](const Result &r) { MANDATE(r.size() == 1); },
         [TEST_CTX](const DrogonDbException &e) {
-            FAULT("mysql - DbClient asynchronous interface(4) what():" +
-                  std::string(e.base().what()));
+            FAULT("mysql - DbClient asynchronous interface(4) what():",
+                  e.base().what());
         },
         "pg1",
         "postgresql1");
@@ -1046,8 +1038,8 @@ DROGON_TEST(MySQLTest)
         "delete from users where user_id = ? and user_name = ?",
         [TEST_CTX](const Result &r) { MANDATE(r.affectedRows() == 1); },
         [TEST_CTX](const DrogonDbException &e) {
-            FAULT("mysql - DbClient asynchronous interface(5) what():" +
-                  std::string(e.base().what()));
+            FAULT("mysql - DbClient asynchronous interface(5) what():",
+                  e.base().what());
         },
         "pg1",
         "postgresql1");
@@ -1057,8 +1049,8 @@ DROGON_TEST(MySQLTest)
         "= ? and user_name = ?",
         [TEST_CTX](const Result &r) { MANDATE(r.affectedRows() == 1); },
         [TEST_CTX](const DrogonDbException &e) {
-            FAULT("mysql - DbClient asynchronous interface(6) what():" +
-                  std::string(e.base().what()));
+            FAULT("mysql - DbClient asynchronous interface(6) what():",
+                  e.base().what());
         },
         "pg1",
         "postgresql1",
@@ -1069,8 +1061,8 @@ DROGON_TEST(MySQLTest)
         "truncate table users",
         [TEST_CTX](const Result &r) { SUCCESS(); },
         [TEST_CTX](const DrogonDbException &e) {
-            FAULT("mysql - DbClient asynchronous interface(7) what():" +
-                  std::string(e.base().what()));
+            FAULT("mysql - DbClient asynchronous interface(7) what():",
+                  e.base().what());
         });
 
     /// Test synchronous method
@@ -1089,8 +1081,8 @@ DROGON_TEST(MySQLTest)
     }
     catch (const DrogonDbException &e)
     {
-        FAULT("mysql - DbClient asynchronous interface(0) what():" +
-              std::string(e.base().what()));
+        FAULT("mysql - DbClient asynchronous interface(0) what():",
+              e.base().what());
     }
     /// 3.2 insert
     try
@@ -1106,8 +1098,8 @@ DROGON_TEST(MySQLTest)
     }
     catch (const DrogonDbException &e)
     {
-        FAULT("mysql - DbClient asynchronous interface(1) what():" +
-              std::string(e.base().what()));
+        FAULT("mysql - DbClient asynchronous interface(1) what():",
+              e.base().what());
     }
     /// 3.3 query
     try
@@ -1120,8 +1112,8 @@ DROGON_TEST(MySQLTest)
     }
     catch (const DrogonDbException &e)
     {
-        FAULT("mysql - DbClient asynchronous interface(2) what():" +
-              std::string(e.base().what()));
+        FAULT("mysql - DbClient asynchronous interface(2) what():",
+              e.base().what());
     }
     /// 3.4 query for none
     try
@@ -1134,8 +1126,8 @@ DROGON_TEST(MySQLTest)
     }
     catch (const DrogonDbException &e)
     {
-        FAULT("mysql - DbClient asynchronous interface(3) what():" +
-              std::string(e.base().what()));
+        FAULT("mysql - DbClient asynchronous interface(3) what():",
+              e.base().what());
     }
     /// 3.5 bad sql
     try
@@ -1176,8 +1168,7 @@ DROGON_TEST(MySQLTest)
     }
     catch (const DrogonDbException &e)
     {
-        FAULT("mysql - DbClient future interface(0) what():" +
-              std::string(e.base().what()));
+        FAULT("mysql - DbClient future interface(0) what():", e.base().what());
     }
     /// 4.2 insert
     f = clientPtr->execSqlAsyncFuture(
@@ -1194,8 +1185,7 @@ DROGON_TEST(MySQLTest)
     }
     catch (const DrogonDbException &e)
     {
-        FAULT("mysql - DbClient future interface(1) what():" +
-              std::string(e.base().what()));
+        FAULT("mysql - DbClient future interface(1) what():", e.base().what());
     }
     /// 4.3 query
     f = clientPtr->execSqlAsyncFuture(
@@ -1209,8 +1199,7 @@ DROGON_TEST(MySQLTest)
     }
     catch (const DrogonDbException &e)
     {
-        FAULT("mysql - DbClient future interface(2) what():" +
-              std::string(e.base().what()));
+        FAULT("mysql - DbClient future interface(2) what():", e.base().what());
     }
     /// 4.4 query for none
     f = clientPtr->execSqlAsyncFuture(
@@ -1224,8 +1213,7 @@ DROGON_TEST(MySQLTest)
     }
     catch (const DrogonDbException &e)
     {
-        FAULT("mysql - DbClient future interface(3) what():" +
-              std::string(e.base().what()));
+        FAULT("mysql - DbClient future interface(3) what():", e.base().what());
     }
     /// 4.5 bad sql
     f = clientPtr->execSqlAsyncFuture(
@@ -1250,8 +1238,7 @@ DROGON_TEST(MySQLTest)
     }
     catch (const DrogonDbException &e)
     {
-        FAULT("mysql - DbClient future interface(5) what():" +
-              std::string(e.base().what()));
+        FAULT("mysql - DbClient future interface(5) what():", e.base().what());
     }
 
     /// 5 Test Result and Row exception throwing
@@ -1283,8 +1270,7 @@ DROGON_TEST(MySQLTest)
     }
     catch (const DrogonDbException &e)
     {
-        FAULT("mysql - Row throwing exceptions(0) what():" +
-              std::string(e.base().what()));
+        FAULT("mysql - Row throwing exceptions(0) what():", e.base().what());
     }
 
     // 5.3 try to access nonexistent column by name
@@ -1321,14 +1307,13 @@ DROGON_TEST(MySQLTest)
     }
     catch (const DrogonDbException &e)
     {
-        FAULT("mysql -  Row throwing exceptions(3) what():" +
-              std::string(e.base().what()));
+        FAULT("mysql -  Row throwing exceptions(3) what():", e.base().what());
     }
 
     /// Test ORM mapper
     /// 6.1 insert, noneblocking
     using namespace drogon_model::drogonTestMysql;
-    drogon::orm::Mapper<Users> mapper(clientPtr);
+    Mapper<Users> mapper(clientPtr);
     Users user;
     user.setUserId("pg");
     user.setUserName("postgres");
@@ -1338,16 +1323,16 @@ DROGON_TEST(MySQLTest)
         user,
         [TEST_CTX](Users ret) { MANDATE(ret.getPrimaryKey() == 1); },
         [TEST_CTX](const DrogonDbException &e) {
-            FAULT("mysql - ORM mapper asynchronous interface(0) what():" +
-                  std::string(e.base().what()));
+            FAULT("mysql - ORM mapper asynchronous interface(0) what():",
+                  e.base().what());
         });
     /// 6.1.5 count
     mapper.count(
-        drogon::orm::Criteria(Users::Cols::_id, CompareOperator::EQ, 1),
+        Criteria(Users::Cols::_id, CompareOperator::EQ, 1),
         [TEST_CTX](const size_t c) { MANDATE(c == 1); },
         [TEST_CTX](const DrogonDbException &e) {
-            FAULT("mysql - ORM mapper asynchronous interface(1) what():" +
-                  std::string(e.base().what()));
+            FAULT("mysql - ORM mapper asynchronous interface(1) what():",
+                  e.base().what());
         });
     /// 6.2 insert
     user.setUserId("pg1");
@@ -1356,8 +1341,8 @@ DROGON_TEST(MySQLTest)
         user,
         [TEST_CTX](Users ret) { MANDATE(ret.getPrimaryKey() == 2); },
         [TEST_CTX](const DrogonDbException &e) {
-            FAULT("mysql - ORM mapper asynchronous interface(2) what():" +
-                  std::string(e.base().what()));
+            FAULT("mysql - ORM mapper asynchronous interface(2) what():",
+                  e.base().what());
         });
     /// 6.3 select where in
     mapper.findBy(
@@ -1366,16 +1351,16 @@ DROGON_TEST(MySQLTest)
                  std::vector<int32_t>{2, 200}),
         [TEST_CTX](std::vector<Users> users) { MANDATE(users.size() == 1); },
         [TEST_CTX](const DrogonDbException &e) {
-            FAULT("mysql - ORM mapper asynchronous interface(3) what():" +
-                  std::string(e.base().what()));
+            FAULT("mysql - ORM mapper asynchronous interface(3) what():",
+                  e.base().what());
         });
     /// 6.3.6 custom where query
     mapper.findBy(
         Criteria("id between $? and $?"_sql, 2, 200),
         [TEST_CTX](std::vector<Users> users) { MANDATE(users.size() == 1); },
         [TEST_CTX](const DrogonDbException &e) {
-            FAULT("mysql - ORM mapper asynchronous interface(4) what():" +
-                  std::string(e.base().what()));
+            FAULT("mysql - ORM mapper asynchronous interface(4) what():",
+                  e.base().what());
         });
     /// 6.4 find by primary key. blocking
     try
@@ -1390,8 +1375,8 @@ DROGON_TEST(MySQLTest)
     }
     catch (const DrogonDbException &e)
     {
-        FAULT("mysql - ORM mapper synchronous interface(0) what():" +
-              std::string(e.base().what()));
+        FAULT("mysql - ORM mapper synchronous interface(0) what():",
+              e.base().what());
     }
     /// 6.5 update by criteria. blocking
     try
@@ -1421,8 +1406,8 @@ DROGON_TEST(MySQLTest)
     }
     catch (const DrogonDbException &e)
     {
-        FAULT("mysql - ORM mapper synchronous interface(1) what():" +
-              std::string(e.base().what()));
+        FAULT("mysql - ORM mapper synchronous interface(1) what():",
+              e.base().what());
     }
 #ifdef __cpp_impl_coroutine
     auto coro_test = [clientPtr, TEST_CTX]() -> drogon::Task<> {
@@ -1438,8 +1423,8 @@ DROGON_TEST(MySQLTest)
         }
         catch (const DrogonDbException &e)
         {
-            FAULT("mysql - DbClient coroutine interface(0) what():" +
-                  std::string(e.base().what()));
+            FAULT("mysql - DbClient coroutine interface(0) what():",
+                  e.base().what());
         }
         /// 7.2 Parameter binding
         try
@@ -1450,8 +1435,8 @@ DROGON_TEST(MySQLTest)
         }
         catch (const DrogonDbException &e)
         {
-            FAULT("mysql - DbClient coroutine interface(1) what():" +
-                  std::string(e.base().what()));
+            FAULT("mysql - DbClient coroutine interface(1) what():",
+                  e.base().what());
         }
     };
     drogon::sync_wait(coro_test());
@@ -1473,32 +1458,30 @@ DROGON_TEST(SQLite3Test)
         SUCCESS();
         clientPtr->execSqlAsync(
             "select 1 as result",
-            [TEST_CTX](const drogon::orm::Result &r) {
-                MANDATE(r.size() == 1);
-            },
+            [TEST_CTX](const Result &r) { MANDATE(r.size() == 1); },
             expFunction);
     } >> [TEST_CTX](const DrogonDbException &e) {
-        FAULT("sqlite3 - Prepare the test environment(0):  what():" +
-              std::string(e.base().what()));
+        FAULT("sqlite3 - Prepare the test environment(0):  what():",
+              e.base().what());
     };
 
-    *clientPtr << "CREATE TABLE users \
-        (\
-            id INTEGER PRIMARY KEY autoincrement,\
-            user_id varchar(32),\
-            user_name varchar(64),\
-            password varchar(64),\
-            org_name varchar(20),\
-            signature varchar(50),\
-            avatar_id varchar(32),\
-            salt character varchar(20),\
-            admin boolean DEFAULT false,\
-            CONSTRAINT user_id_org UNIQUE(user_id, org_name)\
-        )" >>
+    *clientPtr << "CREATE TABLE users "
+                  "("
+                  "    id INTEGER PRIMARY KEY autoincrement,"
+                  "    user_id varchar(32),"
+                  "    user_name varchar(64),"
+                  "    password varchar(64),"
+                  "    org_name varchar(20),"
+                  "    signature varchar(50),"
+                  "    avatar_id varchar(32),"
+                  "    salt character varchar(20),"
+                  "    admin boolean DEFAULT false,"
+                  "    CONSTRAINT user_id_org UNIQUE(user_id, org_name)"
+                  ")" >>
         [TEST_CTX](const Result &r) { SUCCESS(); } >>
         [TEST_CTX](const DrogonDbException &e) {
-            FAULT("sqlite3 - Prepare the test environment(1) what():" +
-                  std::string(e.base().what()));
+            FAULT("sqlite3 - Prepare the test environment(1) what():",
+                  e.base().what());
         };
     /// Test1:DbClient streaming-type interface
     /// 1.1 insert,non-blocking
@@ -1510,8 +1493,8 @@ DROGON_TEST(SQLite3Test)
                << "default" >>
         [TEST_CTX](const Result &r) { MANDATE(r.insertId() == 1ULL); } >>
         [TEST_CTX](const DrogonDbException &e) {
-            FAULT("sqlite3 - DbClient streaming-type interface(0) what():" +
-                  std::string(e.base().what()));
+            FAULT("sqlite3 - DbClient streaming-type interface(0) what():",
+                  e.base().what());
         };
     /// 1.2 insert,blocking
     *clientPtr << "insert into users (user_id,user_name,password,org_name) "
@@ -1522,22 +1505,22 @@ DROGON_TEST(SQLite3Test)
                << "default" << Mode::Blocking >>
         [TEST_CTX](const Result &r) { MANDATE(r.insertId() == 2ULL); } >>
         [TEST_CTX](const DrogonDbException &e) {
-            FAULT("sqlite3 - DbClient streaming-type interface(1) what():" +
-                  std::string(e.base().what()));
+            FAULT("sqlite3 - DbClient streaming-type interface(1) what():",
+                  e.base().what());
         };
     /// 1.3 query,no-blocking
     *clientPtr << "select * from users where 1 = 1" << Mode::NonBlocking >>
         [TEST_CTX](const Result &r) { MANDATE(r.size() == 2UL); } >>
         [TEST_CTX](const DrogonDbException &e) {
-            FAULT("sqlite3 - DbClient streaming-type interface(2) what():" +
-                  std::string(e.base().what()));
+            FAULT("sqlite3 - DbClient streaming-type interface(2) what():",
+                  e.base().what());
         };
     /// 1.4 query,blocking
     *clientPtr << "select * from users where 1 = 1" << Mode::Blocking >>
         [TEST_CTX](const Result &r) { MANDATE(r.size() == 2UL); } >>
         [TEST_CTX](const DrogonDbException &e) {
-            FAULT("sqlite3 - DbClient streaming-type interface(3) what():" +
-                  std::string(e.base().what()));
+            FAULT("sqlite3 - DbClient streaming-type interface(3) what():",
+                  e.base().what());
         };
     /// 1.5 query,blocking
     int count = 0;
@@ -1555,15 +1538,15 @@ DROGON_TEST(SQLite3Test)
             }
         } >>
         [TEST_CTX](const DrogonDbException &e) {
-            FAULT("sqlite3 - DbClient streaming-type interface(4) what():" +
-                  std::string(e.base().what()));
+            FAULT("sqlite3 - DbClient streaming-type interface(4) what():",
+                  e.base().what());
         };
     /// 1.6 query, parameter binding
     *clientPtr << "select * from users where id = ?" << 1 >>
         [TEST_CTX](const Result &r) { MANDATE(r.size() == 1UL); } >>
         [TEST_CTX](const DrogonDbException &e) {
-            FAULT("sqlite3 - DbClient streaming-type interface(5) what():" +
-                  std::string(e.base().what()));
+            FAULT("sqlite3 - DbClient streaming-type interface(5) what():",
+                  e.base().what());
         };
     /// 1.7 query, parameter binding
     *clientPtr << "select * from users where user_id = ? and user_name = ?"
@@ -1571,8 +1554,8 @@ DROGON_TEST(SQLite3Test)
                << "postgresql1" >>
         [TEST_CTX](const Result &r) { MANDATE(r.size() == 1UL); } >>
         [TEST_CTX](const DrogonDbException &e) {
-            FAULT("sqlite3 - DbClient streaming-type interface(6) what():" +
-                  std::string(e.base().what()));
+            FAULT("sqlite3 - DbClient streaming-type interface(6) what():",
+                  e.base().what());
         };
     /// 1.8 delete
     *clientPtr << "delete from users where user_id = ? and user_name = ?"
@@ -1580,8 +1563,8 @@ DROGON_TEST(SQLite3Test)
                << "postgresql1" >>
         [TEST_CTX](const Result &r) { MANDATE(r.affectedRows() == 1UL); } >>
         [TEST_CTX](const DrogonDbException &e) {
-            FAULT("sqlite3 - DbClient streaming-type interface(7) what():" +
-                  std::string(e.base().what()));
+            FAULT("sqlite3 - DbClient streaming-type interface(7) what():",
+                  e.base().what());
         };
     /// 1.9 update
     *clientPtr << "update users set user_id = ?, user_name = ? where user_id "
@@ -1592,32 +1575,32 @@ DROGON_TEST(SQLite3Test)
                << "postgresql" >>
         [TEST_CTX](const Result &r) { MANDATE(r.affectedRows() == 1UL); } >>
         [TEST_CTX](const DrogonDbException &e) {
-            FAULT("sqlite3 - DbClient streaming-type interface(8) what():" +
-                  std::string(e.base().what()));
+            FAULT("sqlite3 - DbClient streaming-type interface(8) what():",
+                  e.base().what());
         };
     /// 1.10 clean up
     *clientPtr << "delete from users" >> [TEST_CTX](const Result &r) {
         SUCCESS();
     } >> [TEST_CTX](const DrogonDbException &e) {
-        FAULT("sqlite3 - DbClient streaming-type interface(9.1) what():" +
-              std::string(e.base().what()));
+        FAULT("sqlite3 - DbClient streaming-type interface(9.1) what():",
+              e.base().what());
     };
     *clientPtr << "UPDATE sqlite_sequence SET seq = 0" >>
         [TEST_CTX](const Result &r) { SUCCESS(); } >>
         [TEST_CTX](const DrogonDbException &e) {
-            FAULT("sqlite3 - DbClient streaming-type interface(9.2) what():" +
-                  std::string(e.base().what()));
+            FAULT("sqlite3 - DbClient streaming-type interface(9.2) what():",
+                  e.base().what());
         };
     /// Test asynchronous method
     /// 2.1 insert
     clientPtr->execSqlAsync(
-        "insert into users \
-        (user_id,user_name,password,org_name) \
-        values(?,?,?,?)",
+        "insert into users "
+        "(user_id,user_name,password,org_name) "
+        "values(?,?,?,?)",
         [TEST_CTX](const Result &r) { MANDATE(r.insertId() == 1ULL); },
         [TEST_CTX](const DrogonDbException &e) {
-            FAULT("sqlite3 - DbClient asynchronous interface(0) what():" +
-                  std::string(e.base().what()));
+            FAULT("sqlite3 - DbClient asynchronous interface(0) what():",
+                  e.base().what());
         },
         "pg",
         "postgresql",
@@ -1625,13 +1608,13 @@ DROGON_TEST(SQLite3Test)
         "default");
     /// 2.2 insert
     clientPtr->execSqlAsync(
-        "insert into users \
-        (user_id,user_name,password,org_name) \
-        values(?,?,?,?)",
+        "insert into users "
+        "(user_id,user_name,password,org_name) "
+        "values(?,?,?,?)",
         [TEST_CTX](const Result &r) { MANDATE(r.affectedRows() == 1UL); },
         [TEST_CTX](const DrogonDbException &e) {
-            FAULT("sqlite3 - DbClient asynchronous interface(1) what():" +
-                  std::string(e.base().what()));
+            FAULT("sqlite3 - DbClient asynchronous interface(1) what():",
+                  e.base().what());
         },
         "pg1",
         "postgresql1",
@@ -1642,16 +1625,16 @@ DROGON_TEST(SQLite3Test)
         "select * from users where 1 = 1",
         [TEST_CTX](const Result &r) { MANDATE(r.size() == 2UL); },
         [TEST_CTX](const DrogonDbException &e) {
-            FAULT("sqlite3 - DbClient asynchronous interface(2) what():" +
-                  std::string(e.base().what()));
+            FAULT("sqlite3 - DbClient asynchronous interface(2) what():",
+                  e.base().what());
         });
     /// 2.2 query, parameter binding
     clientPtr->execSqlAsync(
         "select * from users where id = ?",
         [TEST_CTX](const Result &r) { MANDATE(r.size() == 1UL); },
         [TEST_CTX](const DrogonDbException &e) {
-            FAULT("sqlite3 - DbClient asynchronous interface(3) what():" +
-                  std::string(e.base().what()));
+            FAULT("sqlite3 - DbClient asynchronous interface(3) what():",
+                  e.base().what());
         },
         1);
     /// 2.3 query, parameter binding
@@ -1659,8 +1642,8 @@ DROGON_TEST(SQLite3Test)
         "select * from users where user_id = ? and user_name = ?",
         [TEST_CTX](const Result &r) { MANDATE(r.size() == 1UL); },
         [TEST_CTX](const DrogonDbException &e) {
-            FAULT("sqlite3 - DbClient asynchronous interface(4) what():" +
-                  std::string(e.base().what()));
+            FAULT("sqlite3 - DbClient asynchronous interface(4) what():",
+                  e.base().what());
         },
         "pg1",
         "postgresql1");
@@ -1669,8 +1652,8 @@ DROGON_TEST(SQLite3Test)
         "delete from users where user_id = ? and user_name = ?",
         [TEST_CTX](const Result &r) { MANDATE(r.affectedRows() == 1UL); },
         [TEST_CTX](const DrogonDbException &e) {
-            FAULT("sqlite3 - DbClient asynchronous interface(5) what():" +
-                  std::string(e.base().what()));
+            FAULT("sqlite3 - DbClient asynchronous interface(5) what():",
+                  e.base().what());
         },
         "pg1",
         "postgresql1");
@@ -1680,8 +1663,8 @@ DROGON_TEST(SQLite3Test)
         "= ? and user_name = ?",
         [TEST_CTX](const Result &r) { MANDATE(r.affectedRows() == 1UL); },
         [TEST_CTX](const DrogonDbException &e) {
-            FAULT("sqlite3 - DbClient asynchronous interface(6) what():" +
-                  std::string(e.base().what()));
+            FAULT("sqlite3 - DbClient asynchronous interface(6) what():",
+                  e.base().what());
         },
         "pg1",
         "postgresql1",
@@ -1692,15 +1675,15 @@ DROGON_TEST(SQLite3Test)
         "delete from users",
         [TEST_CTX](const Result &r) { SUCCESS(); },
         [TEST_CTX](const DrogonDbException &e) {
-            FAULT("sqlite3 - DbClient asynchronous interface(7.1) what():" +
-                  std::string(e.base().what()));
+            FAULT("sqlite3 - DbClient asynchronous interface(7.1) what():",
+                  e.base().what());
         });
     clientPtr->execSqlAsync(
         "UPDATE sqlite_sequence SET seq = 0",
         [TEST_CTX](const Result &r) { SUCCESS(); },
         [TEST_CTX](const DrogonDbException &e) {
-            FAULT("sqlite3 - DbClient asynchronous interface(7.2) what():" +
-                  std::string(e.base().what()));
+            FAULT("sqlite3 - DbClient asynchronous interface(7.2) what():",
+                  e.base().what());
         });
 
     /// Test synchronous method
@@ -1718,8 +1701,8 @@ DROGON_TEST(SQLite3Test)
     }
     catch (const DrogonDbException &e)
     {
-        FAULT("sqlite3 - DbClient asynchronous interface(0) what():" +
-              std::string(e.base().what()));
+        FAULT("sqlite3 - DbClient asynchronous interface(0) what():",
+              e.base().what());
     }
     /// 3.2 insert
     try
@@ -1735,8 +1718,8 @@ DROGON_TEST(SQLite3Test)
     }
     catch (const DrogonDbException &e)
     {
-        FAULT("sqlite3 - DbClient asynchronous interface(1) what():" +
-              std::string(e.base().what()));
+        FAULT("sqlite3 - DbClient asynchronous interface(1) what():",
+              e.base().what());
     }
     /// 3.3 query
     try
@@ -1749,8 +1732,8 @@ DROGON_TEST(SQLite3Test)
     }
     catch (const DrogonDbException &e)
     {
-        FAULT("sqlite3 - DbClient asynchronous interface(2) what():" +
-              std::string(e.base().what()));
+        FAULT("sqlite3 - DbClient asynchronous interface(2) what():",
+              e.base().what());
     }
     /// 3.4 query for none
     try
@@ -1763,8 +1746,8 @@ DROGON_TEST(SQLite3Test)
     }
     catch (const DrogonDbException &e)
     {
-        FAULT("sqlite3 - DbClient asynchronous interface(3) what():" +
-              std::string(e.base().what()));
+        FAULT("sqlite3 - DbClient asynchronous interface(3) what():",
+              e.base().what());
     }
     /// 3.5 bad sql
     try
@@ -1815,8 +1798,8 @@ DROGON_TEST(SQLite3Test)
     }
     catch (const DrogonDbException &e)
     {
-        FAULT("sqlite3 - DbClient future interface(0) what():" +
-              std::string(e.base().what()));
+        FAULT("sqlite3 - DbClient future interface(0) what():",
+              e.base().what());
     }
     /// 4.2 insert
     f = clientPtr->execSqlAsyncFuture(
@@ -1833,8 +1816,8 @@ DROGON_TEST(SQLite3Test)
     }
     catch (const DrogonDbException &e)
     {
-        FAULT("sqlite3 - DbClient future interface(1) what():" +
-              std::string(e.base().what()));
+        FAULT("sqlite3 - DbClient future interface(1) what():",
+              e.base().what());
     }
     /// 4.3 query
     f = clientPtr->execSqlAsyncFuture(
@@ -1848,8 +1831,8 @@ DROGON_TEST(SQLite3Test)
     }
     catch (const DrogonDbException &e)
     {
-        FAULT("sqlite3 - DbClient future interface(2) what():" +
-              std::string(e.base().what()));
+        FAULT("sqlite3 - DbClient future interface(2) what():",
+              e.base().what());
     }
     /// 4.4 query for none
     f = clientPtr->execSqlAsyncFuture(
@@ -1863,8 +1846,8 @@ DROGON_TEST(SQLite3Test)
     }
     catch (const DrogonDbException &e)
     {
-        FAULT("sqlite3 - DbClient future interface(3) what():" +
-              std::string(e.base().what()));
+        FAULT("sqlite3 - DbClient future interface(3) what():",
+              e.base().what());
     }
     /// 4.5 bad sql
     f = clientPtr->execSqlAsyncFuture(
@@ -1889,8 +1872,8 @@ DROGON_TEST(SQLite3Test)
     }
     catch (const DrogonDbException &e)
     {
-        FAULT("sqlite3 - DbClient future interface(5.1) what():" +
-              std::string(e.base().what()));
+        FAULT("sqlite3 - DbClient future interface(5.1) what():",
+              e.base().what());
     }
     f = clientPtr->execSqlAsyncFuture("UPDATE sqlite_sequence SET seq = 0");
     try
@@ -1900,8 +1883,8 @@ DROGON_TEST(SQLite3Test)
     }
     catch (const DrogonDbException &e)
     {
-        FAULT("sqlite3 - DbClient future interface(5.2) what():" +
-              std::string(e.base().what()));
+        FAULT("sqlite3 - DbClient future interface(5.2) what():",
+              e.base().what());
     }
 
     /// 5 Test Result and Row exception throwing
@@ -1933,8 +1916,7 @@ DROGON_TEST(SQLite3Test)
     }
     catch (const DrogonDbException &e)
     {
-        FAULT("sqlite3 - Row throwing exceptions(0) what():" +
-              std::string(e.base().what()));
+        FAULT("sqlite3 - Row throwing exceptions(0) what():", e.base().what());
     }
 
     // 5.3 try to access nonexistent column by name
@@ -1971,8 +1953,7 @@ DROGON_TEST(SQLite3Test)
     }
     catch (const DrogonDbException &e)
     {
-        FAULT("sqlite3 -  Row throwing exceptions(3) what():" +
-              std::string(e.base().what()));
+        FAULT("sqlite3 -  Row throwing exceptions(3) what():", e.base().what());
     }
     try
     {
@@ -1981,14 +1962,13 @@ DROGON_TEST(SQLite3Test)
     }
     catch (const DrogonDbException &e)
     {
-        FAULT("sqlite3 -  Row throwing exceptions(3) what():" +
-              std::string(e.base().what()));
+        FAULT("sqlite3 -  Row throwing exceptions(3) what():", e.base().what());
     }
 
     /// Test ORM mapper TODO
     /// 5.1 insert, noneblocking
     using namespace drogon_model::sqlite3;
-    drogon::orm::Mapper<Users> mapper(clientPtr);
+    Mapper<Users> mapper(clientPtr);
     Users user;
     user.setUserId("pg");
     user.setUserName("postgres");
@@ -1998,8 +1978,8 @@ DROGON_TEST(SQLite3Test)
         user,
         [TEST_CTX](Users ret) { MANDATE(ret.getPrimaryKey() == 1UL); },
         [TEST_CTX](const DrogonDbException &e) {
-            FAULT("sqlite3 - ORM mapper asynchronous interface(0) what():" +
-                  std::string(e.base().what()));
+            FAULT("sqlite3 - ORM mapper asynchronous interface(0) what():",
+                  e.base().what());
         });
     /// 5.2 insert
     user.setUserId("pg1");
@@ -2008,8 +1988,8 @@ DROGON_TEST(SQLite3Test)
         user,
         [TEST_CTX](Users ret) { MANDATE(ret.getPrimaryKey() == 2UL); },
         [TEST_CTX](const DrogonDbException &e) {
-            FAULT("sqlite3 - ORM mapper asynchronous interface(1) what():" +
-                  std::string(e.base().what()));
+            FAULT("sqlite3 - ORM mapper asynchronous interface(1) what():",
+                  e.base().what());
         });
     /// 5.3 select where in
     mapper.findBy(
@@ -2018,24 +1998,24 @@ DROGON_TEST(SQLite3Test)
                  std::vector<int32_t>{2, 200}),
         [TEST_CTX](std::vector<Users> users) { MANDATE(users.size() == 1UL); },
         [TEST_CTX](const DrogonDbException &e) {
-            FAULT("sqlite3 - ORM mapper asynchronous interface(2) what():" +
-                  std::string(e.base().what()));
+            FAULT("sqlite3 - ORM mapper asynchronous interface(2) what():",
+                  e.base().what());
         });
     /// 5.3.5 count
     mapper.count(
-        drogon::orm::Criteria(Users::Cols::_id, CompareOperator::EQ, 2),
+        Criteria(Users::Cols::_id, CompareOperator::EQ, 2),
         [TEST_CTX](const size_t c) { MANDATE(c == 1UL); },
         [TEST_CTX](const DrogonDbException &e) {
-            FAULT("sqlite3 - ORM mapper asynchronous interface(3) what():" +
-                  std::string(e.base().what()));
+            FAULT("sqlite3 - ORM mapper asynchronous interface(3) what():",
+                  e.base().what());
         });
     /// 5.3.6 custom where query
     mapper.findBy(
         Criteria("password is not null"_sql),
         [TEST_CTX](std::vector<Users> users) { MANDATE(users.size() == 2); },
         [TEST_CTX](const DrogonDbException &e) {
-            FAULT("sqlite3 - ORM mapper asynchronous interface(4) what():" +
-                  std::string(e.base().what()));
+            FAULT("sqlite3 - ORM mapper asynchronous interface(4) what():",
+                  e.base().what());
         });
     /// 5.4 find by primary key. blocking
     try
@@ -2045,8 +2025,8 @@ DROGON_TEST(SQLite3Test)
     }
     catch (const DrogonDbException &e)
     {
-        FAULT("sqlite3 - ORM mapper synchronous interface(0) what():" +
-              std::string(e.base().what()));
+        FAULT("sqlite3 - ORM mapper synchronous interface(0) what():",
+              e.base().what());
     }
 #ifdef __cpp_impl_coroutine
     auto coro_test = [clientPtr, TEST_CTX]() -> drogon::Task<> {
@@ -2062,8 +2042,8 @@ DROGON_TEST(SQLite3Test)
         }
         catch (const DrogonDbException &e)
         {
-            FAULT("sqlite3 - DbClient coroutine interface(0) what():" +
-                  std::string(e.base().what()));
+            FAULT("sqlite3 - DbClient coroutine interface(0) what():",
+                  e.base().what());
         }
         /// 7.2 Parameter binding
         try
@@ -2074,8 +2054,8 @@ DROGON_TEST(SQLite3Test)
         }
         catch (const DrogonDbException &e)
         {
-            FAULT("sqlite3 - DbClient coroutine interface(1) what():" +
-                  std::string(e.base().what()));
+            FAULT("sqlite3 - DbClient coroutine interface(1) what():",
+                  e.base().what());
         }
         /// 7.3 ORM CoroMapper
         try
@@ -2087,8 +2067,8 @@ DROGON_TEST(SQLite3Test)
         }
         catch (const DrogonDbException &e)
         {
-            FAULT("sqlite3 - CoroMapper coroutine interface(0) what():" +
-                  std::string(e.base().what()));
+            FAULT("sqlite3 - CoroMapper coroutine interface(0) what():",
+                  e.base().what());
         }
         try
         {
@@ -2099,8 +2079,8 @@ DROGON_TEST(SQLite3Test)
         }
         catch (const DrogonDbException &e)
         {
-            FAULT("sqlite3 - CoroMapper coroutine interface(1) what():" +
-                  std::string(e.base().what()));
+            FAULT("sqlite3 - CoroMapper coroutine interface(1) what():",
+                  e.base().what());
         }
         try
         {
@@ -2110,8 +2090,8 @@ DROGON_TEST(SQLite3Test)
         }
         catch (const DrogonDbException &e)
         {
-            FAULT("sqlite3 - CoroMapper coroutine interface(2) what():" +
-                  std::string(e.base().what()));
+            FAULT("sqlite3 - CoroMapper coroutine interface(2) what():",
+                  e.base().what());
         }
         co_await drogon::sleepCoro(
             trantor::EventLoop::getEventLoopOfCurrentThread(), 1.0s);
@@ -2141,6 +2121,6 @@ int main(int argc, char **argv)
 #if USE_SQLITE3
     sqlite3Client = DbClient::newSqlite3Client("filename=:memory:", 1);
 #endif
-    int testStatus = test::run(argc, argv);
+    const int testStatus = test::run(argc, argv);
     return testStatus;
 }


### PR DESCRIPTION
I made some improvements on `db_test.cc` which was a bit complicated:
* Make `FAULT` & `FAIL` accept variadic arguments to avoid creating temporary variables (`std::string(e.base().what())` & `operator+`)
* Remove `drogon::orm` which was using namespaced
* Avoid connecting strings by `\`