### PR TITLE
Possibility to add plugins without config file

### DIFF
--- a/lib/inc/drogon/HttpAppFramework.h
+++ b/lib/inc/drogon/HttpAppFramework.h
@@ -731,6 +731,26 @@ class DROGON_EXPORT HttpAppFramework : public trantor::NonCopyable
         const std::vector<std::pair<std::string, std::string>>
             &sslConfCmds) = 0;
 
+    /// Add plugins 
+    /**
+     * @param configs The plugins array
+     *
+     * @note
+     * This operation can be performed by an option in the configuration file.
+    */
+    virtual void addPlugins(const Json::Value& configs) = 0;
+
+    /// Add a plugin
+    /**
+     * @param name Name of the plugin
+     * @param dependencies Names of plugins this plugin depends on
+     * @param config Custom config for the plugin
+    */
+    virtual void addPlugin(
+        const std::string& name, 
+        const std::vector<std::string>& dependencies, 
+        const Json::Value& config) = 0;
+
     /// Add a listener for http or https service
     /**
      * @param ip is the ip that the listener listens on.

--- a/lib/inc/drogon/HttpAppFramework.h
+++ b/lib/inc/drogon/HttpAppFramework.h
@@ -731,25 +731,24 @@ class DROGON_EXPORT HttpAppFramework : public trantor::NonCopyable
         const std::vector<std::pair<std::string, std::string>>
             &sslConfCmds) = 0;
 
-    /// Add plugins 
+    /// Add plugins
     /**
      * @param configs The plugins array
      *
      * @note
      * This operation can be performed by an option in the configuration file.
-    */
-    virtual void addPlugins(const Json::Value& configs) = 0;
+     */
+    virtual void addPlugins(const Json::Value &configs) = 0;
 
     /// Add a plugin
     /**
      * @param name Name of the plugin
      * @param dependencies Names of plugins this plugin depends on
      * @param config Custom config for the plugin
-    */
-    virtual void addPlugin(
-        const std::string& name, 
-        const std::vector<std::string>& dependencies, 
-        const Json::Value& config) = 0;
+     */
+    virtual void addPlugin(const std::string &name,
+                           const std::vector<std::string> &dependencies,
+                           const Json::Value &config) = 0;
 
     /// Add a listener for http or https service
     /**

--- a/lib/src/HttpAppFrameworkImpl.cc
+++ b/lib/src/HttpAppFrameworkImpl.cc
@@ -349,29 +349,30 @@ PluginBase *HttpAppFrameworkImpl::getPlugin(const std::string &name)
     return pluginsManagerPtr_->getPlugin(name);
 }
 void HttpAppFrameworkImpl::addPlugin(
-    const std::string& name, 
-    const std::vector<std::string>& dependencies, 
-    const Json::Value& config)
+    const std::string &name,
+    const std::vector<std::string> &dependencies,
+    const Json::Value &config)
 {
     assert(!isRunning());
     Json::Value pluginConfig;
     pluginConfig["name"] = name;
     Json::Value deps(Json::arrayValue);
-    for(const auto dep : dependencies)
+    for (const auto dep : dependencies)
     {
         deps.append(dep);
     }
     pluginConfig["dependencies"] = deps;
     pluginConfig["config"] = config;
-    auto& plugins = jsonRuntimeConfig_["plugins"];
+    auto &plugins = jsonRuntimeConfig_["plugins"];
     plugins.append(pluginConfig);
 }
-void HttpAppFrameworkImpl::addPlugins(const Json::Value& configs)
+void HttpAppFrameworkImpl::addPlugins(const Json::Value &configs)
 {
     assert(!isRunning());
     assert(configs.isArray());
-    auto& plugins = jsonRuntimeConfig_["plugins"];
-    for(const auto config : configs){
+    auto &plugins = jsonRuntimeConfig_["plugins"];
+    for (const auto config : configs)
+    {
         plugins.append(config);
     }
 }
@@ -614,9 +615,9 @@ void HttpAppFrameworkImpl::run()
     const auto &runtumePluginConfig = jsonRuntimeConfig_["plugins"];
     if (!pluginConfig.isNull())
     {
-        if(!runtumePluginConfig.isNull() && runtumePluginConfig.isArray())
+        if (!runtumePluginConfig.isNull() && runtumePluginConfig.isArray())
         {
-            for(const auto& plugin : runtumePluginConfig)
+            for (const auto &plugin : runtumePluginConfig)
             {
                 pluginConfig.append(plugin);
             }

--- a/lib/src/HttpAppFrameworkImpl.cc
+++ b/lib/src/HttpAppFrameworkImpl.cc
@@ -353,21 +353,24 @@ void HttpAppFrameworkImpl::addPlugin(
     const std::vector<std::string>& dependencies, 
     const Json::Value& config)
 {
+    assert(!isRunning());
     Json::Value pluginConfig;
     pluginConfig["name"] = name;
     Json::Value deps(Json::arrayValue);
-    for(const auto dep : dependencies) {
+    for(const auto dep : dependencies)
+    {
         deps.append(dep);
     }
     pluginConfig["dependencies"] = deps;
     pluginConfig["config"] = config;
-    auto& plugins = jsonConfig_["plugins"];
+    auto& plugins = jsonRuntimeConfig_["plugins"];
     plugins.append(pluginConfig);
 }
 void HttpAppFrameworkImpl::addPlugins(const Json::Value& configs)
 {
+    assert(!isRunning());
     assert(configs.isArray());
-    auto& plugins = jsonConfig_["plugins"];
+    auto& plugins = jsonRuntimeConfig_["plugins"];
     for(const auto config : configs){
         plugins.append(config);
     }
@@ -607,7 +610,22 @@ void HttpAppFrameworkImpl::run()
     // now start running!!
     running_ = true;
     // Initialize plugins
-    const auto &pluginConfig = jsonConfig_["plugins"];
+    auto &pluginConfig = jsonConfig_["plugins"];
+    const auto &runtumePluginConfig = jsonRuntimeConfig_["plugins"];
+    if (!pluginConfig.isNull())
+    {
+        if(!runtumePluginConfig.isNull() && runtumePluginConfig.isArray())
+        {
+            for(const auto& plugin : runtumePluginConfig)
+            {
+                pluginConfig.append(plugin);
+            }
+        }
+    }
+    else
+    {
+        jsonConfig_["plugins"] = runtumePluginConfig;
+    }
     if (!pluginConfig.isNull())
     {
         pluginsManagerPtr_->initializeAllPlugins(pluginConfig,

--- a/lib/src/HttpAppFrameworkImpl.cc
+++ b/lib/src/HttpAppFrameworkImpl.cc
@@ -348,6 +348,30 @@ PluginBase *HttpAppFrameworkImpl::getPlugin(const std::string &name)
 {
     return pluginsManagerPtr_->getPlugin(name);
 }
+void HttpAppFrameworkImpl::addPlugin(
+    const std::string& name, 
+    const std::vector<std::string>& dependencies, 
+    const Json::Value& config)
+{
+    Json::Value pluginConfig;
+    pluginConfig["name"] = name;
+    Json::Value deps(Json::arrayValue);
+    for(const auto dep : dependencies) {
+        deps.append(dep);
+    }
+    pluginConfig["dependencies"] = deps;
+    pluginConfig["config"] = config;
+    auto& plugins = jsonConfig_["plugins"];
+    plugins.append(pluginConfig);
+}
+void HttpAppFrameworkImpl::addPlugins(const Json::Value& configs)
+{
+    assert(configs.isArray());
+    auto& plugins = jsonConfig_["plugins"];
+    for(const auto config : configs){
+        plugins.append(config);
+    }
+}
 HttpAppFramework &HttpAppFrameworkImpl::addListener(
     const std::string &ip,
     uint16_t port,

--- a/lib/src/HttpAppFrameworkImpl.h
+++ b/lib/src/HttpAppFrameworkImpl.h
@@ -57,11 +57,10 @@ class HttpAppFrameworkImpl final : public HttpAppFramework
     }
 
     PluginBase *getPlugin(const std::string &name) override;
-    void addPlugins(const Json::Value& configs);
-    void addPlugin(
-        const std::string& name, 
-        const std::vector<std::string>& dependencies, 
-        const Json::Value& config);
+    void addPlugins(const Json::Value &configs);
+    void addPlugin(const std::string &name,
+                   const std::vector<std::string> &dependencies,
+                   const Json::Value &config);
     HttpAppFramework &addListener(
         const std::string &ip,
         uint16_t port,

--- a/lib/src/HttpAppFrameworkImpl.h
+++ b/lib/src/HttpAppFrameworkImpl.h
@@ -57,6 +57,11 @@ class HttpAppFrameworkImpl final : public HttpAppFramework
     }
 
     PluginBase *getPlugin(const std::string &name) override;
+    void addPlugins(const Json::Value& configs);
+    void addPlugin(
+        const std::string& name, 
+        const std::vector<std::string>& dependencies, 
+        const Json::Value& config);
     HttpAppFramework &addListener(
         const std::string &ip,
         uint16_t port,

--- a/lib/src/HttpAppFrameworkImpl.h
+++ b/lib/src/HttpAppFrameworkImpl.h
@@ -698,6 +698,7 @@ class HttpAppFrameworkImpl final : public HttpAppFramework
     std::vector<AdviceDestroySessionCallback> sessionDestroyAdvices_;
     std::shared_ptr<trantor::AsyncFileLogger> asyncFileLoggerPtr_;
     Json::Value jsonConfig_;
+    Json::Value jsonRuntimeConfig_;
     HttpResponsePtr custom404_;
     std::function<HttpResponsePtr(HttpStatusCode)> customErrorHandler_ =
         &defaultErrorHandler;


### PR DESCRIPTION
Someone can use limited subset of config settings(and another file settings format, toml for example) accepting defaults mostly.
For most settings it's ok, except plugins. 
There no a possibility to add plugins at runtime like listeners (drogon::app().addListener)
Suggested such functionality (drogon::app().addPlugin[s])