### PR TITLE
Fix generation of JSON field validation for short type.

### DIFF
--- a/drogon_ctl/templates/model_cc.csp
+++ b/drogon_ctl/templates/model_cc.csp
@@ -1492,7 +1492,7 @@ if(!col.notNull_){%>
             }
 <%c++
             }
-            else if(col.colType_.find("int") == 0)
+            else if(col.colType_.find("int") == 0 || col.colType_ == "short")
             {
 %>
             if(!pJson.isInt())


### PR DESCRIPTION
## Bug

`drogon_ctl` generates model files using *short* datatype fields to represent Postgres's SMALLINT datatype.
However, the template used to generate the model files didn't consider shorts when validating input field types.
This resulted in *shorts* falling under the *string* catchall within `validJsonOfField`. This caused the generated model's `validateJsonFor*` functions to only accept *string* input for *short* fields, not integers.

## Change

Added condition for shorts such that jsoncpp's `isInt()` check is applied to *short*  fields. This pattern is used elsewhere  ([example](https://github.com/drogonframework/drogon/blob/master/drogon_ctl/templates/model_cc.csp#L410)).
