### PR TITLE
Fix HttpController regex path matching

### DIFF
--- a/lib/inc/drogon/CacheMap.h
+++ b/lib/inc/drogon/CacheMap.h
@@ -265,7 +265,7 @@ class CacheMap
      */
     T2 operator[](const T1 &key)
     {
-        int timeout = 0;
+        size_t timeout = 0;
         std::lock_guard<std::mutex> lock(mtx_);
         auto iter = map_.find(key);
         if (iter != map_.end())
@@ -324,7 +324,7 @@ class CacheMap
     /// Check if the value of the keyword exists
     bool find(const T1 &key)
     {
-        int timeout = 0;
+        size_t timeout = 0;
         bool flag = false;
 
         std::lock_guard<std::mutex> lock(mtx_);

--- a/lib/inc/drogon/drogon_test.h
+++ b/lib/inc/drogon/drogon_test.h
@@ -215,7 +215,7 @@ struct ComparsionResult
 template <typename T>
 struct Lhs
 {
-    template <typename _ = void>  // HACK: prevent this function to be evaulated
+    template <typename _ = void>  // HACK: prevent this function to be evaluated
                                   // when not invoked
     std::pair<bool, std::string> result() const
     {
@@ -472,6 +472,7 @@ DROGON_EXPORT int run(int argc, char** argv);
         }                                                   \
         catch (const std::exception& e)                     \
         {                                                   \
+            (void)e;                                        \
             on_exception;                                   \
         }                                                   \
         catch (...)                                         \

--- a/lib/inc/drogon/utils/Utilities.h
+++ b/lib/inc/drogon/utils/Utilities.h
@@ -396,7 +396,7 @@ inline bool fromString<bool>(const std::string &p) noexcept(false)
     }
     std::string l{p};
     std::transform(p.begin(), p.end(), l.begin(), [](unsigned char c) {
-        return tolower(c);
+        return (char)tolower(c);
     });
     if (l == "true")
     {

--- a/lib/src/ConfigLoader.cc
+++ b/lib/src/ConfigLoader.cc
@@ -381,7 +381,7 @@ static void loadApp(const Json::Value &app)
         auto precisionLength = precision.get("precision", 0).asUInt64();
         auto precisionType =
             precision.get("precision_type", "significant").asString();
-        drogon::app().setFloatPrecisionInJson(precisionLength, precisionType);
+        drogon::app().setFloatPrecisionInJson((unsigned int)precisionLength, precisionType);
     }
     // log
     loadLogSetting(app["log"]);

--- a/lib/src/ConfigLoader.cc
+++ b/lib/src/ConfigLoader.cc
@@ -381,7 +381,8 @@ static void loadApp(const Json::Value &app)
         auto precisionLength = precision.get("precision", 0).asUInt64();
         auto precisionType =
             precision.get("precision_type", "significant").asString();
-        drogon::app().setFloatPrecisionInJson((unsigned int)precisionLength, precisionType);
+        drogon::app().setFloatPrecisionInJson((unsigned int)precisionLength,
+                                              precisionType);
     }
     // log
     loadLogSetting(app["log"]);

--- a/lib/src/Hodor.cc
+++ b/lib/src/Hodor.cc
@@ -45,7 +45,7 @@ Hodor::LimitStrategy Hodor::makeLimitStrategy(const Json::Value &config)
         strategy.ipLimiterMapPtr =
             std::make_unique<CacheMap<std::string, RateLimiterPtr>>(
                 drogon::app().getLoop(),
-                timeUnit_.count() / 60 < 1 ? 1 : timeUnit_.count() / 60,
+                float(timeUnit_.count() / 60 < 1 ? 1 : timeUnit_.count() / 60),
                 2,
                 100);
     }
@@ -56,7 +56,7 @@ Hodor::LimitStrategy Hodor::makeLimitStrategy(const Json::Value &config)
         strategy.userLimiterMapPtr =
             std::make_unique<CacheMap<std::string, RateLimiterPtr>>(
                 drogon::app().getLoop(),
-                timeUnit_.count() / 60 < 1 ? 1 : timeUnit_.count() / 60,
+                float(timeUnit_.count() / 60 < 1 ? 1 : timeUnit_.count() / 60),
                 2,
                 100);
     }

--- a/lib/src/HttpControllersRouter.cc
+++ b/lib/src/HttpControllersRouter.cc
@@ -490,7 +490,8 @@ void HttpControllersRouter::route(
         for (auto &item : ctrlVector_)
         {
             auto const &ctrlRegex = item.regex_;
-            if (std::regex_match(req->path(), result, ctrlRegex) && item.binders_[req->method()])
+            if (std::regex_match(req->path(), result, ctrlRegex) &&
+                item.binders_[req->method()])
             {
                 routerItemPtr = &item;
                 break;

--- a/lib/src/HttpControllersRouter.cc
+++ b/lib/src/HttpControllersRouter.cc
@@ -490,7 +490,7 @@ void HttpControllersRouter::route(
         for (auto &item : ctrlVector_)
         {
             auto const &ctrlRegex = item.regex_;
-            if (std::regex_match(req->path(), result, ctrlRegex))
+            if (std::regex_match(req->path(), result, ctrlRegex) && item.binders_[req->method()])
             {
                 routerItemPtr = &item;
                 break;

--- a/lib/src/RealIpResolver.cc
+++ b/lib/src/RealIpResolver.cc
@@ -74,6 +74,7 @@ static trantor::InetAddress parseAddress(const std::string& addr)
     }
     catch (const std::exception& ex)
     {
+        (void)ex;
         LOG_ERROR << "Error in ipv4 address: " + addr;
         port = 0;
     }

--- a/lib/src/TokenBucketRateLimiter.cc
+++ b/lib/src/TokenBucketRateLimiter.cc
@@ -19,7 +19,7 @@ bool TokenBucketRateLimiter::isAllowed()
         now - lastTime_);
     tokens_ += capacity_ * (duration / timeUnit_);
     if (tokens_ > capacity_)
-        tokens_ = capacity_;
+        tokens_ = (double)capacity_;
     lastTime_ = now;
     if (tokens_ > 1.0)
     {

--- a/lib/src/Utilities.cc
+++ b/lib/src/Utilities.cc
@@ -120,7 +120,7 @@ class Base64CharMap
             index++;
         charMap_[static_cast<int>('/')] = charMap_[static_cast<int>('_')] =
             index;
-        charMap_[0] = 0xff;
+        charMap_[0] = char(0xff);
     }
     char getIndex(const char c) const noexcept
     {
@@ -1191,7 +1191,7 @@ static bool systemRandomBytes(void *ptr, size_t size)
       (__GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 25))))
     return getentropy(ptr, size) != -1;
 #elif defined(_WIN32)  // Windows
-    return RtlGenRandom(ptr, size);
+    return RtlGenRandom(ptr, (ULONG)size);
 #elif defined(__unix__) || defined(__HAIKU__)
     // fallback to /dev/urandom for other/old UNIX
     thread_local std::unique_ptr<FILE, std::function<void(FILE *)> > fptr(
@@ -1213,7 +1213,7 @@ static bool systemRandomBytes(void *ptr, size_t size)
 bool secureRandomBytes(void *ptr, size_t size)
 {
 #ifdef OpenSSL_FOUND
-    if (RAND_bytes((unsigned char *)ptr, size) == 0)
+    if (RAND_bytes((unsigned char *)ptr, (int)size) == 0)
         return true;
 #endif
     if (systemRandomBytes(ptr, size))

--- a/lib/src/drogon_test.cc
+++ b/lib/src/drogon_test.cc
@@ -84,8 +84,8 @@ void printTestStats()
     else
         ratio = 1;
     const size_t barSize = 80;
-    size_t greenBar = barSize * ratio;
-    size_t redBar = barSize * (1 - ratio);
+    auto greenBar = size_t(barSize * ratio);
+    auto redBar = size_t(barSize * (1 - ratio));
     if (greenBar + redBar != barSize)
     {
         float fraction = (ratio * barSize) - (size_t)(ratio * barSize);

--- a/lib/src/ssl_funcs/Sha1.cc
+++ b/lib/src/ssl_funcs/Sha1.cc
@@ -44,7 +44,7 @@ unsigned char *SHA1(const unsigned char *dataIn,
                     unsigned char *dataOut)
 {
     unsigned char *pbytes = (unsigned char *)dataIn;
-    unsigned int nbyte = dataLen;
+    unsigned int nbyte = (unsigned int)dataLen;
 
     static unsigned int words[80];
     unsigned int H[5] = {

--- a/lib/tests/CMakeLists.txt
+++ b/lib/tests/CMakeLists.txt
@@ -1,4 +1,7 @@
 link_libraries(${PROJECT_NAME})
+if(WIN32)
+  link_libraries(iphlpapi)
+endif(WIN32)
 set(UNITTEST_SOURCES
     unittests/main.cc
     unittests/Base64Test.cc

--- a/lib/tests/unittests/Base64Test.cc
+++ b/lib/tests/unittests/Base64Test.cc
@@ -6,7 +6,7 @@ DROGON_TEST(Base64)
 {
     std::string in{"drogon framework"};
     auto encoded = drogon::utils::base64Encode((const unsigned char *)in.data(),
-                                               in.length());
+                                               (unsigned int)in.length());
     auto decoded = drogon::utils::base64Decode(encoded);
     CHECK(encoded == "ZHJvZ29uIGZyYW1ld29yaw==");
     CHECK(decoded == in);
@@ -20,11 +20,11 @@ DROGON_TEST(Base64)
             in.append(1, char(i));
         }
         auto out = drogon::utils::base64Encode((const unsigned char *)in.data(),
-                                               in.length());
+                                               (unsigned int)in.length());
         auto out2 = drogon::utils::base64Decode(out);
         auto encoded =
             drogon::utils::base64Encode((const unsigned char *)in.data(),
-                                        in.length());
+                                        (unsigned int)in.length());
         auto decoded = drogon::utils::base64Decode(encoded);
         CHECK(decoded == in);
     }
@@ -34,7 +34,7 @@ DROGON_TEST(Base64)
         std::string in{"drogon framework"};
         auto encoded =
             drogon::utils::base64Encode((const unsigned char *)in.data(),
-                                        in.length(),
+                                        (unsigned int)in.length(),
                                         true);
         auto decoded = drogon::utils::base64Decode(encoded);
         CHECK(encoded == "ZHJvZ29uIGZyYW1ld29yaw==");
@@ -51,7 +51,7 @@ DROGON_TEST(Base64)
         }
         auto encoded =
             drogon::utils::base64Encode((const unsigned char *)in.data(),
-                                        in.length(),
+                                        (unsigned int)in.length(),
                                         true);
         auto decoded = drogon::utils::base64Decode(encoded);
         CHECK(decoded == in);

--- a/lib/tests/unittests/CacheMapTest.cc
+++ b/lib/tests/unittests/CacheMapTest.cc
@@ -13,7 +13,7 @@ DROGON_TEST(CacheMapTest)
     trantor::EventLoopThread loopThread;
     loopThread.run();
     drogon::CacheMap<std::string, std::string> cache(loopThread.getLoop(),
-                                                     0.1,
+                                                     0.1f,
                                                      4,
                                                      30);
 

--- a/nosql_lib/redis/tests/CMakeLists.txt
+++ b/nosql_lib/redis/tests/CMakeLists.txt
@@ -1,4 +1,7 @@
 link_libraries(${PROJECT_NAME})
+if(WIN32)
+  link_libraries(iphlpapi)
+endif(WIN32)
 
 add_executable(redis_test
         redis_test.cc

--- a/nosql_lib/redis/tests/redis_test.cc
+++ b/nosql_lib/redis/tests/redis_test.cc
@@ -158,6 +158,7 @@ DROGON_TEST(RedisTest)
     }
     catch (const RedisException &err)
     {
+        (void)err;
         MANDATE(false);
     }
     catch (const std::runtime_error &err)

--- a/orm_lib/inc/drogon/orm/SqlBinder.h
+++ b/orm_lib/inc/drogon/orm/SqlBinder.h
@@ -372,10 +372,12 @@ class DROGON_EXPORT SqlBinder : public trantor::NonCopyable
             switch (sizeof(T))
             {
                 case 2:
-                    *std::static_pointer_cast<uint16_t>(obj) = htons((uint16_t)parameter);
+                    *std::static_pointer_cast<uint16_t>(obj) =
+                        htons((uint16_t)parameter);
                     break;
                 case 4:
-                    *std::static_pointer_cast<uint32_t>(obj) = htonl((uint32_t)parameter);
+                    *std::static_pointer_cast<uint32_t>(obj) =
+                        htonl((uint32_t)parameter);
                     break;
                 case 8:
                     *std::static_pointer_cast<uint64_t>(obj) =

--- a/orm_lib/inc/drogon/orm/SqlBinder.h
+++ b/orm_lib/inc/drogon/orm/SqlBinder.h
@@ -372,14 +372,14 @@ class DROGON_EXPORT SqlBinder : public trantor::NonCopyable
             switch (sizeof(T))
             {
                 case 2:
-                    *std::static_pointer_cast<uint16_t>(obj) = htons(parameter);
+                    *std::static_pointer_cast<uint16_t>(obj) = htons((uint16_t)parameter);
                     break;
                 case 4:
-                    *std::static_pointer_cast<uint32_t>(obj) = htonl(parameter);
+                    *std::static_pointer_cast<uint32_t>(obj) = htonl((uint32_t)parameter);
                     break;
                 case 8:
                     *std::static_pointer_cast<uint64_t>(obj) =
-                        htonll(parameter);
+                        htonll((uint64_t)parameter);
                     break;
                 case 1:
                 default:

--- a/orm_lib/src/Field.cc
+++ b/orm_lib/src/Field.cc
@@ -20,7 +20,7 @@
 using namespace drogon::orm;
 Field::Field(const Row &row, Row::SizeType columnNum) noexcept
     : row_(Result::SizeType(row.index_)),
-      column_(columnNum),
+      column_((long)columnNum),
       result_(row.result_)
 {
 }

--- a/orm_lib/src/Row.cc
+++ b/orm_lib/src/Row.cc
@@ -84,7 +84,7 @@ Row::ConstIterator Row::cbegin() const noexcept
 
 Row::ConstIterator Row::end() const noexcept
 {
-    return ConstIterator(*this, size());
+    return ConstIterator(*this, (Field::SizeType)size());
 }
 
 Row::ConstIterator Row::cend() const noexcept

--- a/orm_lib/tests/CMakeLists.txt
+++ b/orm_lib/tests/CMakeLists.txt
@@ -1,4 +1,7 @@
 link_libraries(${PROJECT_NAME})
+if(WIN32)
+  link_libraries(iphlpapi)
+endif(WIN32)
 
 add_executable(db_test
     db_test.cc


### PR DESCRIPTION
Since (probably) the commit *4abbf76214a39c75d0c8343a3d950f2f2f98d517*, when an HttpController has path matching regex for different HttpMethod that "conflict", the first matching one is returned, disregarding the method (verb) of the HttpRequest.

* This PR fixes this by also checking the verb (1st commit).
* I also fixes compilation (missing library at link) of test executables on Windows (2nd commit).
* And finally, in a 3rd commit, I fixed compilation warning due to missing explicit casts.

Build environment:
* Windows 10 (x64)
* Visual Studio 2022
* vcpkg (static) for the 3rd party libraries
* cmake build & test with ninja
