### PR TITLE
Add SlashRemover plugin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -302,6 +302,7 @@ set(DROGON_SOURCES
     lib/src/SlidingWindowRateLimiter.cc
     lib/src/TokenBucketRateLimiter.cc
     lib/src/Hodor.cc
+    lib/src/SlashRemover.cc
     lib/src/drogon_test.cc
     lib/src/ConfigAdapterManager.cc
     lib/src/JsonConfigAdapter.cc
@@ -731,6 +732,7 @@ set(DROGON_PLUGIN_HEADERS
     lib/inc/drogon/plugins/AccessLogger.h
     lib/inc/drogon/plugins/RealIpResolver.h
     lib/inc/drogon/plugins/Hodor.h
+    lib/inc/drogon/plugins/SlashRemover.h
     lib/inc/drogon/plugins/GlobalFilters.h)
 
 install(FILES ${DROGON_PLUGIN_HEADERS}

--- a/lib/inc/drogon/drogon.h
+++ b/lib/inc/drogon/drogon.h
@@ -31,6 +31,7 @@
 #include <drogon/plugins/AccessLogger.h>
 #include <drogon/plugins/RealIpResolver.h>
 #include <drogon/plugins/Hodor.h>
+#include <drogon/plugins/SlashRemover.h>
 #include <drogon/plugins/GlobalFilters.h>
 #include <drogon/IntranetIpFilter.h>
 #include <drogon/LocalHostFilter.h>

--- a/lib/inc/drogon/plugins/SlashRemover.h
+++ b/lib/inc/drogon/plugins/SlashRemover.h
@@ -35,8 +35,9 @@ example.com/ -> example.com
         // If true, it removes all duplicate slashes, e.g.
 example.com///home -> example.com/home
         "remove_duplicate_slashes": true,
-                // If true, redirects the request, otherwise forwards
-internally. "redirect": true
+        // If true, redirects the request, otherwise forwards
+internally.
+        "redirect": true
      }
   }
   @endcode

--- a/lib/inc/drogon/plugins/SlashRemover.h
+++ b/lib/inc/drogon/plugins/SlashRemover.h
@@ -34,7 +34,9 @@ example.com/ -> example.com
         "remove_trailing_slashes": true,
         // If true, it removes all duplicate slashes, e.g.
 example.com///home -> example.com/home
-        "remove_duplicate_slashes": true
+        "remove_duplicate_slashes": true,
+                // If true, redirects the request, otherwise forwards
+internally. "redirect": true
      }
   }
   @endcode
@@ -52,7 +54,6 @@ class DROGON_EXPORT SlashRemover : public drogon::Plugin<SlashRemover>
     void shutdown() override;
 
   private:
-    bool trailingSlashes_{true};
-    bool duplicateSlashes_{true};
+    bool trailingSlashes_{true}, duplicateSlashes_{true}, redirect_{true};
 };
 }  // namespace drogon::plugin

--- a/lib/inc/drogon/plugins/SlashRemover.h
+++ b/lib/inc/drogon/plugins/SlashRemover.h
@@ -30,10 +30,10 @@ namespace drogon::plugin
      "dependencies": [],
      "config": {
         // If true, it removes all trailing slashes, e.g.
-example.com/ -> example.com
+///home// -> ///home
         "remove_trailing_slashes": true,
         // If true, it removes all duplicate slashes, e.g.
-example.com///home -> example.com/home
+///home// -> /home/
         "remove_duplicate_slashes": true,
         // If true, redirects the request, otherwise forwards
 internally.

--- a/lib/inc/drogon/plugins/SlashRemover.h
+++ b/lib/inc/drogon/plugins/SlashRemover.h
@@ -2,7 +2,7 @@
  *  @file SlashRemover.h
  *  @author Mis1eader
  *
- *  Copyright 2018, Mis1eader.  All rights reserved.
+ *  Copyright 2023, Mis1eader.  All rights reserved.
  *  https://github.com/an-tao/drogon
  *  Use of this source code is governed by a MIT license
  *  that can be found in the License file.

--- a/lib/inc/drogon/plugins/SlashRemover.h
+++ b/lib/inc/drogon/plugins/SlashRemover.h
@@ -1,0 +1,58 @@
+/**
+ *  @file SlashRemover.h
+ *  @author Mis1eader
+ *
+ *  Copyright 2018, Mis1eader.  All rights reserved.
+ *  https://github.com/an-tao/drogon
+ *  Use of this source code is governed by a MIT license
+ *  that can be found in the License file.
+ *
+ *  Drogon
+ *
+ */
+
+#pragma once
+
+#include "drogon/plugins/Plugin.h"
+#include "drogon/utils/FunctionTraits.h"
+#include <json/value.h>
+
+namespace drogon::plugin
+{
+/**
+ * @brief The SlashRemover plugin redirects requests to proper paths if they
+ * contain excessive slashes.
+ * The json configuration is as follows:
+ *
+ * @code
+  {
+     "name": "drogon::plugin::SlashRemover",
+     "dependencies": [],
+     "config": {
+        // If true, it removes all trailing slashes, e.g.
+example.com/ -> example.com
+        "remove_trailing_slashes": true,
+        // If true, it removes all duplicate slashes, e.g.
+example.com///home -> example.com/home
+        "remove_duplicate_slashes": true
+     }
+  }
+  @endcode
+ *
+ * Enable the plugin by adding the configuration to the list of plugins in the
+ * configuration file.
+ * */
+class DROGON_EXPORT SlashRemover : public drogon::Plugin<SlashRemover>
+{
+  public:
+    SlashRemover()
+    {
+    }
+    void initAndStart(const Json::Value &config) override;
+    void shutdown() override;
+
+  private:
+    bool trailingSlashes_{true};
+    bool duplicateSlashes_{true};
+};
+}  // namespace drogon::plugin

--- a/lib/src/Hodor.cc
+++ b/lib/src/Hodor.cc
@@ -204,7 +204,7 @@ void Hodor::onHttpRequest(const drogon::HttpRequestPtr &req,
                           drogon::AdviceCallback &&adviceCallback,
                           drogon::AdviceChainCallback &&chainCallback)
 {
-    std::string ip =
+    auto ip =
         (useRealIpResolver_ ? drogon::plugin::RealIpResolver::GetRealAddr(req)
                             : req->peerAddr())
             .toIpNetEndian();

--- a/lib/src/Hodor.cc
+++ b/lib/src/Hodor.cc
@@ -1,8 +1,5 @@
 #include <drogon/plugins/Hodor.h>
 #include <drogon/plugins/RealIpResolver.h>
-#include <netinet/in.h>
-#include <cstring>
-#include "trantor/net/InetAddress.h"
 
 using namespace drogon::plugin;
 Hodor::LimitStrategy Hodor::makeLimitStrategy(const Json::Value &config)
@@ -203,29 +200,14 @@ bool Hodor::checkLimit(const drogon::HttpRequestPtr &req,
     }
     return true;
 }
-void extractIp(const trantor::InetAddress &from, std::string &to)
-{
-    if (from.isIpV6())
-    {
-        static constexpr auto bytes = sizeof(in6_addr);
-        to.resize(bytes);
-        std::memcpy(&to[0], from.ip6NetEndian(), bytes);
-        return;
-    }
-    const auto ip = from.ipNetEndian();
-    static constexpr auto bytes = sizeof(ip);
-    to.resize(bytes);
-    std::memcpy(&to[0], &ip, bytes);
-}
 void Hodor::onHttpRequest(const drogon::HttpRequestPtr &req,
                           drogon::AdviceCallback &&adviceCallback,
                           drogon::AdviceChainCallback &&chainCallback)
 {
-    std::string ip;
-    extractIp(useRealIpResolver_
-                  ? drogon::plugin::RealIpResolver::GetRealAddr(req)
-                  : req->peerAddr(),
-              ip);
+    std::string ip =
+        (useRealIpResolver_ ? drogon::plugin::RealIpResolver::GetRealAddr(req)
+                            : req->peerAddr())
+            .toIpNetEndian();
     optional<std::string> userId;
     if (userIdGetter_)
     {

--- a/lib/src/SlashRemover.cc
+++ b/lib/src/SlashRemover.cc
@@ -11,6 +11,12 @@ using std::string;
 #define TRAILING_SLASH_REGEX ".+\\/$"
 #define DUPLICATE_SLASH_REGEX ".*\\/{2,}.*"
 
+inline constexpr const char* regexes[] = {
+    TRAILING_SLASH_REGEX,
+    DUPLICATE_SLASH_REGEX,
+    TRAILING_SLASH_REGEX "|" DUPLICATE_SLASH_REGEX,
+};
+
 static inline bool removeTrailingSlashes(string& url)
 {
     // If only contains '/', it will return -1, and added with 1 it will be 0,
@@ -59,8 +65,8 @@ void SlashRemover::initAndStart(const Json::Value& config)
     if (!removerFunctionMask)
         return;
     app().registerHandlerViaRegex(
-        TRAILING_SLASH_REGEX,
         [removerFunctionMask,
+        regexes[removeMode - 1],
          this](const HttpRequestPtr& req,
                std::function<void(const HttpResponsePtr&)>&& callback) {
             string newPath = req->path();

--- a/lib/src/SlashRemover.cc
+++ b/lib/src/SlashRemover.cc
@@ -9,7 +9,7 @@ using namespace plugin;
 using std::string;
 
 #define TRAILING_SLASH_REGEX ".+\\/$"
-#define DUPLICATE_SLASH_REGEX ".*\\/{2}.*"
+#define DUPLICATE_SLASH_REGEX ".*\\/{2,}.*"
 
 static bool removeTrailingSlashes(string& url)
 {

--- a/lib/src/SlashRemover.cc
+++ b/lib/src/SlashRemover.cc
@@ -25,8 +25,11 @@ static inline bool removeTrailingSlashes(string& url)
 }
 static inline void removeDuplicateSlashes(string& url)
 {
-    size_t a = 0;
-    for (size_t b = 1, len = url.size(); b < len; ++b)
+    size_t a = 1, len = url.size();
+    for (; a < len && (url[a - 1] != '/' || url[a] != '/'); ++a)
+    {
+    }
+    for (size_t b = --a + 1; b < len; ++b)
     {
         const char c = url[b];
         if (c != '/' || url[a] != '/')

--- a/lib/src/SlashRemover.cc
+++ b/lib/src/SlashRemover.cc
@@ -11,7 +11,7 @@ using std::string;
 #define TRAILING_SLASH_REGEX "^.+\\/$"
 #define DUPLICATE_SLASH_REGEX "^.+\\/{2}.*$"
 
-bool removeTrailingSlashes(string& url)
+static bool removeTrailingSlashes(string& url)
 {
     // If only contains '/', it will return -1, and added with 1 it will be 0,
     // hence empty, meaning root
@@ -23,7 +23,7 @@ bool removeTrailingSlashes(string& url)
     }
     return false;
 }
-void removeDuplicateSlashes(string& url)
+static void removeDuplicateSlashes(string& url)
 {
     size_t a = 0;
     for (size_t b = 1, len = url.size(); b < len; ++b)
@@ -34,7 +34,7 @@ void removeDuplicateSlashes(string& url)
     }
     url.resize(a + 1);
 }
-void removeExcessiveSlashes(string& url)
+static void removeExcessiveSlashes(string& url)
 {
     if (url[url.size() - 1] ==
             '/' &&  // This check is so we don't search if there is no trailing
@@ -46,7 +46,7 @@ void removeExcessiveSlashes(string& url)
     removeDuplicateSlashes(url);
 }
 
-void trailingSlashRemover(
+static void trailingSlashRemover(
     const HttpRequestPtr& req,
     std::function<void(const HttpResponsePtr&)>&& callback)
 {
@@ -54,7 +54,7 @@ void trailingSlashRemover(
     removeTrailingSlashes(redirectedPath);
     callback(HttpResponse::newRedirectionResponse(redirectedPath));
 }
-void duplicateSlashRemover(
+static void duplicateSlashRemover(
     const HttpRequestPtr& req,
     std::function<void(const HttpResponsePtr&)>&& callback)
 {
@@ -62,7 +62,7 @@ void duplicateSlashRemover(
     removeDuplicateSlashes(redirectedPath);
     callback(HttpResponse::newRedirectionResponse(redirectedPath));
 }
-void excessiveSlashRemover(
+static void excessiveSlashRemover(
     const HttpRequestPtr& req,
     std::function<void(const HttpResponsePtr&)>&& callback)
 {

--- a/lib/src/SlashRemover.cc
+++ b/lib/src/SlashRemover.cc
@@ -109,12 +109,12 @@ void SlashRemover::initAndStart(const Json::Value& config)
         {
             app().registerHandlerViaRegex(
                 TRAILING_SLASH_REGEX,
-                redirect_ ? [](const HttpRequestPtr& req,
-                   std::function<void(const HttpResponsePtr&)>&& callback) {
-                    trailingSlashRemover(req, std::move(callback));
-                } : [](const HttpRequestPtr& req,
-                   std::function<void(const HttpResponsePtr&)>&& callback) {
-                    trailingSlashRemoverForward(req, std::move(callback));
+                [this](const HttpRequestPtr& req,
+                       std::function<void(const HttpResponsePtr&)>&& callback) {
+                    if (redirect_)
+                        trailingSlashRemover(req, std::move(callback));
+                    else
+                        trailingSlashRemoverForward(req, std::move(callback));
                 });
             break;
         }
@@ -122,12 +122,12 @@ void SlashRemover::initAndStart(const Json::Value& config)
         {
             app().registerHandlerViaRegex(
                 DUPLICATE_SLASH_REGEX,
-                redirect_ ? [](const HttpRequestPtr& req,
-                   std::function<void(const HttpResponsePtr&)>&& callback) {
-                    duplicateSlashRemover(req, std::move(callback));
-                } : [](const HttpRequestPtr& req,
-                   std::function<void(const HttpResponsePtr&)>&& callback) {
-                    duplicateSlashRemoverForward(req, std::move(callback));
+                [this](const HttpRequestPtr& req,
+                       std::function<void(const HttpResponsePtr&)>&& callback) {
+                    if (redirect_)
+                        duplicateSlashRemover(req, std::move(callback));
+                    else
+                        duplicateSlashRemoverForward(req, std::move(callback));
                 });
             break;
         }
@@ -135,12 +135,12 @@ void SlashRemover::initAndStart(const Json::Value& config)
         {
             app().registerHandlerViaRegex(
                 TRAILING_SLASH_REGEX "|" DUPLICATE_SLASH_REGEX,
-                redirect_ ? [](const HttpRequestPtr& req,
-                   std::function<void(const HttpResponsePtr&)>&& callback) {
-                    excessiveSlashRemover(req, std::move(callback));
-                } : [](const HttpRequestPtr& req,
-                   std::function<void(const HttpResponsePtr&)>&& callback) {
-                    excessiveSlashRemoverForward(req, std::move(callback));
+                [this](const HttpRequestPtr& req,
+                       std::function<void(const HttpResponsePtr&)>&& callback) {
+                    if (redirect_)
+                        excessiveSlashRemover(req, std::move(callback));
+                    else
+                        excessiveSlashRemoverForward(req, std::move(callback));
                 });
             break;
         }

--- a/lib/src/SlashRemover.cc
+++ b/lib/src/SlashRemover.cc
@@ -1,0 +1,118 @@
+#include "drogon/plugins/SlashRemover.h"
+#include "drogon/HttpAppFramework.h"
+#include "drogon/utils/FunctionTraits.h"
+#include <functional>
+#include <string>
+
+using namespace drogon;
+using namespace plugin;
+using std::string;
+
+#define TRAILING_SLASH_REGEX "^.+\\/$"
+#define DUPLICATE_SLASH_REGEX "^.+\\/{2}.*$"
+
+bool removeTrailingSlashes(string& url)
+{
+    // If only contains '/', it will return -1, and added with 1 it will be 0,
+    // hence empty, meaning root
+    url.resize(url.find_last_not_of('/') + 1);
+    if (url.empty())  // Root
+    {
+        url = '/';
+        return true;
+    }
+    return false;
+}
+void removeDuplicateSlashes(string& url)
+{
+    size_t a = 0;
+    for (size_t b = 1, len = url.size(); b < len; ++b)
+    {
+        const char c = url[b];
+        if (c != '/' || url[a] != '/')
+            url[++a] = c;
+    }
+    url.resize(a + 1);
+}
+void removeExcessiveSlashes(string& url)
+{
+    if (url[url.size() - 1] ==
+            '/' &&  // This check is so we don't search if there is no trailing
+                    // slash to begin with
+        removeTrailingSlashes(
+            url))  // If it is root path, we don't need to check for duplicates
+        return;
+
+    removeDuplicateSlashes(url);
+}
+
+void trailingSlashRemover(
+    const HttpRequestPtr& req,
+    std::function<void(const HttpResponsePtr&)>&& callback)
+{
+    string redirectedPath = req->path();
+    removeTrailingSlashes(redirectedPath);
+    callback(HttpResponse::newRedirectionResponse(redirectedPath));
+}
+void duplicateSlashRemover(
+    const HttpRequestPtr& req,
+    std::function<void(const HttpResponsePtr&)>&& callback)
+{
+    string redirectedPath = req->path();
+    removeDuplicateSlashes(redirectedPath);
+    callback(HttpResponse::newRedirectionResponse(redirectedPath));
+}
+void excessiveSlashRemover(
+    const HttpRequestPtr& req,
+    std::function<void(const HttpResponsePtr&)>&& callback)
+{
+    string redirectedPath = req->path();
+    removeExcessiveSlashes(redirectedPath);
+    callback(HttpResponse::newRedirectionResponse(redirectedPath));
+}
+
+void SlashRemover::initAndStart(const Json::Value& config)
+{
+    trailingSlashes_ = config.get("remove_trailing_slashes", true).asBool();
+    duplicateSlashes_ = config.get("remove_duplicate_slashes", true).asBool();
+    switch ((trailingSlashes_ << 0) | (duplicateSlashes_ << 1))
+    {
+        case 1 << 0:
+        {
+            app().registerHandlerViaRegex(
+                TRAILING_SLASH_REGEX,
+                [](const HttpRequestPtr& req,
+                   std::function<void(const HttpResponsePtr&)>&& callback) {
+                    trailingSlashRemover(req, std::move(callback));
+                });
+            break;
+        }
+        case 1 << 1:
+        {
+            app().registerHandlerViaRegex(
+                DUPLICATE_SLASH_REGEX,
+                [](const HttpRequestPtr& req,
+                   std::function<void(const HttpResponsePtr&)>&& callback) {
+                    duplicateSlashRemover(req, std::move(callback));
+                });
+            break;
+        }
+        case (1 << 0) | (1 << 1):
+        {
+            app().registerHandlerViaRegex(
+                TRAILING_SLASH_REGEX "|" DUPLICATE_SLASH_REGEX,
+                [](const HttpRequestPtr& req,
+                   std::function<void(const HttpResponsePtr&)>&& callback) {
+                    excessiveSlashRemover(req, std::move(callback));
+                });
+            break;
+        }
+        default:
+            return;
+    }
+}
+
+void SlashRemover::shutdown()
+{
+    LOG_TRACE << "SlashRemover plugin is shutdown!";
+}

--- a/lib/src/SlashRemover.cc
+++ b/lib/src/SlashRemover.cc
@@ -8,8 +8,8 @@ using namespace drogon;
 using namespace plugin;
 using std::string;
 
-#define TRAILING_SLASH_REGEX "^.+\\/$"
-#define DUPLICATE_SLASH_REGEX "^.+\\/{2}.*$"
+#define TRAILING_SLASH_REGEX ".+\\/$"
+#define DUPLICATE_SLASH_REGEX ".*\\/{2}.*"
 
 static bool removeTrailingSlashes(string& url)
 {

--- a/lib/tests/CMakeLists.txt
+++ b/lib/tests/CMakeLists.txt
@@ -24,7 +24,8 @@ set(UNITTEST_SOURCES
     unittests/CacheMapTest.cc
     unittests/StringOpsTest.cc
     unittests/ControllerCreationTest.cc
-    unittests/MultiPartParserTest.cc)
+    unittests/MultiPartParserTest.cc
+	unittests/SlashRemoverTest.cc)
 
 if(DROGON_CXX_STANDARD GREATER_EQUAL 20 AND HAS_COROUTINE)
   set(UNITTEST_SOURCES ${UNITTEST_SOURCES} unittests/CoroutineTest.cc)

--- a/lib/tests/CMakeLists.txt
+++ b/lib/tests/CMakeLists.txt
@@ -25,7 +25,7 @@ set(UNITTEST_SOURCES
     unittests/StringOpsTest.cc
     unittests/ControllerCreationTest.cc
     unittests/MultiPartParserTest.cc
-	unittests/SlashRemoverTest.cc)
+    unittests/SlashRemoverTest.cc)
 
 if(DROGON_CXX_STANDARD GREATER_EQUAL 20 AND HAS_COROUTINE)
   set(UNITTEST_SOURCES ${UNITTEST_SOURCES} unittests/CoroutineTest.cc)

--- a/lib/tests/unittests/SlashRemoverTest.cc
+++ b/lib/tests/unittests/SlashRemoverTest.cc
@@ -1,0 +1,29 @@
+#include <drogon/drogon_test.h>
+#include <../../lib/src/SlashRemover.cc>
+
+using std::string;
+
+DROGON_TEST(SlashRemoverTest)
+{
+    const string url = "///home//", root = "///";
+
+    string cleanUrl = url;
+    removeTrailingSlashes(cleanUrl);
+    CHECK(cleanUrl == "///home");
+
+    cleanUrl = url;
+    removeDuplicateSlashes(cleanUrl);
+    CHECK(cleanUrl == "/home/");
+
+    cleanUrl = url;
+    removeExcessiveSlashes(cleanUrl);
+    CHECK(cleanUrl == "/home");
+
+    cleanUrl = root;
+    removeTrailingSlashes(cleanUrl);
+    CHECK(cleanUrl == "/");
+
+    cleanUrl = root;
+    removeDuplicateSlashes(cleanUrl);
+    CHECK(cleanUrl == "/");
+}


### PR DESCRIPTION
This new plugin redirects requests to proper paths if they contain excessive slashes, including trailing slashes, or duplicate slashes. Both can be enabled independently from one another.

Example of a trailing slash: 'example.com///home///' -> 'example.com///home'
Duplicate slash: 'example.com///home///' -> 'example.com/home/'
Both: 'example.com///home///' -> 'example.com/home'