### PR TITLE
Set the running flag to false after calling the quit() method

### DIFF
--- a/lib/src/HttpAppFrameworkImpl.cc
+++ b/lib/src/HttpAppFrameworkImpl.cc
@@ -1028,6 +1028,7 @@ void HttpAppFrameworkImpl::quit()
             // and reset listenerManagerPtr_ before IO loops quit.
             listenerManagerPtr_->stopIoLoops();
             listenerManagerPtr_.reset();
+            running_ = false;
             getLoop()->quit();
         });
     }


### PR DESCRIPTION
resolve #1361 