### PR TITLE
fix error: conversion from ‘long int’ to ‘Json::Value’ is ambiguous

### DIFF
--- a/lib/src/YamlConfigAdapter.cc
+++ b/lib/src/YamlConfigAdapter.cc
@@ -18,7 +18,7 @@ static bool yaml2json(const Node &node, Json::Value &jsonValue)
         {
             try
             {
-                jsonValue = node.as<int64_t>();
+                jsonValue = node.as<Json::Value::Int64>();
                 return true;
             }
             catch (const YAML::BadConversion &e)


### PR DESCRIPTION
Resolve Compile Error:

YamlConfigAdapter.cc: In function ‘bool YAML::yaml2json(const YAML::Node&, Json::Value&)’:
YamlConfigAdapter.cc:21:46: error: conversion from ‘long int’ to ‘Json::Value’ is ambiguous
   21 |                 jsonValue = node.as<int64_t>();