### PR TITLE
Fix for MSYS2/MinGW compatablity

### DIFF
--- a/lib/src/ConfigLoader.cc
+++ b/lib/src/ConfigLoader.cc
@@ -20,14 +20,18 @@
 #include <sstream>
 #include <thread>
 #include <trantor/utils/Logger.h>
-#if !defined(_WIN32) || defined(__MINGW32__)
+#if !defined(_WIN32)
 #include <unistd.h>
 #define os_access access
 #else
 #include <io.h>
+#ifndef __MINGW32__
 #define os_access _waccess
 #define R_OK 04
 #define W_OK 02
+#else
+#define os_access access
+#endif
 #endif
 #include <drogon/utils/Utilities.h>
 


### PR DESCRIPTION
This patch gets Drogon compiling on MSYS2 again. However, due to some STL bug. Some modification of the shipped STL is needed.

in `/mingw64/include/c++/12.2.0/bits/std_thread.h`
```diff
diff --git a/mingw64/include/c++/12.2.0/bits/std_thread.h.bak b/mingw64/include/c++/12.2.0/bits/std_thread.h
index dd625de..62238dc 100644
--- a/mingw64/include/c++/12.2.0/bits/std_thread.h.bak
+++ b/mingw64/include/c++/12.2.0/bits/std_thread.h
@@ -41,6 +41,7 @@
 #include <bits/invoke.h>       // std::__invoke
 #include <bits/refwrap.h>       // not required, but helpful to users
 #include <bits/unique_ptr.h>   // std::unique_ptr
+#include <cstring>

 #ifdef _GLIBCXX_HAS_GTHREADS
 # include <bits/gthr.h>
@@ -74,6 +75,7 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
     using native_handle_type = __gthread_t;
 #else
     using native_handle_type = int;
+
 #endif

     /// thread::id
@@ -283,7 +285,8 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
     // can't safely use __gthread_equal on default-constructed values (nor
     // the non-zero value returned by this_thread::get_id() for
     // single-threaded programs using GNU libc). Assume EqualityComparable.
-    return __x._M_thread == __y._M_thread;
+    //return __x._M_thread == __y._M_thread;
+    return memcmp(&__x, &__y, sizeof(thread::id)) == 0;
   }

   // N.B. other comparison operators are defined in <thread>
```

And in `/mingw64/include/c++/12.2.0/thread`

```diff
diff --git a/mingw64/include/c++/12.2.0/thread.bak b/mingw64/include/c++/12.2.0/thread
index 92b2426..555f441 100644
--- a/mingw64/include/c++/12.2.0/thread.bak
+++ b/mingw64/include/c++/12.2.0/thread
@@ -71,7 +71,8 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
   {
     // Pthreads doesn't define any way to do this, so we just have to
     // assume native_handle_type is LessThanComparable.
-    return __x._M_thread < __y._M_thread;
+    //return __x._M_thread < __y._M_thread;
+    return memcmp(&__x._M_thread, &__y._M_thread, sizeof(__x._M_thread)) < 0;
   }

   inline bool
@@ -94,7 +95,7 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
       if (__id == thread::id())
        return __out << "thread::id of a non-executing thread";
       else
-       return __out << __id._M_thread;
+       return __out << "<unknwon>";
     }

 #ifdef __cpp_lib_jthread
```

Proof this works
![圖片](https://user-images.githubusercontent.com/8792393/213109736-6e9cbcb3-660d-4c18-b35d-a17be9c7aa00.png)
