### PR TITLE
Strip trailing whitespace with 'ENTER roomnumber' in Redis Chat example code

### DIFF
--- a/examples/redis_chat/controllers/Chat.cc
+++ b/examples/redis_chat/controllers/Chat.cc
@@ -80,7 +80,7 @@ void Chat::handleNewMessage(const WebSocketConnectionPtr& wsConnPtr,
     std::string room;
     if (message.compare(0, 6, "ENTER ") == 0)
     {
-        room = message.substr(6);
+        room = message.substr(6, message.find_last_not_of(" \n") - 5);
         if (!checkRoomNumber(room))
         {
             wsConnPtr->send("ERROR: Invalid room number, should be [0-99].");


### PR DESCRIPTION
I am on a Mac M1 Ventura 13.0, and when I attempt to build and run the Redis Chat example code I got the following error:

```
ERROR: Not in room. Send 'ENTER roomNo' to enter a room first.
ENTER 1
ERROR: Invalid room number, should be [0-99].
```

In a debugger, `std::string room` is appearing as `1\n`, which fails the `checkRoomNumber()` check, even though the input is valid. As a result, I have fixed this by stripping any trailing whitespace that occurs in the parsed room number, so now the example code is working very well on my end :) This fix should play well with other platforms as well,

I am loving Drogon, thanks to the maintainers!

Regards,
Tim