### PR TITLE
Update SqlBinder.h to fix build failure on Raspberry Pi OS

### DIFF
--- a/orm_lib/inc/drogon/orm/SqlBinder.h
+++ b/orm_lib/inc/drogon/orm/SqlBinder.h
@@ -63,10 +63,12 @@ template <typename T>
 constexpr T htonT(T value) noexcept
 {
 #if __BYTE_ORDER == __LITTLE_ENDIAN
-    char *ptr = reinterpret_cast<char *>(&value);
-    std::reverse(ptr, ptr + sizeof(T));
-#endif
+    return (std::reverse(reinterpret_cast<char *>(&value),
+                         reinterpret_cast<char *>(&value) + sizeof(T)),
+            value);
+#else
     return value;
+#endif
 }
 inline uint64_t htonll(uint64_t value)
 {


### PR DESCRIPTION
On a fully updated Rasperry Pi OS using Raspberry Pi OS 2023-05-03 Drogon built fine, but a project linking to/including drogon would fail to build with `/usr/local/include/drogon/orm/SqlBinder.h:70:1: error: body of ‘constexpr’ function ‘constexpr T htonT(T) [with T = long unsigned int]’ not a return-statement 70 | }`.

Compiler details:
    $ gcc -v
    Using built-in specs.
    COLLECT_GCC=gcc
    COLLECT_LTO_WRAPPER=/usr/lib/gcc/aarch64-linux-gnu/10/lto-wrapper
    Target: aarch64-linux-gnu
    Configured with: ../src/configure -v --with-pkgversion='Debian 10.2.1-6' --with-bugurl=file:///usr/share/doc/gcc-10/README.Bugs --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2 --prefix=/usr --with-gcc-major-version-only --program-suffix=-10 --program-prefix=aarch64-linux-gnu- --enable-shared --enable-linker-build-id --libexecdir=/usr/lib --without-included-gettext --enable-threads=posix --libdir=/usr/lib --enable-nls --enable-bootstrap --enable-clocale=gnu --enable-libstdcxx-debug --enable-libstdcxx-time=yes --with-default-libstdcxx-abi=new --enable-gnu-unique-object --disable-libquadmath --disable-libquadmath-support --enable-plugin --enable-default-pie --with-system-zlib --enable-libphobos-checking=release --with-target-system-zlib=auto --enable-objc-gc=auto --enable-multiarch --enable-fix-cortex-a53-843419 --disable-werror --enable-checking=release --build=aarch64-linux-gnu --host=aarch64-linux-gnu --target=aarch64-linux-gnu --with-build-config=bootstrap-lto-lean --enable-link-mutex
    Thread model: posix
    Supported LTO compression algorithms: zlib zstd
    gcc version 10.2.1 20210110 (Debian 10.2.1-6)

This is a proposed fix for this issue that adjusts this function to be a pair of IFDEFed return statements based on network byte order as the original function appeared to intend. This makes it so the function body is entirely a single return statement on each platform. 

The error message from the C++17 compiler (which is the latest version supported on Raspberry Pi OS currently) indicates that constexpr functions must be entirely single return statements.

I read contribution guidelines, and I think I have followed them. I ran format.sh and used a branch name starting wtih "bugfix" as indicated. Let me know if there is anything I need to contribute this or even if you just think there is a better way to do this.