### PR TITLE
Refactor HttpServer codes.

### DIFF
--- a/lib/src/HttpAppFrameworkImpl.cc
+++ b/lib/src/HttpAppFrameworkImpl.cc
@@ -13,52 +13,44 @@
  */
 
 #include "HttpAppFrameworkImpl.h"
-#include "HttpRequestImpl.h"
-#include "HttpClientImpl.h"
-#include "HttpResponseImpl.h"
-#include "HttpUtils.h"
-#include "WebSocketConnectionImpl.h"
-#include "StaticFileRouter.h"
-#include "HttpSimpleControllersRouter.h"
-#include "HttpControllersRouter.h"
-#include "WebsocketControllersRouter.h"
-#include "AOPAdvice.h"
-#include "ConfigLoader.h"
-#include "HttpServer.h"
-#include "PluginsManager.h"
-#include "ListenerManager.h"
-#include "SharedLibManager.h"
-#include "SessionManager.h"
-#include "DbClientManager.h"
-#include "RedisClientManager.h"
-#include <drogon/config.h>
-#include <algorithm>
-#include <drogon/version.h>
-#include <drogon/CacheMap.h>
 #include <drogon/DrClassMap.h>
-#include <drogon/HttpRequest.h>
 #include <drogon/HttpResponse.h>
 #include <drogon/HttpTypes.h>
-#include <drogon/Session.h>
 #include <drogon/utils/Utilities.h>
-#include "filesystem.h"
-#include <trantor/utils/AsyncFileLogger.h>
+#include <drogon/version.h>
 #include <json/json.h>
+#include <trantor/utils/AsyncFileLogger.h>
+#include <algorithm>
+#include "AOPAdvice.h"
+#include "ConfigLoader.h"
+#include "DbClientManager.h"
+#include "HttpClientImpl.h"
+#include "HttpControllersRouter.h"
+#include "HttpRequestImpl.h"
+#include "HttpResponseImpl.h"
+#include "HttpServer.h"
+#include "HttpSimpleControllersRouter.h"
+#include "HttpUtils.h"
+#include "ListenerManager.h"
+#include "PluginsManager.h"
+#include "RedisClientManager.h"
+#include "SessionManager.h"
+#include "SharedLibManager.h"
+#include "StaticFileRouter.h"
+#include "WebSocketConnectionImpl.h"
+#include "WebsocketControllersRouter.h"
+#include "filesystem.h"
 
-#include <fstream>
 #include <iostream>
 #include <memory>
+#include <tuple>
 #include <unordered_map>
 #include <utility>
-#include <tuple>
 
 #include <fcntl.h>
 #include <sys/stat.h>
-#include <sys/types.h>
 #ifndef _WIN32
 #include <sys/wait.h>
-#include <sys/file.h>
-#include <uuid.h>
 #include <unistd.h>
 #define os_access access
 #elif !defined(_WIN32) || defined(__MINGW32__)
@@ -543,8 +535,20 @@ void HttpAppFrameworkImpl::run()
                                                libFileOutputPath_);
     }
 #endif
+
+    // Create IO threads
+    ioLoopThreadPool_ =
+        std::make_unique<trantor::EventLoopThreadPool>(threadNum_,
+                                                       "DrogonIoLoop");
+    std::vector<trantor::EventLoop *> ioLoops = ioLoopThreadPool_->getLoops();
+    for (size_t i = 0; i < threadNum_; ++i)
+    {
+        ioLoops[i]->setIndex(i);
+    }
+    getLoop()->setIndex(threadNum_);
+
     // Create all listeners.
-    auto ioLoops = listenerManagerPtr_->createListeners(
+    listenerManagerPtr_->createListeners(
         [this](const HttpRequestImplPtr &req,
                std::function<void(const HttpResponsePtr &)> &&callback) {
             onAsyncRequest(req, std::move(callback));
@@ -559,15 +563,10 @@ void HttpAppFrameworkImpl::run()
         sslCertPath_,
         sslKeyPath_,
         sslConfCmds_,
-        threadNum_,
+        ioLoops,
         syncAdvices_,
         preSendingAdvices_);
-    assert(ioLoops.size() == threadNum_);
-    for (size_t i = 0; i < threadNum_; ++i)
-    {
-        ioLoops[i]->setIndex(i);
-    }
-    getLoop()->setIndex(threadNum_);
+
     // A fast database client instance should be created in the main event
     // loop, so put the main loop into ioLoops.
     ioLoops.push_back(getLoop());
@@ -609,6 +608,12 @@ void HttpAppFrameworkImpl::run()
         // Let listener event loops run when everything is ready.
         listenerManagerPtr_->startListening();
     });
+    // start all loops
+    // TODO: when should IOLoops start?
+    // In before, IOLoops are started in `listenerManagerPtr_->startListening()`
+    // It should be fine for them to start anywhere before `startListening()`.
+    // However, we should consider other components.
+    ioLoopThreadPool_->start();
     getLoop()->loop();
 }
 
@@ -883,8 +888,19 @@ trantor::EventLoop *HttpAppFrameworkImpl::getLoop() const
 
 trantor::EventLoop *HttpAppFrameworkImpl::getIOLoop(size_t id) const
 {
-    assert(listenerManagerPtr_);
-    return listenerManagerPtr_->getIOLoop(id);
+    if (!ioLoopThreadPool_)
+    {
+        LOG_WARN << "Please call getIOLoop() after drogon::app().run()";
+        return nullptr;
+    }
+    auto n = ioLoopThreadPool_->size();
+    if (id >= n)
+    {
+        LOG_TRACE << "Loop id (" << id << ") out of range [0-" << n << ").";
+        id %= n;
+        LOG_TRACE << "Rounded to : " << id;
+    }
+    return ioLoopThreadPool_->getLoop(id);
 }
 
 HttpAppFramework &HttpAppFramework::instance()
@@ -1028,6 +1044,7 @@ void HttpAppFrameworkImpl::quit()
         getLoop()->queueInLoop([this]() {
             // Release members in the reverse order of initialization
             listenerManagerPtr_->stopListening();
+            listenerManagerPtr_.reset();
             websockCtrlsRouterPtr_.reset();
             staticFileRouterPtr_.reset();
             httpSimpleCtrlsRouterPtr_.reset();
@@ -1035,12 +1052,13 @@ void HttpAppFrameworkImpl::quit()
             pluginsManagerPtr_.reset();
             redisClientManagerPtr_.reset();
             dbClientManagerPtr_.reset();
-            // TODO: let HttpAppFrameworkImpl manage IO loops
-            // and reset listenerManagerPtr_ before IO loops quit.
-            listenerManagerPtr_->stopIoLoops();
-            listenerManagerPtr_.reset();
             running_ = false;
             getLoop()->quit();
+            for (trantor::EventLoop *loop : ioLoopThreadPool_->getLoops())
+            {
+                loop->quit();
+            }
+            ioLoopThreadPool_->wait();
         });
     }
 }

--- a/lib/src/HttpAppFrameworkImpl.h
+++ b/lib/src/HttpAppFrameworkImpl.h
@@ -14,17 +14,22 @@
 
 #pragma once
 
-#include "impl_forwards.h"
 #include <drogon/HttpAppFramework.h>
 #include <drogon/config.h>
 #include <json/json.h>
+#include <functional>
+#include <limits>
 #include <memory>
 #include <mutex>
 #include <regex>
 #include <string>
 #include <vector>
-#include <functional>
-#include <limits>
+#include "impl_forwards.h"
+
+namespace trantor
+{
+class EventLoopThreadPool;
+}
 
 namespace drogon
 {
@@ -635,6 +640,8 @@ class HttpAppFrameworkImpl final : public HttpAppFramework
     std::atomic_bool routersInit_{false};
 
     size_t threadNum_{1};
+    std::unique_ptr<trantor::EventLoopThreadPool> ioLoopThreadPool_;
+
 #ifndef _WIN32
     std::vector<std::string> libFilePaths_;
     std::string libFileOutputPath_;

--- a/lib/src/HttpRequestParser.cc
+++ b/lib/src/HttpRequestParser.cc
@@ -13,14 +13,14 @@
  */
 
 #include "HttpRequestParser.h"
-#include "HttpAppFrameworkImpl.h"
-#include "HttpResponseImpl.h"
-#include "HttpRequestImpl.h"
-#include "HttpUtils.h"
 #include <drogon/HttpTypes.h>
-#include <iostream>
 #include <trantor/utils/Logger.h>
 #include <trantor/utils/MsgBuffer.h>
+#include <iostream>
+#include "HttpAppFrameworkImpl.h"
+#include "HttpRequestImpl.h"
+#include "HttpResponseImpl.h"
+#include "HttpUtils.h"
 
 using namespace trantor;
 using namespace drogon;

--- a/lib/src/HttpRequestParser.cc
+++ b/lib/src/HttpRequestParser.cc
@@ -443,7 +443,8 @@ int HttpRequestParser::parseRequest(MsgBuffer *buf)
     return -1;
 }
 
-void HttpRequestParser::pushRequestToPipelining(const HttpRequestPtr &req)
+void HttpRequestParser::pushRequestToPipelining(const HttpRequestPtr &req,
+                                                bool isHeadMethod)
 {
 #ifndef NDEBUG
     auto conn = conn_.lock();
@@ -452,7 +453,7 @@ void HttpRequestParser::pushRequestToPipelining(const HttpRequestPtr &req)
         conn->getLoop()->assertInLoopThread();
     }
 #endif
-    requestPipelining_.push_back({req, {nullptr, false}});
+    requestPipelining_.push_back({req, {nullptr, isHeadMethod}});
 }
 
 HttpRequestPtr HttpRequestParser::getFirstRequest() const
@@ -500,8 +501,7 @@ void HttpRequestParser::popFirstRequest()
 }
 
 void HttpRequestParser::pushResponseToPipelining(const HttpRequestPtr &req,
-                                                 const HttpResponsePtr &resp,
-                                                 bool isHeadMethod)
+                                                 HttpResponsePtr resp)
 {
 #ifndef NDEBUG
     auto conn = conn_.lock();
@@ -514,7 +514,7 @@ void HttpRequestParser::pushResponseToPipelining(const HttpRequestPtr &req,
     {
         if (iter.first == req)
         {
-            iter.second = {resp, isHeadMethod};
+            iter.second.first = std::move(resp);
             return;
         }
     }

--- a/lib/src/HttpRequestParser.cc
+++ b/lib/src/HttpRequestParser.cc
@@ -446,25 +446,13 @@ int HttpRequestParser::parseRequest(MsgBuffer *buf)
 void HttpRequestParser::pushRequestToPipelining(const HttpRequestPtr &req,
                                                 bool isHeadMethod)
 {
-#ifndef NDEBUG
-    auto conn = conn_.lock();
-    if (conn)
-    {
-        conn->getLoop()->assertInLoopThread();
-    }
-#endif
+    assert(loop_->isInLoopThread());
     requestPipelining_.push_back({req, {nullptr, isHeadMethod}});
 }
 
 HttpRequestPtr HttpRequestParser::getFirstRequest() const
 {
-#ifndef NDEBUG
-    auto conn = conn_.lock();
-    if (conn)
-    {
-        conn->getLoop()->assertInLoopThread();
-    }
-#endif
+    assert(loop_->isInLoopThread());
     if (!requestPipelining_.empty())
     {
         return requestPipelining_.front().first;
@@ -474,13 +462,7 @@ HttpRequestPtr HttpRequestParser::getFirstRequest() const
 
 std::pair<HttpResponsePtr, bool> HttpRequestParser::getFirstResponse() const
 {
-#ifndef NDEBUG
-    auto conn = conn_.lock();
-    if (conn)
-    {
-        conn->getLoop()->assertInLoopThread();
-    }
-#endif
+    assert(loop_->isInLoopThread());
     if (!requestPipelining_.empty())
     {
         return requestPipelining_.front().second;
@@ -490,26 +472,14 @@ std::pair<HttpResponsePtr, bool> HttpRequestParser::getFirstResponse() const
 
 void HttpRequestParser::popFirstRequest()
 {
-#ifndef NDEBUG
-    auto conn = conn_.lock();
-    if (conn)
-    {
-        conn->getLoop()->assertInLoopThread();
-    }
-#endif
+    assert(loop_->isInLoopThread());
     requestPipelining_.pop_front();
 }
 
 void HttpRequestParser::pushResponseToPipelining(const HttpRequestPtr &req,
                                                  HttpResponsePtr resp)
 {
-#ifndef NDEBUG
-    auto conn = conn_.lock();
-    if (conn)
-    {
-        conn->getLoop()->assertInLoopThread();
-    }
-#endif
+    assert(loop_->isInLoopThread());
     for (auto &iter : requestPipelining_)
     {
         if (iter.first == req)

--- a/lib/src/HttpRequestParser.h
+++ b/lib/src/HttpRequestParser.h
@@ -21,6 +21,7 @@
 #include <trantor/utils/MsgBuffer.h>
 #include <mutex>
 #include <deque>
+#include <memory>
 
 namespace drogon
 {
@@ -75,13 +76,12 @@ class HttpRequestParser : public trantor::NonCopyable,
         websockConnPtr_ = conn;
     }
     // to support request pipelining(rfc2616-8.1.2.2)
-    void pushRequestToPipelining(const HttpRequestPtr &req);
+    void pushRequestToPipelining(const HttpRequestPtr &req, bool isHeadMethod);
     HttpRequestPtr getFirstRequest() const;
     std::pair<HttpResponsePtr, bool> getFirstResponse() const;
     void popFirstRequest();
     void pushResponseToPipelining(const HttpRequestPtr &req,
-                                  const HttpResponsePtr &resp,
-                                  bool isHeadMethod);
+                                  HttpResponsePtr resp);
     size_t numberOfRequestsInPipelining() const
     {
         return requestPipelining_.size();

--- a/lib/src/HttpRequestParser.h
+++ b/lib/src/HttpRequestParser.h
@@ -43,7 +43,7 @@ class HttpRequestParser : public trantor::NonCopyable,
     explicit HttpRequestParser(const trantor::TcpConnectionPtr &connPtr);
 
     // return false if any error
-    bool parseRequest(trantor::MsgBuffer *buf);
+    int parseRequest(trantor::MsgBuffer *buf);
 
     bool gotAll() const
     {

--- a/lib/src/HttpRequestParser.h
+++ b/lib/src/HttpRequestParser.h
@@ -14,14 +14,14 @@
 
 #pragma once
 
-#include "impl_forwards.h"
 #include <drogon/HttpTypes.h>
-#include <trantor/utils/NonCopyable.h>
 #include <trantor/net/TcpConnection.h>
 #include <trantor/utils/MsgBuffer.h>
-#include <mutex>
+#include <trantor/utils/NonCopyable.h>
 #include <deque>
 #include <memory>
+#include <mutex>
+#include "impl_forwards.h"
 
 namespace drogon
 {

--- a/lib/src/HttpRequestParser.h
+++ b/lib/src/HttpRequestParser.h
@@ -76,12 +76,9 @@ class HttpRequestParser : public trantor::NonCopyable,
         websockConnPtr_ = conn;
     }
     // to support request pipelining(rfc2616-8.1.2.2)
-    void pushRequestToPipelining(const HttpRequestPtr &req, bool isHeadMethod);
-    HttpRequestPtr getFirstRequest() const;
-    std::pair<HttpResponsePtr, bool> getFirstResponse() const;
-    void popFirstRequest();
-    void pushResponseToPipelining(const HttpRequestPtr &req,
-                                  HttpResponsePtr resp);
+    void pushRequestToPipelining(const HttpRequestPtr &, bool isHeadMethod);
+    bool pushResponseToPipelining(const HttpRequestPtr &, HttpResponsePtr);
+    void popReadyResponses(std::vector<std::pair<HttpResponsePtr, bool>> &);
     size_t numberOfRequestsInPipelining() const
     {
         return requestPipelining_.size();

--- a/lib/src/HttpRequestParser.h
+++ b/lib/src/HttpRequestParser.h
@@ -147,7 +147,7 @@ class HttpRequestParser : public trantor::NonCopyable,
         responseBuffer_;
     std::unique_ptr<std::vector<HttpRequestImplPtr>> requestBuffer_;
     std::vector<HttpRequestImplPtr> requestsPool_;
-    size_t currentChunkLength_;
+    size_t currentChunkLength_{0};
     size_t currentContentLength_{0};
 };
 

--- a/lib/src/HttpServer.cc
+++ b/lib/src/HttpServer.cc
@@ -13,17 +13,16 @@
  */
 
 #include "HttpServer.h"
-#include "HttpRequestImpl.h"
-#include "HttpRequestParser.h"
-#include "HttpAppFrameworkImpl.h"
-#include "HttpResponseImpl.h"
-#include "WebSocketConnectionImpl.h"
-#include <drogon/HttpRequest.h>
 #include <drogon/HttpResponse.h>
 #include <drogon/utils/Utilities.h>
+#include <trantor/utils/Logger.h>
 #include <functional>
 #include <utility>
-#include <trantor/utils/Logger.h>
+#include "HttpAppFrameworkImpl.h"
+#include "HttpRequestImpl.h"
+#include "HttpRequestParser.h"
+#include "HttpResponseImpl.h"
+#include "WebSocketConnectionImpl.h"
 
 #if COZ_PROFILING
 #include <coz.h>

--- a/lib/src/HttpServer.cc
+++ b/lib/src/HttpServer.cc
@@ -441,17 +441,23 @@ void HttpServer::handleResponse(
     }
 }
 
-using CallbackParams = struct
+struct ChunkingParams
 {
-    std::function<std::size_t(char *, std::size_t)> dataCallback;
-    bool bFinished;
+    using DataCallback = std::function<std::size_t(char *, std::size_t)>;
+    explicit ChunkingParams(DataCallback cb) : dataCallback(std::move(cb))
+    {
+    }
+    DataCallback dataCallback;
+    bool bFinished{false};
 #ifndef NDEBUG  // defined by CMake for release build
-    std::size_t nDataReturned;
+    std::size_t nDataReturned{0};
 #endif
 };
-static std::size_t chunkingCallback(std::shared_ptr<CallbackParams> cbParams,
-                                    char *pBuffer,
-                                    std::size_t nSize)
+
+static std::size_t chunkingCallback(
+    const std::shared_ptr<ChunkingParams> &cbParams,
+    char *pBuffer,
+    std::size_t nSize)
 {
     if (!cbParams)
         return 0;
@@ -463,7 +469,6 @@ static std::size_t chunkingCallback(std::shared_ptr<CallbackParams> cbParams,
         {
             cbParams->dataCallback(pBuffer, nSize);
             cbParams->dataCallback = {};
-            cbParams.reset();
         }
         return 0;
     }
@@ -574,20 +579,11 @@ void HttpServer::sendResponse(const TcpConnectionPtr &conn,
                     (headers.at("transfer-encoding") == "chunked");
                 if (bChunked)
                 {
-                    auto chunkCallback =
-                        std::bind(chunkingCallback,
-                                  std::shared_ptr<CallbackParams>(
-                                      new CallbackParams{streamCallback,
-#ifndef NDEBUG  // defined by CMake for release build
-                                                         false,
-                                                         0}),
-#else
-                                                         false}),
-#endif
-
-                                  _1,
-                                  _2);
-                    conn->sendStream(chunkCallback);
+                    conn->sendStream(
+                        [ctx = std::make_shared<ChunkingParams>(
+                             streamCallback)](char *buffer, size_t len) {
+                            return chunkingCallback(ctx, buffer, len);
+                        });
                 }
                 else
                     conn->sendStream(streamCallback);
@@ -651,19 +647,11 @@ void HttpServer::sendResponses(
                         (headers.at("transfer-encoding") == "chunked");
                     if (bChunked)
                     {
-                        auto chunkCallback =
-                            std::bind(chunkingCallback,
-                                      std::shared_ptr<CallbackParams>(
-                                          new CallbackParams{streamCallback,
-#ifndef NDEBUG  // defined by CMake for release build
-                                                             false,
-                                                             0}),
-#else
-                                                             false}),
-#endif
-                                      _1,
-                                      _2);
-                        conn->sendStream(chunkCallback);
+                        conn->sendStream(
+                            [ctx = std::make_shared<ChunkingParams>(
+                                 streamCallback)](char *buffer, size_t len) {
+                                return chunkingCallback(ctx, buffer, len);
+                            });
                     }
                     else
                         conn->sendStream(streamCallback);

--- a/lib/src/HttpServer.h
+++ b/lib/src/HttpServer.h
@@ -30,7 +30,7 @@ class HttpServer : trantor::NonCopyable
   public:
     HttpServer(trantor::EventLoop *loop,
                const trantor::InetAddress &listenAddr,
-               const std::string &name,
+               std::string name,
                const std::vector<
                    std::function<HttpResponsePtr(const HttpRequestPtr &)>>
                    &syncAdvices,
@@ -49,7 +49,6 @@ class HttpServer : trantor::NonCopyable
     {
         httpAsyncCallback_ = cb;
     }
-
     void setNewWebsocketCallback(const WebSocketNewAsyncCallback &cb)
     {
         newWebsocketCallback_ = cb;

--- a/lib/src/HttpServer.h
+++ b/lib/src/HttpServer.h
@@ -14,13 +14,13 @@
 
 #pragma once
 
-#include "impl_forwards.h"
 #include <trantor/net/TcpServer.h>
 #include <trantor/net/callbacks.h>
 #include <trantor/utils/NonCopyable.h>
 #include <functional>
 #include <string>
 #include <vector>
+#include "impl_forwards.h"
 
 struct CallbackParamPack;
 namespace drogon

--- a/lib/src/HttpServer.h
+++ b/lib/src/HttpServer.h
@@ -22,6 +22,7 @@
 #include <string>
 #include <vector>
 
+struct CallbackParamPack;
 namespace drogon
 {
 class HttpServer : trantor::NonCopyable
@@ -105,6 +106,8 @@ class HttpServer : trantor::NonCopyable
     void onRequests(const trantor::TcpConnectionPtr &,
                     const std::vector<HttpRequestImplPtr> &,
                     const std::shared_ptr<HttpRequestParser> &);
+    void handleResponse(const HttpResponsePtr &response,
+                        const std::shared_ptr<CallbackParamPack> &paramPack);
     void sendResponse(const trantor::TcpConnectionPtr &,
                       const HttpResponsePtr &,
                       bool isHeadMethod);

--- a/lib/src/HttpServer.h
+++ b/lib/src/HttpServer.h
@@ -66,6 +66,10 @@ class HttpServer : trantor::NonCopyable
     {
         server_.setIoLoopNum(numThreads);
     }
+    void setIoLoops(const std::vector<trantor::EventLoop *> &ioLoops)
+    {
+        server_.setIoLoops(ioLoops);
+    }
     void kickoffIdleConnections(size_t timeout)
     {
         server_.kickoffIdleConnections(timeout);

--- a/lib/src/HttpServer.h
+++ b/lib/src/HttpServer.h
@@ -106,7 +106,8 @@ class HttpServer : trantor::NonCopyable
                     const std::vector<HttpRequestImplPtr> &,
                     const std::shared_ptr<HttpRequestParser> &);
     void handleResponse(const HttpResponsePtr &response,
-                        const std::shared_ptr<CallbackParamPack> &paramPack);
+                        const std::shared_ptr<CallbackParamPack> &paramPack,
+                        bool *respReadyPtr);
     void sendResponse(const trantor::TcpConnectionPtr &,
                       const HttpResponsePtr &,
                       bool isHeadMethod);

--- a/lib/src/HttpServer.h
+++ b/lib/src/HttpServer.h
@@ -118,6 +118,7 @@ class HttpServer : trantor::NonCopyable
     trantor::ConnectionCallback connectionCallback_;
     const std::vector<std::function<HttpResponsePtr(const HttpRequestPtr &)>>
         &syncAdvices_;
+    const bool hasSyncAdvices_;
     const std::vector<
         std::function<void(const HttpRequestPtr &, const HttpResponsePtr &)>>
         &preSendingAdvices_;

--- a/lib/src/ListenerManager.cc
+++ b/lib/src/ListenerManager.cc
@@ -13,15 +13,12 @@
  */
 
 #include "ListenerManager.h"
-#include "HttpServer.h"
-#include "HttpAppFrameworkImpl.h"
 #include <drogon/config.h>
-#include <trantor/utils/Logger.h>
 #include <fcntl.h>
-#include <sys/stat.h>
-#include <sys/types.h>
+#include <trantor/utils/Logger.h>
+#include "HttpAppFrameworkImpl.h"
+#include "HttpServer.h"
 #ifndef _WIN32
-#include <sys/wait.h>
 #include <sys/file.h>
 #include <unistd.h>
 #endif
@@ -71,7 +68,17 @@ void ListenerManager::addListener(
         ip, port, useSSL, certFile, keyFile, useOldTLS, sslConfCmds);
 }
 
-std::vector<trantor::EventLoop *> ListenerManager::createListeners(
+std::vector<trantor::InetAddress> ListenerManager::getListeners() const
+{
+    std::vector<trantor::InetAddress> listeners;
+    for (auto &server : servers_)
+    {
+        listeners.emplace_back(server->address());
+    }
+    return listeners;
+}
+
+void ListenerManager::createListeners(
     const HttpAsyncCallback &httpCallback,
     const WebSocketNewAsyncCallback &webSocketCallback,
     const ConnectionCallback &connectionCallback,
@@ -85,25 +92,21 @@ std::vector<trantor::EventLoop *> ListenerManager::createListeners(
     const std::string & /*globalKeyFile*/,
     const std::vector<std::pair<std::string, std::string>> & /*sslConfCmds*/,
 #endif
-    size_t threadNum,
+    const std::vector<trantor::EventLoop *> &ioLoops,
     const std::vector<std::function<HttpResponsePtr(const HttpRequestPtr &)>>
         &syncAdvices,
     const std::vector<
         std::function<void(const HttpRequestPtr &, const HttpResponsePtr &)>>
         &preSendingAdvices)
 {
+    LOG_TRACE << "thread num=" << ioLoops.size();
 #ifdef __linux__
-    for (size_t i = 0; i < threadNum; ++i)
+    for (size_t i = 0; i < ioLoops.size(); ++i)
     {
-        LOG_TRACE << "thread num=" << threadNum;
-        auto loopThreadPtr = std::make_shared<EventLoopThread>("DrogonIoLoop");
-        listeningloopThreads_.push_back(loopThreadPtr);
-        ioLoops_.push_back(loopThreadPtr->getLoop());
         for (auto const &listener : listeners_)
         {
             auto const &ip = listener.ip_;
-            bool isIpv6 = ip.find(':') == std::string::npos ? false : true;
-            std::shared_ptr<HttpServer> serverPtr;
+            bool isIpv6 = (ip.find(':') != std::string::npos);
             InetAddress listenAddress(ip, listener.port_, isIpv6);
             if (listenAddress.isUnspecified())
             {
@@ -121,33 +124,24 @@ std::vector<trantor::EventLoop *> ListenerManager::createListeners(
                                  "drogonPortTest",
                                  true,
                                  false);
-                serverPtr =
-                    std::make_shared<HttpServer>(loopThreadPtr->getLoop(),
-                                                 listenAddress,
-                                                 "drogon",
-                                                 syncAdvices,
-                                                 preSendingAdvices);
             }
-            else
-            {
-                serverPtr =
-                    std::make_shared<HttpServer>(loopThreadPtr->getLoop(),
-                                                 listenAddress,
-                                                 "drogon",
-                                                 syncAdvices,
-                                                 preSendingAdvices);
-            }
+            std::shared_ptr<HttpServer> serverPtr =
+                std::make_shared<HttpServer>(ioLoops[i],
+                                             listenAddress,
+                                             "drogon",
+                                             syncAdvices,
+                                             preSendingAdvices);
 
             if (listener.useSSL_)
             {
 #ifdef OpenSSL_FOUND
                 auto cert = listener.certFile_;
                 auto key = listener.keyFile_;
-                if (cert == "")
+                if (cert.empty())
                     cert = globalCertFile;
-                if (key == "")
+                if (key.empty())
                     key = globalKeyFile;
-                if (cert == "" || key == "")
+                if (cert.empty() || key.empty())
                 {
                     std::cerr
                         << "You can't use https without cert file or key file"
@@ -165,25 +159,22 @@ std::vector<trantor::EventLoop *> ListenerManager::createListeners(
             serverPtr->setNewWebsocketCallback(webSocketCallback);
             serverPtr->setConnectionCallback(connectionCallback);
             serverPtr->kickoffIdleConnections(connectionTimeout);
-            serverPtr->start();
             servers_.push_back(serverPtr);
         }
     }
 #else
 
-    ioLoopThreadPoolPtr_ = std::make_shared<EventLoopThreadPool>(threadNum);
     if (!listeners_.empty())
     {
-        auto loopThreadPtr =
-            std::make_shared<EventLoopThread>("DrogonListeningLoop");
-        listeningloopThreads_.push_back(loopThreadPtr);
+        listeningThread_ =
+            std::make_unique<EventLoopThread>("DrogonListeningLoop");
+        listeningThread_->run();
         for (auto const &listener : listeners_)
         {
-            LOG_TRACE << "thread num=" << threadNum;
             auto ip = listener.ip_;
-            bool isIpv6 = ip.find(':') == std::string::npos ? false : true;
+            bool isIpv6 = (ip.find(':') != std::string::npos);
             auto serverPtr = std::make_shared<HttpServer>(
-                loopThreadPtr->getLoop(),
+                listeningThread_->getLoop(),
                 InetAddress(ip, listener.port_, isIpv6),
                 "drogon",
                 syncAdvices,
@@ -211,106 +202,36 @@ std::vector<trantor::EventLoop *> ListenerManager::createListeners(
                 serverPtr->enableSSL(cert, key, listener.useOldTLS_, cmds);
 #endif
             }
-            serverPtr->setIoLoopThreadPool(ioLoopThreadPoolPtr_);
+            serverPtr->setIoLoops(ioLoops);
             serverPtr->setHttpAsyncCallback(httpCallback);
             serverPtr->setNewWebsocketCallback(webSocketCallback);
             serverPtr->setConnectionCallback(connectionCallback);
             serverPtr->kickoffIdleConnections(connectionTimeout);
-            serverPtr->start();
             servers_.push_back(serverPtr);
         }
     }
-    else
-    {
-        ioLoopThreadPoolPtr_->start();
-    }
-    ioLoops_ = ioLoopThreadPoolPtr_->getLoops();
 #endif
-    return ioLoops_;
 }
 
 void ListenerManager::startListening()
 {
-    for (auto &loopThread : listeningloopThreads_)
+    for (auto &server : servers_)
     {
-        loopThread->run();
+        server->start();
     }
 }
 
-trantor::EventLoop *ListenerManager::getIOLoop(size_t id) const
-{
-#ifdef __linux__
-    auto const n = listeningloopThreads_.size();
-#else
-    auto const n = ioLoopThreadPoolPtr_->size();
-#endif
-    if (0 == n)
-    {
-        LOG_WARN << "Please call getIOLoop() after drogon::app().run()";
-        return nullptr;
-    }
-    if (id >= n)
-    {
-        LOG_TRACE << "Loop id (" << id << ") out of range [0-" << n << ").";
-        id %= n;
-        LOG_TRACE << "Rounded to : " << id;
-    }
-#ifdef __linux__
-    assert(listeningloopThreads_[id]);
-    return listeningloopThreads_[id]->getLoop();
-#else
-    return ioLoopThreadPoolPtr_->getLoop(id);
-#endif
-}
 void ListenerManager::stopListening()
 {
     for (auto &serverPtr : servers_)
     {
         serverPtr->stop();
     }
-#ifndef __linux__
-    for (auto &listenerLoopPtr : listeningloopThreads_)
+    if (listeningThread_)
     {
-        auto loop = listenerLoopPtr->getLoop();
+        auto loop = listeningThread_->getLoop();
         assert(!loop->isInLoopThread());
-        if (loop->isRunning())
-        {
-            std::promise<int> pro;
-            auto f = pro.get_future();
-            loop->queueInLoop([loop, &pro]() {
-                loop->quit();
-                pro.set_value(1);
-            });
-            (void)f.get();
-        }
+        loop->quit();
+        listeningThread_->wait();
     }
-#endif
-}
-
-void ListenerManager::stopIoLoops()
-{
-    for (auto loop : ioLoops_)
-    {
-        assert(!loop->isInLoopThread());
-        if (loop->isRunning())
-        {
-            std::promise<int> pro;
-            auto f = pro.get_future();
-            loop->queueInLoop([loop, &pro]() {
-                loop->quit();
-                pro.set_value(1);
-            });
-            (void)f.get();
-        }
-    }
-}
-
-std::vector<trantor::InetAddress> ListenerManager::getListeners() const
-{
-    std::vector<trantor::InetAddress> listeners;
-    for (auto &server : servers_)
-    {
-        listeners.emplace_back(server->address());
-    }
-    return listeners;
 }

--- a/lib/src/StaticFileRouter.h
+++ b/lib/src/StaticFileRouter.h
@@ -47,7 +47,7 @@ class StaticFileRouter
     {
         brStaticFlag_ = useBrStatic;
     }
-    void init(const std::vector<trantor::EventLoop *> &ioloops);
+    void init(const std::vector<trantor::EventLoop *> &ioLoops);
 
     void sendStaticFileResponse(
         const std::string &filePath,

--- a/lib/tests/integration_test/client/HttpPipeliningTest.cc
+++ b/lib/tests/integration_test/client/HttpPipeliningTest.cc
@@ -38,8 +38,6 @@ DROGON_TEST(HttpPipeliningTest)
                             REQUIRE(resp->getBody().length() == 44618UL);
                         });
 
-    auto request = HttpRequest::newHttpRequest();
-    request->setPath("/pipe");
     for (int i = 0; i < 19; ++i)
     {
         client->sendRequest(
@@ -54,5 +52,41 @@ DROGON_TEST(HttpPipeliningTest)
                 counter = c;
                 REQUIRE(resp->body().empty());
             });
+    }
+}
+
+DROGON_TEST(HttpPipeliningStrangeTest1)
+{
+    auto client = HttpClient::newHttpClient("127.0.0.1", 8848);
+    client->setPipeliningDepth(64);
+    for (int i = 0; i < 4; ++i)
+    {
+        auto request = HttpRequest::newHttpRequest();
+        request->setPath("/pipe/strange-1");
+        request->setBody(std::to_string(i));
+        client->sendRequest(request,
+                            [TEST_CTX, i](ReqResult r,
+                                          const HttpResponsePtr &resp) {
+                                REQUIRE(r == ReqResult::Ok);
+                                REQUIRE(resp->body() == std::to_string(i));
+                            });
+    }
+}
+
+DROGON_TEST(HttpPipeliningStrangeTest2)
+{
+    auto client = HttpClient::newHttpClient("127.0.0.1", 8848);
+    client->setPipeliningDepth(64);
+    for (int i = 0; i < 6; ++i)
+    {
+        auto request = HttpRequest::newHttpRequest();
+        request->setPath("/pipe/strange-2");
+        request->setBody(std::to_string(i));
+        client->sendRequest(request,
+                            [TEST_CTX, i](ReqResult r,
+                                          const HttpResponsePtr &resp) {
+                                REQUIRE(r == ReqResult::Ok);
+                                REQUIRE(resp->body() == std::to_string(i));
+                            });
     }
 }

--- a/lib/tests/integration_test/server/PipeliningTest.cc
+++ b/lib/tests/integration_test/server/PipeliningTest.cc
@@ -1,10 +1,11 @@
 #include "PipeliningTest.h"
 #include <trantor/net/EventLoop.h>
 #include <atomic>
+#include <mutex>
 
-void PipeliningTest::asyncHandleHttpRequest(
+void PipeliningTest::normalPipe(
     const HttpRequestPtr &req,
-    std::function<void(const HttpResponsePtr &)> &&callback)
+    std::function<void(const HttpResponsePtr &)> &&callback) const
 {
     static std::atomic<int> counter{0};
     int c = counter.fetch_add(1);
@@ -38,4 +39,110 @@ void PipeliningTest::asyncHandleHttpRequest(
             resp->setBody(std::move(str));
             callback(resp);
         });
+}
+
+// Receive 1, cache 1
+// Receive 2, send 1 send 2
+void PipeliningTest::strangePipe1(
+    const HttpRequestPtr &req,
+    std::function<void(const HttpResponsePtr &)> &&callback)
+{
+    static std::mutex mtx;
+    static std::vector<
+        std::pair<std::function<void(const HttpResponsePtr &)>, std::string>>
+        callbacks;
+
+    LOG_INFO << "Receive request " << req->body();
+    std::function<void(const HttpResponsePtr &)> cb1;
+    std::string body1;
+    std::function<void(const HttpResponsePtr &)> cb2;
+    std::string body2;
+    {
+        std::lock_guard<std::mutex> lock(mtx);
+        if (callbacks.empty())
+        {
+            callbacks.emplace_back(std::move(callback), req->getBody());
+            return;
+        }
+        auto item = std::move(callbacks.back());
+        callbacks.pop_back();
+        cb1 = std::move(item.first);
+        body1 = std::move(item.second);
+        cb2 = std::move(callback);
+        body2 = req->body();
+    }
+    if (cb1)
+    {
+        auto resp = HttpResponse::newHttpResponse();
+        resp->setBody(body1);
+        cb1(resp);
+    }
+    if (cb2)
+    {
+        auto resp = HttpResponse::newHttpResponse();
+        resp->setBody(body2);
+        cb2(resp);
+    }
+}
+
+// Receive 1, cache 1
+// Receive 2, send 1 cache 2
+// Receive 3, send 2 send 3
+void PipeliningTest::strangePipe2(
+    const HttpRequestPtr &req,
+    std::function<void(const HttpResponsePtr &)> &&callback)
+{
+    static std::mutex mtx;
+    static std::vector<
+        std::pair<std::function<void(const HttpResponsePtr &)>, std::string>>
+        callbacks;
+    static uint64_t idx{0};
+
+    LOG_INFO << "Receive request " << req->body();
+    std::function<void(const HttpResponsePtr &)> cb1;
+    std::string body1;
+    std::function<void(const HttpResponsePtr &)> cb2;
+    std::string body2;
+
+    std::string lastBody;
+    {
+        std::lock_guard<std::mutex> lock(mtx);
+        ++idx;
+        if (idx % 3 == 1)
+        {
+            assert(callbacks.empty());
+            callbacks.emplace_back(std::move(callback), req->getBody());
+            return;
+        }
+        assert(callbacks.size() == 1);
+        if (idx % 3 == 2)
+        {
+            auto item = std::move(callbacks.back());
+            cb1 = std::move(item.first);
+            body1 = std::move(item.second);
+            callbacks.pop_back();
+            callbacks.emplace_back(std::move(callback), req->getBody());
+        }
+        else
+        {
+            auto item = std::move(callbacks.back());
+            cb1 = std::move(item.first);
+            body1 = std::move(item.second);
+            callbacks.pop_back();
+            cb2 = std::move(callback);
+            body2 = req->getBody();
+        }
+    }
+    if (cb1)
+    {
+        auto resp = HttpResponse::newHttpResponse();
+        resp->setBody(body1);
+        cb1(resp);
+    }
+    if (cb2)
+    {
+        auto resp = HttpResponse::newHttpResponse();
+        resp->setBody(body2);
+        cb2(resp);
+    }
 }

--- a/lib/tests/integration_test/server/PipeliningTest.cc
+++ b/lib/tests/integration_test/server/PipeliningTest.cc
@@ -69,7 +69,7 @@ void PipeliningTest::strangePipe1(
         cb1 = std::move(item.first);
         body1 = std::move(item.second);
         cb2 = std::move(callback);
-        body2 = req->body();
+        body2 = std::string{req->body()};
     }
     if (cb1)
     {
@@ -103,8 +103,6 @@ void PipeliningTest::strangePipe2(
     std::string body1;
     std::function<void(const HttpResponsePtr &)> cb2;
     std::string body2;
-
-    std::string lastBody;
     {
         std::lock_guard<std::mutex> lock(mtx);
         ++idx;
@@ -130,7 +128,7 @@ void PipeliningTest::strangePipe2(
             body1 = std::move(item.second);
             callbacks.pop_back();
             cb2 = std::move(callback);
-            body2 = req->getBody();
+            body2 = std::string{req->body()};
         }
     }
     if (cb1)

--- a/lib/tests/integration_test/server/PipeliningTest.h
+++ b/lib/tests/integration_test/server/PipeliningTest.h
@@ -1,14 +1,32 @@
 #pragma once
-#include <drogon/HttpSimpleController.h>
+#include <drogon/HttpController.h>
 using namespace drogon;
-class PipeliningTest : public drogon::HttpSimpleController<PipeliningTest>
+// class PipeliningTest : public drogon::HttpSimpleController<PipeliningTest>
+//{
+//   public:
+//     virtual void asyncHandleHttpRequest(
+//         const HttpRequestPtr &req,
+//         std::function<void(const HttpResponsePtr &)> &&callback) override;
+//     PATH_LIST_BEGIN
+//     // list path definitions here;
+//     PATH_ADD("/pipe", Get);
+//     PATH_LIST_END
+// };
+
+class PipeliningTest : public drogon::HttpController<PipeliningTest>
 {
   public:
-    virtual void asyncHandleHttpRequest(
+    METHOD_LIST_BEGIN
+    ADD_METHOD_TO(PipeliningTest::normalPipe, "/pipe", Get);
+    ADD_METHOD_TO(PipeliningTest::strangePipe1, "/pipe/strange-1", Get);
+    ADD_METHOD_TO(PipeliningTest::strangePipe2, "/pipe/strange-2", Get);
+    METHOD_LIST_END
+
+    void normalPipe(
         const HttpRequestPtr &req,
-        std::function<void(const HttpResponsePtr &)> &&callback) override;
-    PATH_LIST_BEGIN
-    // list path definitions here;
-    PATH_ADD("/pipe", Get);
-    PATH_LIST_END
+        std::function<void(const HttpResponsePtr &)> &&callback) const;
+    void strangePipe1(const HttpRequestPtr &req,
+                      std::function<void(const HttpResponsePtr &)> &&callback);
+    void strangePipe2(const HttpRequestPtr &req,
+                      std::function<void(const HttpResponsePtr &)> &&callback);
 };


### PR DESCRIPTION
### Refactors
- Let HttpAppFrameworkImpl manager I/O loops. 
- Simplify TcpServer I/O loop codes.
- Simplify nested if branches in HttpServer and HttpRequestParser.
- Use switch-case instead of multiple else-if in HttpRequestParser::parserRequest().
- Simplify HttpServer request pipelining logic.

### Bugfix
- Fix wrong max method length.
- Fix two potential oom attacks in HttpRequestParser.
- Fix potential pipelining malfunction caused by special callback orders.

### Future TODOs
- Some responses will not go through  pre-sending advices.
- Response sending logic can be more neat.
