### PR TITLE
Changes to free http client if no request is pending

### DIFF
--- a/lib/src/HttpClientImpl.cc
+++ b/lib/src/HttpClientImpl.cc
@@ -280,14 +280,16 @@ struct RequestCallbackParams
     RequestCallbackParams(HttpReqCallback &&cb,
                           HttpClientImplPtr client,
                           HttpRequestPtr req)
-        : callback(cb), clientPtr(client), requestPtr(req)
+        : callback(std::move(cb)),
+          clientPtr(std::move(client)),
+          requestPtr(std::move(req))
     {
     }
 
     const drogon::HttpReqCallback callback;
     const HttpClientImplPtr clientPtr;
     const HttpRequestPtr requestPtr;
-    bool timeoutFlag;
+    bool timeoutFlag{false};
 };
 
 void HttpClientImpl::sendRequestInLoop(const HttpRequestPtr &req,
@@ -312,7 +314,7 @@ void HttpClientImpl::sendRequestInLoop(const HttpRequestPtr &req,
             auto callbackParamsPtr = weakCallbackBackPtr.lock();
             if (callbackParamsPtr != nullptr)
             {
-                auto thisPtr = callbackParamsPtr->clientPtr;
+                auto &thisPtr = callbackParamsPtr->clientPtr;
                 if (callbackParamsPtr->timeoutFlag)
                 {
                     return;

--- a/lib/src/HttpClientImpl.cc
+++ b/lib/src/HttpClientImpl.cc
@@ -275,6 +275,21 @@ void HttpClientImpl::sendRequest(const drogon::HttpRequestPtr &req,
         });
 }
 
+struct RequestCallbackParams
+{
+    RequestCallbackParams(HttpReqCallback &&cb,
+                          HttpClientImplPtr client,
+                          HttpRequestPtr req)
+        : callback(cb), clientPtr(client), requestPtr(req)
+    {
+    }
+
+    const drogon::HttpReqCallback callback;
+    const HttpClientImplPtr clientPtr;
+    const HttpRequestPtr requestPtr;
+    bool timeoutFlag;
+};
+
 void HttpClientImpl::sendRequestInLoop(const HttpRequestPtr &req,
                                        HttpReqCallback &&callback,
                                        double timeout)
@@ -285,52 +300,49 @@ void HttpClientImpl::sendRequestInLoop(const HttpRequestPtr &req,
         return;
     }
 
-    auto timeoutFlag = std::make_shared<bool>(false);
-    auto callbackPtr =
-        std::make_shared<drogon::HttpReqCallback>(std::move(callback));
-    auto thisPtr = shared_from_this();
-    loop_->runAfter(timeout,
-                    [timeoutFlag,
-                     weakCallbackPtr =
-                         std::weak_ptr<HttpReqCallback>(callbackPtr),
-                     reqPtr = std::weak_ptr<HttpRequest>(req),
-                     thisPtr] {
-                        if (*timeoutFlag)
-                        {
-                            return;
-                        }
-                        *timeoutFlag = true;
+    auto callbackParamsPtr =
+        std::make_shared<RequestCallbackParams>(std::move(callback),
+                                                shared_from_this(),
+                                                req);
 
-                        auto req = reqPtr.lock();
-                        if (req != nullptr)
-                        {
-                            for (auto iter = thisPtr->requestsBuffer_.begin();
-                                 iter != thisPtr->requestsBuffer_.end();
-                                 ++iter)
-                            {
-                                if (iter->first == req)
-                                {
-                                    thisPtr->requestsBuffer_.erase(iter);
-                                    break;
-                                }
-                            }
-                        }
+    loop_->runAfter(
+        timeout,
+        [weakCallbackBackPtr =
+             std::weak_ptr<RequestCallbackParams>(callbackParamsPtr)] {
+            auto callbackParamsPtr = weakCallbackBackPtr.lock();
+            if (callbackParamsPtr != nullptr)
+            {
+                auto thisPtr = callbackParamsPtr->clientPtr;
+                if (callbackParamsPtr->timeoutFlag)
+                {
+                    return;
+                }
 
-                        auto callbackPtr = weakCallbackPtr.lock();
-                        if (callbackPtr != nullptr)
-                        {
-                            (*callbackPtr)(ReqResult::Timeout, nullptr);
-                        }
-                    });
+                callbackParamsPtr->timeoutFlag = true;
+
+                for (auto iter = thisPtr->requestsBuffer_.begin();
+                     iter != thisPtr->requestsBuffer_.end();
+                     ++iter)
+                {
+                    if (iter->first == callbackParamsPtr->requestPtr)
+                    {
+                        thisPtr->requestsBuffer_.erase(iter);
+                        break;
+                    }
+                }
+
+                (callbackParamsPtr->callback)(ReqResult::Timeout, nullptr);
+            }
+        });
     sendRequestInLoop(req,
-                      [timeoutFlag, callbackPtr](ReqResult r,
-                                                 const HttpResponsePtr &resp) {
-                          if (*timeoutFlag)
+                      [callbackParamsPtr](ReqResult r,
+                                          const HttpResponsePtr &resp) {
+                          if (callbackParamsPtr->timeoutFlag)
                           {
                               return;
                           }
-                          *timeoutFlag = true;
-                          (*callbackPtr)(r, resp);
+                          callbackParamsPtr->timeoutFlag = true;
+                          (callbackParamsPtr->callback)(r, resp);
                       });
 }
 

--- a/lib/tests/integration_test/client/main.cc
+++ b/lib/tests/integration_test/client/main.cc
@@ -1189,6 +1189,35 @@ DROGON_TEST(HttpsTest)
     doTest(client, TEST_CTX);
 }
 
+DROGON_TEST(HttpsTimeoutTest)
+{
+    if (!app().supportSSL())
+        return;
+
+    auto client = HttpClient::newHttpClient("https://127.0.0.1:8849",
+                                            app().getLoop(),
+                                            false,
+                                            false);
+    auto req = HttpRequest::newHttpRequest();
+    req->setPath("/api/v1/apitest/static");
+    req->setMethod(drogon::Get);
+    auto weakClient = std::weak_ptr<HttpClient>(client);
+    auto weakReq = std::weak_ptr<HttpRequest>(req);
+    client->sendRequest(
+        req,
+        [weakClient, weakReq, TEST_CTX](ReqResult result,
+                                        const HttpResponsePtr &resp) {
+            REQUIRE(result == ReqResult::Ok);
+            CHECK(resp->getStatusCode() == k200OK);
+
+            app().getLoop()->queueInLoop([weakClient, weakReq, TEST_CTX]() {
+                CHECK(weakReq.expired());
+                CHECK(weakClient.expired());
+            });
+        },
+        60);
+}
+
 int main(int argc, char **argv)
 {
     trantor::Logger::setLogLevel(trantor::Logger::LogLevel::kDebug);


### PR DESCRIPTION
Expires client object quicker by using weak_ptr with timeout. Without this fix the client remains until all the requests have completed processing their timeout callbacks.

Fixes: https://github.com/drogonframework/drogon/issues/1510