### PR TITLE
Fix WebSocket client bad_weak_ptr if the client destruced in message handler

### DIFF
--- a/lib/src/WebSocketConnectionImpl.cc
+++ b/lib/src/WebSocketConnectionImpl.cc
@@ -372,6 +372,7 @@ void WebSocketConnectionImpl::onNewMessage(
     const trantor::TcpConnectionPtr &connPtr,
     trantor::MsgBuffer *buffer)
 {
+    auto self = shared_from_this();
     while (buffer->readableBytes() > 0)
     {
         auto success = parser_.parse(buffer);
@@ -397,7 +398,7 @@ void WebSocketConnectionImpl::onNewMessage(
                 }
                 // LOG_TRACE << "new message received: " << message
                 //           << "\n(type=" << (int)type << ")";
-                messageCallback_(std::move(message), shared_from_this(), type);
+                messageCallback_(std::move(message), self, type);
             }
             else
             {


### PR DESCRIPTION
This PR fixes crash due to `bad_shared_ptr` when a websocket client is destructed during message processing. In the following condition

* WS client is created and connected to server
* Server sends us the data we want and the server closes the connection
* We trigger a the WS client to destruct inside the message handler

This causes the WebSocket close handler to be processed after destruction. Thus `bad_weak_ptr`

Example code
```c++
Task<> service()
{
    auto client = WebSocketClient::newWebSocketClient("ws://127.0.0.1:7860");
    client->setMessageHandler([](std::string &&message,
                                   const WebSocketClientPtr &client,
                                   const WebSocketMessageType &type)
    {
        // The server sends us the data we want. Exit. This causes the coroutine to end. Destructing the client.
        // The client crash on handling the "close" message because there 0 references to the client
        app().quit();
    });

    co_await client->connectToServerCoro(req);
    LOG_INFO << "Connected to server";
    co_await untilQuit(app().getLoop());
}
```