### PR TITLE
Use syncAdvices.empty() to check empty.

### DIFF
--- a/lib/src/HttpServer.cc
+++ b/lib/src/HttpServer.cc
@@ -93,7 +93,6 @@ HttpServer::HttpServer(
       newWebsocketCallback_(defaultWebSockAsyncCallback),
       connectionCallback_(defaultConnectionCallback),
       syncAdvices_(syncAdvices),
-      hasSyncAdvices_(!syncAdvices.empty()),
       preSendingAdvices_(preSendingAdvices)
 {
     server_.setConnectionCallback(
@@ -280,7 +279,7 @@ void HttpServer::onRequests(
             requestParser->pushRequestToPipelining(req, isHeadMethod);
             reqPipelined = true;
         }
-        if (hasSyncAdvices_ &&
+        if (!syncAdvices_.empty() &&
             !passSyncAdvices(
                 req, requestParser, syncAdvices_, reqPipelined, isHeadMethod))
         {

--- a/lib/src/HttpServer.h
+++ b/lib/src/HttpServer.h
@@ -121,7 +121,6 @@ class HttpServer : trantor::NonCopyable
     trantor::ConnectionCallback connectionCallback_;
     const std::vector<std::function<HttpResponsePtr(const HttpRequestPtr &)>>
         &syncAdvices_;
-    const bool hasSyncAdvices_;
     const std::vector<
         std::function<void(const HttpRequestPtr &, const HttpResponsePtr &)>>
         &preSendingAdvices_;


### PR DESCRIPTION
To be consistent with previous behavior, we use syncAdvices_.empty() to check.

However it should be noted that,
the const reference member is allowed to be modified outside, which is NOT a thread safe action.
We should make a change in the future.
