### PR TITLE
Update Utilities.cc

### DIFF
--- a/lib/src/Utilities.cc
+++ b/lib/src/Utilities.cc
@@ -1223,7 +1223,7 @@ bool secureRandomBytes(void *ptr, size_t size)
 
 namespace internal
 {
-DROGON_EXPORT const size_t fixedRandomNumber = []() {
+const size_t fixedRandomNumber = []() {
     size_t res;
     utils::secureRandomBytes(&res, sizeof(res));
     return res;


### PR DESCRIPTION
Fix error when building with MinGW-w64:
```
lib/src/Utilities.cc:1226:28: error: external linkage required for symbol 'drogon::utils::internal::fixedRandomNumber' because of 'dllexport' attribute                    
```
`DROGON_EXPORT` is already specified in `lib/inc/drogon/utils/Utilities.h`, it doesn't need to be repeated in `lib/src/Utilities.cc` when defining `fixedRandomNumber`.