### PR TITLE
Add switchThreadCoro().

### DIFF
--- a/lib/inc/drogon/utils/coroutine.h
+++ b/lib/inc/drogon/utils/coroutine.h
@@ -238,7 +238,6 @@ struct [[nodiscard]] Task
             {
                 return std::move(coro_.promise().result());
             }
-
           private:
             handle_type coro_;
         };

--- a/lib/inc/drogon/utils/coroutine.h
+++ b/lib/inc/drogon/utils/coroutine.h
@@ -238,6 +238,7 @@ struct [[nodiscard]] Task
             {
                 return std::move(coro_.promise().result());
             }
+
           private:
             handle_type coro_;
         };
@@ -695,7 +696,6 @@ struct [[nodiscard]] LoopAwaiter : CallbackAwaiter<void>
     trantor::EventLoop *resumeLoop_{nullptr};
     std::function<void()> taskFunc_;
 };
-
 
 struct [[nodiscard]] SwitchThreadAwaiter : CallbackAwaiter<void>
 {


### PR DESCRIPTION
Support switching thread in coroutine functions.

This is useful when you want to handle some data in only one thread.
For example, switching back to the original thread after executing an sql query.

```cpp
auto loop = trantor::EventLoop::getEventLoopOfCurrentThread();
auto result = co_await drogon::app().getDbClient()->execSqlCoro(...);
co_await switchThreadCoro(loop);
```
