### PR TITLE
add webp and svg to the default file_types

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -145,7 +145,9 @@
             "xap",
             "apk",
             "cur",
-            "xml"
+            "xml",
+            "webp",
+            "svg"
         ],
         // mime: A dictionary that extends the internal MIME type support. Maps extensions into new MIME types
         // note: This option only adds MIME to the sever. `file_types` above have to be set for the server to serve them.

--- a/drogon_ctl/templates/config.csp
+++ b/drogon_ctl/templates/config.csp
@@ -145,7 +145,9 @@
             "xap",
             "apk",
             "cur",
-            "xml"
+            "xml",
+            "svg",
+            "webp"
         ],
         // mime: A dictionary that extends the internal MIME type support. Maps extensions into new MIME types
         // note: This option only adds MIME to the sever. `file_types` above have to be set for the server to serve them.


### PR DESCRIPTION
I was wandering in the code and wondering why my svg logos and webp images weren't loading my static site. I added em to the config.json list under file_types and tada! The logo and webp images populated. :tada: 