### PR TITLE
Drogon test refactor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -276,7 +276,8 @@ set(DROGON_SOURCES
     lib/src/FixedWindowRateLimiter.cc
     lib/src/SlidingWindowRateLimiter.cc
     lib/src/TokenBucketRateLimiter.cc
-    lib/src/Hodor.cc)
+    lib/src/Hodor.cc
+    lib/src/drogon_test.cc)
 set(private_headers
     lib/src/AOPAdvice.h
     lib/src/CacheFile.h

--- a/lib/inc/drogon/drogon_test.h
+++ b/lib/inc/drogon/drogon_test.h
@@ -4,7 +4,6 @@
 #include <drogon/utils/string_view.h>
 #include <drogon/exports.h>
 
-#include <iostream>
 #include <memory>
 #include <mutex>
 #include <sstream>
@@ -55,14 +54,10 @@ class Case;
 
 namespace internal
 {
-extern std::mutex mtxRegister;
-extern std::mutex mtxTestStats;
-extern bool testHasPrinted;
-extern std::atomic<size_t> numAssertions;
-extern std::atomic<size_t> numCorrectAssertions;
-extern size_t numTestCases;
-extern std::atomic<size_t> numFailedTestCases;
-extern bool printSuccessfulTests;
+DROGON_EXPORT extern std::atomic<size_t> numAssertions;
+DROGON_EXPORT extern std::atomic<size_t> numCorrectAssertions;
+DROGON_EXPORT extern std::atomic<size_t> numFailedTestCases;
+DROGON_EXPORT extern bool printSuccessfulTests;
 
 DROGON_EXPORT void registerCase(Case* test);
 DROGON_EXPORT void unregisterCase(Case* test);
@@ -345,15 +340,8 @@ class ThreadSafeStream final
     std::ostream& os_;
 };
 
-inline ThreadSafeStream print()
-{
-    return ThreadSafeStream(std::cout);
-}
-
-inline ThreadSafeStream printErr()
-{
-    return ThreadSafeStream(std::cerr);
-}
+DROGON_EXPORT ThreadSafeStream print();
+DROGON_EXPORT ThreadSafeStream printErr();
 
 class CaseBase : public trantor::NonCopyable
 {

--- a/lib/inc/drogon/drogon_test.h
+++ b/lib/inc/drogon/drogon_test.h
@@ -5,14 +5,10 @@
 #include <drogon/exports.h>
 
 #include <iostream>
-#include <set>
 #include <memory>
-#include <condition_variable>
 #include <mutex>
 #include <sstream>
 #include <atomic>
-#include <future>
-#include <iomanip>
 #include <cstddef>
 /**
  * @brief Drogon Test is a minimal effort test framework developed because the
@@ -60,29 +56,16 @@ class Case;
 namespace internal
 {
 extern std::mutex mtxRegister;
-extern std::promise<void> allTestRan;
 extern std::mutex mtxTestStats;
 extern bool testHasPrinted;
-extern std::set<Case*> registeredTests;
 extern std::atomic<size_t> numAssertions;
 extern std::atomic<size_t> numCorrectAssertions;
 extern size_t numTestCases;
 extern std::atomic<size_t> numFailedTestCases;
 extern bool printSuccessfulTests;
-inline void registerCase(Case* test)
-{
-    std::unique_lock<std::mutex> l(mtxRegister);
-    registeredTests.insert(test);
-}
 
-inline void unregisterCase(Case* test)
-{
-    std::unique_lock<std::mutex> l(mtxRegister);
-    registeredTests.erase(test);
-
-    if (registeredTests.empty())
-        allTestRan.set_value();
-}
+DROGON_EXPORT void registerCase(Case* test);
+DROGON_EXPORT void unregisterCase(Case* test);
 
 template <typename _Tp, typename dummy = void>
 struct is_printable : std::false_type

--- a/lib/inc/drogon/drogon_test.h
+++ b/lib/inc/drogon/drogon_test.h
@@ -2,6 +2,7 @@
 #include <trantor/utils/NonCopyable.h>
 #include <drogon/DrObject.h>
 #include <drogon/utils/string_view.h>
+#include <drogon/exports.h>
 
 #include <iostream>
 #include <set>
@@ -125,17 +126,28 @@ inline std::string escapeString(const string_view sv)
     return result;
 }
 
-inline std::string prettifyString(const string_view sv, size_t maxLength = 120)
-{
-    if (sv.size() <= maxLength)
-        return "\"" + escapeString(sv) + "\"";
+std::string prettifyString(const string_view sv, size_t maxLength = 120);
 
-    const std::string msg = "...\" (truncated)";
-    return "\"" + escapeString(sv.substr(0, maxLength)) + msg;
+#ifdef __cpp_fold_expressions
+template <typename... Args>
+inline void outputReason(Args&&... args)
+{
+    (std::cout << ... << std::forward<Args>(args));
 }
-
-namespace internal
+#else
+template <typename Head>
+inline void outputReason(Head&& head)
 {
+    std::cout << std::forward<Head>(head);
+}
+template <typename Head, typename... Tail>
+inline void outputReason(Head&& head, Tail&&... tail)
+{
+    std::cout << std::forward<Head>(head);
+    outputReason(std::forward<Tail>(tail)...);
+}
+#endif
+
 template <bool P>
 struct AttemptPrintViaStream
 {
@@ -165,8 +177,6 @@ struct StringPrinter
         return prettifyString(v);
     }
 };
-
-}  // namespace internal
 
 template <typename T>
 inline std::string attemptPrint(T&& v)
@@ -443,201 +453,8 @@ struct TestCase : public CaseBase
     virtual void doTest_(std::shared_ptr<Case>) = 0;
 };
 
-void printTestStats();
-
-#ifdef DROGON_TEST_MAIN
-
-namespace internal
-{
-static std::string leftpad(const std::string& str, size_t len)
-{
-    if (len <= str.size())
-        return str;
-    return std::string(len - str.size(), ' ') + str;
-}
-}  // namespace internal
-
-static void printHelp(string_view argv0)
-{
-    print() << "A Drogon Test application:\n\n"
-            << "Usage: " << argv0 << " [options]\n"
-            << "options:\n"
-            << "    -r        Run a specific test\n"
-            << "    -s        Print successful tests\n"
-            << "    -l        List avaliable tests\n"
-            << "    -h        Print this help message\n";
-}
-
-void printTestStats()
-{
-    std::unique_lock<std::mutex> lk(internal::mtxTestStats);
-    if (internal::testHasPrinted)
-        return;
-    const size_t successAssertions = internal::numCorrectAssertions;
-    const size_t totalAssertions = internal::numAssertions;
-    const size_t successTests =
-        internal::numTestCases - internal::numFailedTestCases;
-    const size_t totalTests = internal::numTestCases;
-
-    float ratio;
-    if (totalAssertions != 0)
-        ratio = (float)successTests / totalTests;
-    else
-        ratio = 1;
-    const size_t barSize = 80;
-    size_t greenBar = barSize * ratio;
-    size_t redBar = barSize * (1 - ratio);
-    if (greenBar + redBar != barSize)
-    {
-        float fraction = (ratio * barSize) - (size_t)(ratio * barSize);
-        if (fraction >= 0.5f)
-            greenBar++;
-        else
-            redBar++;
-    }
-    if (successAssertions != totalAssertions && redBar == 0)
-    {
-        redBar = 1;
-        greenBar--;
-    }
-
-    print() << "\n\x1B[0;31m" << std::string(redBar, '=') << "\x1B[0;32m"
-            << std::string(greenBar, '=') << "\x1B[0m\n";
-
-    if (successAssertions == totalAssertions)
-    {
-        print() << "\x1B[1;32m  All tests passed\x1B[0m (" << totalAssertions
-                << " assertions in " << totalTests << " tests cases).\n";
-    }
-    else
-    {
-        std::string totalAssertsionStr = std::to_string(totalAssertions);
-        std::string successAssertionsStr = std::to_string(successAssertions);
-        std::string failedAssertsionStr =
-            std::to_string(totalAssertions - successAssertions);
-        std::string totalTestsStr = std::to_string(totalTests);
-        std::string successTestsStr = std::to_string(successTests);
-        std::string failedTestsStr = std::to_string(totalTests - successTests);
-        const size_t totalLen =
-            (std::max)(totalAssertsionStr.size(), totalTestsStr.size());
-        const size_t successLen =
-            (std::max)(successAssertionsStr.size(), successTestsStr.size());
-        const size_t failedLen =
-            (std::max)(failedAssertsionStr.size(), failedTestsStr.size());
-        using internal::leftpad;
-        print() << "assertions: " << leftpad(totalAssertsionStr, totalLen)
-                << " | \x1B[0;32m" << leftpad(successAssertionsStr, successLen)
-                << " passed\x1B[0m | \x1B[0;31m"
-                << leftpad(failedAssertsionStr, failedLen) << " failed\x1B[0m\n"
-                << "test cases: " << leftpad(totalTestsStr, totalLen)
-                << " | \x1B[0;32m" << leftpad(successTestsStr, successLen)
-                << " passed\x1B[0m | \x1B[0;31m"
-                << leftpad(failedTestsStr, failedLen) << " failed\x1B[0m\n";
-    }
-    internal::testHasPrinted = true;
-}
-
-static int run(int argc, char** argv)
-{
-    internal::numCorrectAssertions = 0;
-    internal::numAssertions = 0;
-    internal::numFailedTestCases = 0;
-    internal::numTestCases = 0;
-    internal::printSuccessfulTests = false;
-
-    std::string targetTest;
-    bool listTests = false;
-    for (int i = 1; i < argc; i++)
-    {
-        std::string param = argv[i];
-        if (param == "-r" && i + 1 < argc)
-        {
-            targetTest = argv[i + 1];
-            i++;
-        }
-        if (param == "-h")
-        {
-            printHelp(argv[0]);
-            exit(0);
-        }
-        if (param == "-s")
-        {
-            internal::printSuccessfulTests = true;
-        }
-        if (param == "-l")
-        {
-            listTests = true;
-        }
-    }
-    auto classNames = DrClassMap::getAllClassName();
-
-    if (listTests)
-    {
-        print() << "Avaliable Tests:\n";
-        for (const auto& name : classNames)
-        {
-            if (name.find(DROGON_TESTCASE_PREIX_STR_) == 0)
-            {
-                auto test =
-                    std::unique_ptr<DrObjectBase>(DrClassMap::newObject(name));
-                auto ptr = dynamic_cast<TestCase*>(test.get());
-                if (ptr == nullptr)
-                    continue;
-                print() << "  " << ptr->name() << "\n";
-            }
-        }
-        exit(0);
-    }
-
-    std::vector<std::shared_ptr<TestCase>> testCases;
-    // NOTE: Registering a dummy case prevents the test-end signal to be
-    // emited too early as there's always an case that hasn't finish
-    std::shared_ptr<Case> dummyCase = std::make_shared<Case>("__dummy_dummy_");
-    for (const auto& name : classNames)
-    {
-        if (name.find(DROGON_TESTCASE_PREIX_STR_) == 0)
-        {
-            auto obj =
-                std::shared_ptr<DrObjectBase>(DrClassMap::newObject(name));
-            auto test = std::dynamic_pointer_cast<TestCase>(obj);
-            if (test == nullptr)
-            {
-                LOG_WARN << "Class " << name
-                         << " seems to be a test case. But type information "
-                            "disagrees.";
-                continue;
-            }
-            if (targetTest.empty() || test->name() == targetTest)
-            {
-                internal::numTestCases++;
-                test->doTest_(std::make_shared<Case>(test->name()));
-                testCases.emplace_back(std::move(test));
-            }
-        }
-    }
-    dummyCase = {};
-
-    if (targetTest != "" && internal::numTestCases == 0)
-    {
-        printErr() << "Cannot find test named " << targetTest << "\n";
-        exit(1);
-    }
-
-    std::unique_lock<std::mutex> l(internal::mtxRegister);
-    if (internal::registeredTests.empty() == false)
-    {
-        auto fut = internal::allTestRan.get_future();
-        l.unlock();
-        fut.get();
-        assert(internal::registeredTests.empty());
-    }
-    testCases.clear();
-
-    printTestStats();
-
-    return internal::numCorrectAssertions != internal::numAssertions;
-}
-#endif
+DROGON_EXPORT void printTestStats();
+DROGON_EXPORT int run(int argc, char** argv);
 }  // namespace test
 }  // namespace drogon
 
@@ -929,35 +746,6 @@ static int run(int argc, char** argv)
         drogon::test::internal::numCorrectAssertions++; \
     } while (0)
 
-namespace drogon
-{
-namespace test
-{
-namespace internal
-{
-#ifdef __cpp_fold_expressions
-template <typename... Args>
-inline void outputReason(Args&&... args)
-{
-    (std::cout << ... << std::forward<Args>(args));
-}
-#else
-template <typename Head>
-inline void outputReason(Head&& head)
-{
-    std::cout << std::forward<Head>(head);
-}
-template <typename Head, typename... Tail>
-inline void outputReason(Head&& head, Tail&&... tail)
-{
-    std::cout << std::forward<Head>(head);
-    outputReason(std::forward<Tail>(tail)...);
-}
-#endif
-}  // namespace internal
-}  // namespace test
-}  // namespace drogon
-
 #define FAIL(...)                                                       \
     do                                                                  \
     {                                                                   \
@@ -1022,28 +810,3 @@ inline void outputReason(Head&& head, Tail&&... tail)
          ctx_tmp__ != nullptr;                                           \
          TEST_CTX = ctx_hold__, ctx_tmp__ = nullptr)                     \
         if (TEST_CTX = ctx_tmp__, TEST_CTX != nullptr)
-
-#ifdef DROGON_TEST_MAIN
-namespace drogon
-{
-namespace test
-{
-std::mutex ThreadSafeStream::mtx_;
-
-namespace internal
-{
-std::mutex mtxRegister;
-std::mutex mtxTestStats;
-bool testHasPrinted = false;
-std::set<Case*> registeredTests;
-std::promise<void> allTestRan;
-std::atomic<size_t> numAssertions;
-std::atomic<size_t> numCorrectAssertions;
-size_t numTestCases;
-std::atomic<size_t> numFailedTestCases;
-bool printSuccessfulTests;
-}  // namespace internal
-}  // namespace test
-}  // namespace drogon
-
-#endif

--- a/lib/inc/drogon/drogon_test.h
+++ b/lib/inc/drogon/drogon_test.h
@@ -104,7 +104,8 @@ inline std::string escapeString(const string_view sv)
     return result;
 }
 
-DROGON_EXPORT std::string prettifyString(const string_view sv, size_t maxLength = 120);
+DROGON_EXPORT std::string prettifyString(const string_view sv,
+                                         size_t maxLength = 120);
 
 #ifdef __cpp_fold_expressions
 template <typename... Args>

--- a/lib/inc/drogon/drogon_test.h
+++ b/lib/inc/drogon/drogon_test.h
@@ -104,7 +104,7 @@ inline std::string escapeString(const string_view sv)
     return result;
 }
 
-std::string prettifyString(const string_view sv, size_t maxLength = 120);
+DROGON_EXPORT std::string prettifyString(const string_view sv, size_t maxLength = 120);
 
 #ifdef __cpp_fold_expressions
 template <typename... Args>
@@ -317,7 +317,7 @@ struct Decomposer
 
 }  // namespace internal
 
-class ThreadSafeStream final
+DROGON_EXPORT class ThreadSafeStream final
 {
   public:
     ThreadSafeStream(std::ostream& os) : os_(os)

--- a/lib/inc/drogon/drogon_test.h
+++ b/lib/inc/drogon/drogon_test.h
@@ -318,7 +318,7 @@ struct Decomposer
 
 }  // namespace internal
 
-DROGON_EXPORT class ThreadSafeStream final
+class DROGON_EXPORT ThreadSafeStream final
 {
   public:
     ThreadSafeStream(std::ostream& os) : os_(os)

--- a/lib/src/drogon_test.cc
+++ b/lib/src/drogon_test.cc
@@ -1,0 +1,221 @@
+#include <drogon/drogon_test.h>
+
+namespace drogon
+{
+namespace test
+{
+std::mutex ThreadSafeStream::mtx_;
+
+namespace internal
+{
+std::mutex mtxRegister;
+std::mutex mtxTestStats;
+bool testHasPrinted = false;
+std::set<Case*> registeredTests;
+std::promise<void> allTestRan;
+std::atomic<size_t> numAssertions;
+std::atomic<size_t> numCorrectAssertions;
+size_t numTestCases;
+std::atomic<size_t> numFailedTestCases;
+bool printSuccessfulTests;
+
+static std::string leftpad(const std::string& str, size_t len)
+{
+    if (len <= str.size())
+        return str;
+    return std::string(len - str.size(), ' ') + str;
+}
+
+std::string prettifyString(const string_view sv, size_t maxLength)
+{
+    if (sv.size() <= maxLength)
+        return "\"" + escapeString(sv) + "\"";
+
+    const std::string msg = "...\" (truncated)";
+    return "\"" + escapeString(sv.substr(0, maxLength)) + msg;
+}
+
+}  // namespace internal
+
+static void printHelp(string_view argv0)
+{
+    print() << "A Drogon Test application:\n\n"
+            << "Usage: " << argv0 << " [options]\n"
+            << "options:\n"
+            << "    -r        Run a specific test\n"
+            << "    -s        Print successful tests\n"
+            << "    -l        List avaliable tests\n"
+            << "    -h        Print this help message\n";
+}
+
+void printTestStats()
+{
+    std::unique_lock<std::mutex> lk(internal::mtxTestStats);
+    if (internal::testHasPrinted)
+        return;
+    const size_t successAssertions = internal::numCorrectAssertions;
+    const size_t totalAssertions = internal::numAssertions;
+    const size_t successTests =
+        internal::numTestCases - internal::numFailedTestCases;
+    const size_t totalTests = internal::numTestCases;
+
+    float ratio;
+    if (totalAssertions != 0)
+        ratio = (float)successTests / totalTests;
+    else
+        ratio = 1;
+    const size_t barSize = 80;
+    size_t greenBar = barSize * ratio;
+    size_t redBar = barSize * (1 - ratio);
+    if (greenBar + redBar != barSize)
+    {
+        float fraction = (ratio * barSize) - (size_t)(ratio * barSize);
+        if (fraction >= 0.5f)
+            greenBar++;
+        else
+            redBar++;
+    }
+    if (successAssertions != totalAssertions && redBar == 0)
+    {
+        redBar = 1;
+        greenBar--;
+    }
+
+    print() << "\n\x1B[0;31m" << std::string(redBar, '=') << "\x1B[0;32m"
+            << std::string(greenBar, '=') << "\x1B[0m\n";
+
+    if (successAssertions == totalAssertions)
+    {
+        print() << "\x1B[1;32m  All tests passed\x1B[0m (" << totalAssertions
+                << " assertions in " << totalTests << " tests cases).\n";
+    }
+    else
+    {
+        std::string totalAssertsionStr = std::to_string(totalAssertions);
+        std::string successAssertionsStr = std::to_string(successAssertions);
+        std::string failedAssertsionStr =
+            std::to_string(totalAssertions - successAssertions);
+        std::string totalTestsStr = std::to_string(totalTests);
+        std::string successTestsStr = std::to_string(successTests);
+        std::string failedTestsStr = std::to_string(totalTests - successTests);
+        const size_t totalLen =
+            (std::max)(totalAssertsionStr.size(), totalTestsStr.size());
+        const size_t successLen =
+            (std::max)(successAssertionsStr.size(), successTestsStr.size());
+        const size_t failedLen =
+            (std::max)(failedAssertsionStr.size(), failedTestsStr.size());
+        using internal::leftpad;
+        print() << "assertions: " << leftpad(totalAssertsionStr, totalLen)
+                << " | \x1B[0;32m" << leftpad(successAssertionsStr, successLen)
+                << " passed\x1B[0m | \x1B[0;31m"
+                << leftpad(failedAssertsionStr, failedLen) << " failed\x1B[0m\n"
+                << "test cases: " << leftpad(totalTestsStr, totalLen)
+                << " | \x1B[0;32m" << leftpad(successTestsStr, successLen)
+                << " passed\x1B[0m | \x1B[0;31m"
+                << leftpad(failedTestsStr, failedLen) << " failed\x1B[0m\n";
+    }
+    internal::testHasPrinted = true;
+}
+
+int run(int argc, char** argv)
+{
+    internal::numCorrectAssertions = 0;
+    internal::numAssertions = 0;
+    internal::numFailedTestCases = 0;
+    internal::numTestCases = 0;
+    internal::printSuccessfulTests = false;
+
+    std::string targetTest;
+    bool listTests = false;
+    for (int i = 1; i < argc; i++)
+    {
+        std::string param = argv[i];
+        if (param == "-r" && i + 1 < argc)
+        {
+            targetTest = argv[i + 1];
+            i++;
+        }
+        if (param == "-h")
+        {
+            printHelp(argv[0]);
+            exit(0);
+        }
+        if (param == "-s")
+        {
+            internal::printSuccessfulTests = true;
+        }
+        if (param == "-l")
+        {
+            listTests = true;
+        }
+    }
+    auto classNames = DrClassMap::getAllClassName();
+
+    if (listTests)
+    {
+        print() << "Avaliable Tests:\n";
+        for (const auto& name : classNames)
+        {
+            if (name.find(DROGON_TESTCASE_PREIX_STR_) == 0)
+            {
+                auto test =
+                    std::unique_ptr<DrObjectBase>(DrClassMap::newObject(name));
+                auto ptr = dynamic_cast<TestCase*>(test.get());
+                if (ptr == nullptr)
+                    continue;
+                print() << "  " << ptr->name() << "\n";
+            }
+        }
+        exit(0);
+    }
+
+    std::vector<std::shared_ptr<TestCase>> testCases;
+    // NOTE: Registering a dummy case prevents the test-end signal to be
+    // emited too early as there's always an case that hasn't finish
+    std::shared_ptr<Case> dummyCase = std::make_shared<Case>("__dummy_dummy_");
+    for (const auto& name : classNames)
+    {
+        if (name.find(DROGON_TESTCASE_PREIX_STR_) == 0)
+        {
+            auto obj =
+                std::shared_ptr<DrObjectBase>(DrClassMap::newObject(name));
+            auto test = std::dynamic_pointer_cast<TestCase>(obj);
+            if (test == nullptr)
+            {
+                LOG_WARN << "Class " << name
+                         << " seems to be a test case. But type information "
+                            "disagrees.";
+                continue;
+            }
+            if (targetTest.empty() || test->name() == targetTest)
+            {
+                internal::numTestCases++;
+                test->doTest_(std::make_shared<Case>(test->name()));
+                testCases.emplace_back(std::move(test));
+            }
+        }
+    }
+    dummyCase = {};
+
+    if (targetTest != "" && internal::numTestCases == 0)
+    {
+        printErr() << "Cannot find test named " << targetTest << "\n";
+        exit(1);
+    }
+
+    std::unique_lock<std::mutex> l(internal::mtxRegister);
+    if (internal::registeredTests.empty() == false)
+    {
+        auto fut = internal::allTestRan.get_future();
+        l.unlock();
+        fut.get();
+        assert(internal::registeredTests.empty());
+    }
+    testCases.clear();
+
+    printTestStats();
+
+    return internal::numCorrectAssertions != internal::numAssertions;
+}
+}  // namespace test
+}  // namespace drogon

--- a/lib/src/drogon_test.cc
+++ b/lib/src/drogon_test.cc
@@ -236,5 +236,16 @@ int run(int argc, char** argv)
 
     return internal::numCorrectAssertions != internal::numAssertions;
 }
+
+ThreadSafeStream print()
+{
+    return ThreadSafeStream(std::cout);
+}
+
+ThreadSafeStream printErr()
+{
+    return ThreadSafeStream(std::cerr);
+}
+
 }  // namespace test
 }  // namespace drogon

--- a/lib/src/drogon_test.cc
+++ b/lib/src/drogon_test.cc
@@ -1,5 +1,9 @@
 #include <drogon/drogon_test.h>
 
+#include <set>
+#include <future>
+#include <condition_variable>
+
 namespace drogon
 {
 namespace test
@@ -18,6 +22,21 @@ std::atomic<size_t> numCorrectAssertions;
 size_t numTestCases;
 std::atomic<size_t> numFailedTestCases;
 bool printSuccessfulTests;
+
+void registerCase(Case* test)
+{
+    std::unique_lock<std::mutex> l(mtxRegister);
+    registeredTests.insert(test);
+}
+
+void unregisterCase(Case* test)
+{
+    std::unique_lock<std::mutex> l(mtxRegister);
+    registeredTests.erase(test);
+
+    if (registeredTests.empty())
+        allTestRan.set_value();
+}
 
 static std::string leftpad(const std::string& str, size_t len)
 {


### PR DESCRIPTION
Provides following improvements

* `DROGON_TEST_MAIN` is no longer needed. Thus the test header can be used in PCH
* Move code into .cc file for faster test compiling
* namespace cleanups