### PR TITLE
Accept `postgres` for DbClient type as well

### DIFF
--- a/orm_lib/src/DbClientManager.cc
+++ b/orm_lib/src/DbClientManager.cc
@@ -173,7 +173,7 @@ void DbClientManager::createDbClient(const std::string &dbType,
     info.timeout_ = timeout;
     info.autoBatch_ = autoBatch;
 
-    if (type == "postgresql")
+    if (type == "postgresql" || type == "postgres")
     {
 #if USE_POSTGRESQL
         info.dbType_ = orm::ClientType::PostgreSQL;


### PR DESCRIPTION
AFAIK, the URI scheme for PostgreSQL can be either `postgresql` or `postgres`. So, it would be more convenient if `createDbClient` accepts both.