### PR TITLE
Replace redundant unique_ptr<string> with just string

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ CMakeSettings.json
 install
 trace.json
 .cache/
+compile_commands.json

--- a/lib/src/HttpMessageBody.h
+++ b/lib/src/HttpMessageBody.h
@@ -121,40 +121,38 @@ class HttpMessageStringViewBody : public HttpMessageBody
     }
     const std::string &getString() const override
     {
-        if (!bodyString_)
+        if (bodyString_.empty())
         {
             if (!body_.empty())
             {
-                bodyString_ =
-                    std::make_unique<std::string>(body_.data(), body_.length());
+                bodyString_ = body_;
             }
             else
             {
-                bodyString_ = std::make_unique<std::string>();
+                bodyString_.clear();
             }
         }
-        return *bodyString_;
+        return bodyString_;
     }
     std::string &getString() override
     {
-        if (!bodyString_)
+        if (bodyString_.empty())
         {
             if (!body_.empty())
             {
-                bodyString_ =
-                    std::make_unique<std::string>(body_.data(), body_.length());
+                bodyString_ = body_;
             }
             else
             {
-                bodyString_ = std::make_unique<std::string>();
+                bodyString_.clear();
             }
         }
-        return *bodyString_;
+        return bodyString_;
     }
 
   private:
     string_view body_;
-    mutable std::unique_ptr<std::string> bodyString_;
+    mutable std::string bodyString_;
 };
 
 }  // namespace drogon

--- a/lib/src/HttpMessageBody.h
+++ b/lib/src/HttpMessageBody.h
@@ -125,11 +125,7 @@ class HttpMessageStringViewBody : public HttpMessageBody
         {
             if (!body_.empty())
             {
-                bodyString_ = body_;
-            }
-            else
-            {
-                bodyString_.clear();
+                bodyString_ = std::string(body_.begin(), body_.end());
             }
         }
         return bodyString_;
@@ -140,11 +136,7 @@ class HttpMessageStringViewBody : public HttpMessageBody
         {
             if (!body_.empty())
             {
-                bodyString_ = body_;
-            }
-            else
-            {
-                bodyString_.clear();
+                bodyString_ = std::string(body_.begin(), body_.end());
             }
         }
         return bodyString_;


### PR DESCRIPTION
Unique_ptr here is redundant and inefficient. Strings already have empty state - its called empty string.

Is this class even needed? `grep --include="*.h" --include="*.cc" -Rin HttpMessageStringViewBody` resulted in only one usage [here](https://github.com/drogonframework/drogon/blob/abee656699072e8750a054dfa27ab0775baeddfe/lib/src/HttpResponseImpl.h#L423). I think it's pointless to store owning string right next to non-owning string_view to it.