### PR TITLE
Fix a data race in drogon_test.

### DIFF
--- a/lib/inc/drogon/drogon_test.h
+++ b/lib/inc/drogon/drogon_test.h
@@ -623,9 +623,11 @@ static int run(int argc, char** argv)
         exit(1);
     }
 
+    std::unique_lock<std::mutex> l(internal::mtxRegister);
     if (internal::registeredTests.empty() == false)
     {
         auto fut = internal::allTestRan.get_future();
+        l.unlock();
         fut.get();
         assert(internal::registeredTests.empty());
     }


### PR DESCRIPTION
[Thread Sanitizer](https://github.com/google/sanitizers/wiki/ThreadSanitizerCppManual) complains about a race involving `registeredTests` when using DROGON_TEST.

Didn't add any tests because this behavior already shows up under the existing tests under TSan.