### PR TITLE
feat: implement send-file max size

### DIFF
--- a/lib/inc/drogon/HttpAppFramework.h
+++ b/lib/inc/drogon/HttpAppFramework.h
@@ -1089,6 +1089,7 @@ class DROGON_EXPORT HttpAppFramework : public trantor::NonCopyable
      */
     virtual HttpAppFramework &setBrStatic(bool useGzipStatic) = 0;
 
+    virtual HttpAppFramework &setSendfileMaxSize(size_t maxSize) = 0;
     /// Set the max body size of the requests received by drogon.
     /**
      * The default value is 1M.

--- a/lib/src/ConfigLoader.cc
+++ b/lib/src/ConfigLoader.cc
@@ -431,6 +431,12 @@ static void loadApp(const Json::Value &app)
     drogon::app().setGzipStatic(useGzipStatic);
     auto useBrStatic = app.get("br_static", true).asBool();
     drogon::app().setBrStatic(useBrStatic);
+    auto maxSendfileSize = app.get("sendfile_max_size", "200K").asString();
+    size_t sfSize;
+    if(bytesSize(maxSendfileSize, sfSize))
+    {
+        drogon::app().setSendfileMaxSize(sfSize);
+    }
     auto maxBodySize = app.get("client_max_body_size", "1M").asString();
     size_t size;
     if (bytesSize(maxBodySize, size))

--- a/lib/src/HttpAppFrameworkImpl.h
+++ b/lib/src/HttpAppFrameworkImpl.h
@@ -346,6 +346,11 @@ class HttpAppFrameworkImpl final : public HttpAppFramework
     }
     HttpAppFramework &setGzipStatic(bool useGzipStatic) override;
     HttpAppFramework &setBrStatic(bool useGzipStatic) override;
+    HttpAppFramework &setSendfileMaxSize(size_t maxSize) override
+    {
+        sendFileMaxSize_ = maxSize;
+        return *this;
+    }
     HttpAppFramework &setClientMaxBodySize(size_t maxSize) override
     {
         clientMaxBodySize_ = maxSize;
@@ -395,6 +400,10 @@ class HttpAppFrameworkImpl final : public HttpAppFramework
     HttpAppFramework &setImplicitPage(
         const std::string &implicitPageFile) override;
     const std::string &getImplicitPage() const override;
+    size_t getSendfileMaxSize() const
+    {
+      return sendFileMaxSize_;
+    }
     size_t getClientMaxBodySize() const
     {
         return clientMaxBodySize_;
@@ -665,6 +674,7 @@ class HttpAppFrameworkImpl final : public HttpAppFramework
     std::pair<unsigned int, std::string> floatPrecisionInJson_{0,
                                                                "significant"};
     bool usingCustomErrorHandler_{false};
+    size_t sendFileMaxSize_{1024 * 200};
     size_t clientMaxBodySize_{1024 * 1024};
     size_t clientMaxMemoryBodySize_{64 * 1024};
     size_t clientMaxWebSocketMessageSize_{128 * 1024};

--- a/lib/src/HttpResponseImpl.cc
+++ b/lib/src/HttpResponseImpl.cc
@@ -316,7 +316,7 @@ HttpResponsePtr HttpResponse::newFileResponse(
     }
     pbuf->pubseekoff(offset, std::ifstream::beg);  // rewind
 
-    if (HttpAppFrameworkImpl::instance().useSendfile() && length > 1024 * 200)
+    if (HttpAppFrameworkImpl::instance().useSendfile() && length > HttpAppFrameworkImpl::instance().getSendfileMaxSize())
     // TODO : Is 200k an appropriate value? Or set it to be configurable
     {
         // The advantages of sendfile() can only be reflected in sending large


### PR DESCRIPTION
Hi,

While testing Drogon on a Windows Server 2019 instance I ran into severe problems when returning animated gifs, mp4, or webp files. 

The trace log looked like this:

```bash
- HttpResponseImpl.cc:695
20230101 18:39:57.529000 UTC 4 TRACE [onAsyncRequest] new request:127.0.0.1:52614->127.0.0.1:8081 - HttpAppFrameworkImpl.cc:828
20230101 18:39:57.530000 UTC 4 TRACE [onAsyncRequest] Headers GET /videos/demo_app.gif - HttpAppFrameworkImpl.cc:830
20230101 18:39:57.533000 UTC 4 TRACE [onAsyncRequest] http path=/videos/demo_app.gif - HttpAppFrameworkImpl.cc:831
20230101 18:39:57.534000 UTC 4 TRACE [sendStaticFileResponse] enabled LastModify - StaticFileRouter.cc:446
20230101 18:39:57.534000 UTC 4 TRACE [getFileStat] last modify time:1672589936 - StaticFileRouter.cc:292
20230101 18:39:57.535000 UTC 4 TRACE [newFileResponse] send http file:.//videos/demo_app.gif offset 0 length 0 - HttpResponseImpl.cc:290
20230101 18:39:57.536000 UTC 4 TRACE [sendStaticFileResponse] Save in cache for 120 seconds - StaticFileRouter.cc:562
20230101 18:39:57.536000 UTC 4 TRACE [renderToBuffer] reponse(no body):HTTP/1.1 200 OK
content-length: 728908
content-type: image/gif
server: drogon/1.8.2
expires: Thu, 01 Jan 1970 00:00:00 GMT
accept-range: bytes
last-modified: Sun, 01 Jan 2023 16:18:56 GMT
date: Sun, 01 Jan 2023 18:39:57 GMT

 - HttpResponseImpl.cc:695
?[31;1mNativeCommandExitException: ?[31;1mProgram "demo_web_server.exe" ended with non-zero exit code: -1073741571.?[0m
```

After some back & forth + source code reading, I stumbled upon this comment in *HttpResponseImpl.cc*

```cpp
 if (HttpAppFrameworkImpl::instance().useSendfile() && length > 1024 * 200)
    // TODO : Is 200k an appropriate value? Or set it to be configurable
    {
        // The advantages of sendfile() can only be reflected in sending large
        // files.
        resp->setSendfile(fullPath);
        // Must set length with the right value! Content-Length header relys on
        // this value.
        resp->setSendfileRange(offset, length);
    }
```

Looks like the default size (200k) is not sufficient when sending "large" GIFs. And according to the comment above, a new configuration option could be provided for users to regulate send file sizes. And this is what I did with this PR.

This PR introduces a new configuration option **sendfile_max_size**.

If you put "200K" there and try to _GET /some_file_ , the error from above will appear.
Put a higher value like "10M", and everything will work as expected.

However, as I have no deep knowledge in C++ and am using Drogon only for a few days, I don't expect this PR to come through. But maybe someone more experienced could try to complete this idea? Is this of any use to others?

My local Drogon instance is now running with the changes applied, so it's fine for me.

Drogon is an exceptionally well-written piece of software. Many thanks to the creators and maintainers!

Regards,