### PR TITLE
Revert modifications to the type of clientMaxBodySize

### DIFF
--- a/lib/src/HttpAppFrameworkImpl.h
+++ b/lib/src/HttpAppFrameworkImpl.h
@@ -356,7 +356,7 @@ class HttpAppFrameworkImpl final : public HttpAppFramework
     }
     HttpAppFramework &setGzipStatic(bool useGzipStatic) override;
     HttpAppFramework &setBrStatic(bool useGzipStatic) override;
-    HttpAppFramework &setClientMaxBodySize(uint64_t maxSize) override
+    HttpAppFramework &setClientMaxBodySize(size_t maxSize) override
     {
         clientMaxBodySize_ = maxSize;
         return *this;
@@ -405,7 +405,7 @@ class HttpAppFrameworkImpl final : public HttpAppFramework
     HttpAppFramework &setImplicitPage(
         const std::string &implicitPageFile) override;
     const std::string &getImplicitPage() const override;
-    uint64_t getClientMaxBodySize() const
+    size_t getClientMaxBodySize() const
     {
         return clientMaxBodySize_;
     }
@@ -686,7 +686,7 @@ class HttpAppFrameworkImpl final : public HttpAppFramework
     std::pair<unsigned int, std::string> floatPrecisionInJson_{0,
                                                                "significant"};
     bool usingCustomErrorHandler_{false};
-    uint64_t clientMaxBodySize_{1024 * 1024};
+    size_t clientMaxBodySize_{1024 * 1024};
     size_t clientMaxMemoryBodySize_{64 * 1024};
     size_t clientMaxWebSocketMessageSize_{128 * 1024};
     std::string homePageFile_{"index.html"};


### PR DESCRIPTION
The maximum amount of memory that can be managed in a 32-bit system is 4GB, and the parameter type of the mmap function is also size_t. For these reasons, the patch #1592  did not have the expected effect and even caused some potential issues (such as #1594). Therefore, we have to revert to the size_t version. I apologize for my oversight.