### PR TITLE
example中存在内存泄漏

### DIFF
--- a/examples/redis/controllers/Client.cc
+++ b/examples/redis/controllers/Client.cc
@@ -33,6 +33,8 @@ void Client::get(const HttpRequestPtr &,
                               &json,
                               &errors);
 
+            delete reader;
+
             response["response"] = redisResponse;
             if (parsingSuccessful)
             {


### PR DESCRIPTION
在此处使用的Json::CharReader *获取一个newCharReader newCharReader中返回的是一个new OurCharReader（继承自CharReader ） ,因此需要通过delete来进行删除

不建议更改为unique_ptr包裹，因为其他俩处使用样列正是使用unique_ptr包裹，在此处可使builder.newCharReader()的意图更为清晰