### PR TITLE
Use weakptr instead of shared_ptr

### DIFF
--- a/lib/src/HttpClientImpl.cc
+++ b/lib/src/HttpClientImpl.cc
@@ -289,35 +289,38 @@ void HttpClientImpl::sendRequestInLoop(const HttpRequestPtr &req,
     auto callbackPtr =
         std::make_shared<drogon::HttpReqCallback>(std::move(callback));
     auto thisPtr = shared_from_this();
-    loop_->runAfter(
-        timeout,
-        [timeoutFlag, weakCallbackPtr = std::weak_ptr(callbackPtr) ,
-            reqPtr = std::weak_ptr(req), thisPtr] {
-            if (*timeoutFlag)
-            {
-                return;
-            }
-            *timeoutFlag = true;
+    loop_->runAfter(timeout,
+                    [timeoutFlag,
+                     weakCallbackPtr = std::weak_ptr(callbackPtr),
+                     reqPtr = std::weak_ptr(req),
+                     thisPtr] {
+                        if (*timeoutFlag)
+                        {
+                            return;
+                        }
+                        *timeoutFlag = true;
 
-            auto req = reqPtr.lock();
-            if (req != nullptr) {
-                for (auto iter = thisPtr->requestsBuffer_.begin();
-                    iter != thisPtr->requestsBuffer_.end();
-                    ++iter)
-                {
-                    if (iter->first == req)
-                    {
-                        thisPtr->requestsBuffer_.erase(iter);
-                        break;
-                    }
-                }
-            }
+                        auto req = reqPtr.lock();
+                        if (req != nullptr)
+                        {
+                            for (auto iter = thisPtr->requestsBuffer_.begin();
+                                 iter != thisPtr->requestsBuffer_.end();
+                                 ++iter)
+                            {
+                                if (iter->first == req)
+                                {
+                                    thisPtr->requestsBuffer_.erase(iter);
+                                    break;
+                                }
+                            }
+                        }
 
-            auto callbackPtr = weakCallbackPtr.lock();
-            if (callbackPtr != nullptr) {
-                (*callbackPtr)(ReqResult::Timeout, nullptr);
-            }
-        });
+                        auto callbackPtr = weakCallbackPtr.lock();
+                        if (callbackPtr != nullptr)
+                        {
+                            (*callbackPtr)(ReqResult::Timeout, nullptr);
+                        }
+                    });
     sendRequestInLoop(req,
                       [timeoutFlag, callbackPtr](ReqResult r,
                                                  const HttpResponsePtr &resp) {

--- a/lib/src/HttpClientImpl.cc
+++ b/lib/src/HttpClientImpl.cc
@@ -291,7 +291,8 @@ void HttpClientImpl::sendRequestInLoop(const HttpRequestPtr &req,
     auto thisPtr = shared_from_this();
     loop_->runAfter(timeout,
                     [timeoutFlag,
-                     weakCallbackPtr = std::weak_ptr<HttpReqCallback>(callbackPtr),
+                     weakCallbackPtr =
+                         std::weak_ptr<HttpReqCallback>(callbackPtr),
                      reqPtr = std::weak_ptr<HttpRequest>(req),
                      thisPtr] {
                         if (*timeoutFlag)

--- a/lib/src/HttpClientImpl.cc
+++ b/lib/src/HttpClientImpl.cc
@@ -291,8 +291,8 @@ void HttpClientImpl::sendRequestInLoop(const HttpRequestPtr &req,
     auto thisPtr = shared_from_this();
     loop_->runAfter(timeout,
                     [timeoutFlag,
-                     weakCallbackPtr = std::weak_ptr(callbackPtr),
-                     reqPtr = std::weak_ptr(req),
+                     weakCallbackPtr = std::weak_ptr<HttpReqCallback>(callbackPtr),
+                     reqPtr = std::weak_ptr<HttpRequest>(req),
                      thisPtr] {
                         if (*timeoutFlag)
                         {

--- a/lib/src/HttpClientImpl.cc
+++ b/lib/src/HttpClientImpl.cc
@@ -289,28 +289,35 @@ void HttpClientImpl::sendRequestInLoop(const HttpRequestPtr &req,
     auto callbackPtr =
         std::make_shared<drogon::HttpReqCallback>(std::move(callback));
     auto thisPtr = shared_from_this();
-    loop_->runAfter(timeout, [timeoutFlag, callbackPtr, reqPtr = std::weak_ptr(req), thisPtr] {
-        if (*timeoutFlag)
-        {
-            return;
-        }
-        *timeoutFlag = true;
-
-        auto req = reqPtr.lock();
-        if (req != nullptr) {
-            for (auto iter = thisPtr->requestsBuffer_.begin();
-                iter != thisPtr->requestsBuffer_.end();
-                ++iter)
+    loop_->runAfter(
+        timeout,
+        [timeoutFlag, weakCallbackPtr = std::weak_ptr(callbackPtr) ,
+            reqPtr = std::weak_ptr(req), thisPtr] {
+            if (*timeoutFlag)
             {
-                if (iter->first == req)
+                return;
+            }
+            *timeoutFlag = true;
+
+            auto req = reqPtr.lock();
+            if (req != nullptr) {
+                for (auto iter = thisPtr->requestsBuffer_.begin();
+                    iter != thisPtr->requestsBuffer_.end();
+                    ++iter)
                 {
-                    thisPtr->requestsBuffer_.erase(iter);
-                    break;
+                    if (iter->first == req)
+                    {
+                        thisPtr->requestsBuffer_.erase(iter);
+                        break;
+                    }
                 }
             }
-        }
-        (*callbackPtr)(ReqResult::Timeout, nullptr);
-    });
+
+            auto callbackPtr = weakCallbackPtr.lock();
+            if (callbackPtr != nullptr) {
+                (*callbackPtr)(ReqResult::Timeout, nullptr);
+            }
+        });
     sendRequestInLoop(req,
                       [timeoutFlag, callbackPtr](ReqResult r,
                                                  const HttpResponsePtr &resp) {


### PR DESCRIPTION
If HttpClient sendRequest is called with timeout, the request object stays around for the whole time of the timeout. This fix is an attempt to not hold reference to the request in the timeout callback.