### PR TITLE
Add coroutine to wait until event loop ends

### DIFF
--- a/lib/inc/drogon/utils/coroutine.h
+++ b/lib/inc/drogon/utils/coroutine.h
@@ -697,6 +697,21 @@ struct [[nodiscard]] LoopAwaiter : CallbackAwaiter<void>
     std::function<void()> taskFunc_;
 };
 
+struct [[nodiscard]] EndAwaiter : CallbackAwaiter<void>
+{
+    EndAwaiter(trantor::EventLoop *loop) : loop_(loop)
+    {
+        assert(loop);
+    }
+    void await_suspend(std::coroutine_handle<> handle)
+    {
+        loop_->runOnQuit([handle]() { handle.resume(); });
+    }
+
+  private:
+    trantor::EventLoop *loop_{nullptr};
+};
+
 }  // namespace internal
 
 inline internal::TimerAwaiter sleepCoro(
@@ -721,6 +736,12 @@ inline internal::LoopAwaiter queueInLoopCoro(
 {
     assert(workLoop);
     return {workLoop, std::move(taskFunc), resumeLoop};
+}
+
+inline internal::EndAwaiter untilQuit(trantor::EventLoop *loop)
+{
+    assert(loop);
+    return {loop};
 }
 
 template <typename T, typename = std::void_t<>>


### PR DESCRIPTION
Helpful when we need a coroutine to live until the event loop ends. For example

```c++
    WebSocketClientPtr ws_client;
    ws_client = WebSocketClient::newWebSocketClient("wss://echo.websocket.org");
    ws_client->setAsyncMessageHandler(handleWsMessage);
    co_await ws_client->connectToServerCoro(HttpRequest::newHttpRequest());
    co_await untilQuit(app().getLoop());
```