### PR TITLE
Minor improvements for SlashRemover plugin

### DIFF
--- a/lib/src/SlashRemover.cc
+++ b/lib/src/SlashRemover.cc
@@ -26,14 +26,13 @@ inline constexpr const char* regexes[] = {
 
 static inline bool removeTrailingSlashes(string& url)
 {
-    // If only contains '/', it will return -1, and added with 1 it will be 0,
-    // hence empty, meaning root
-    url.resize(url.find_last_not_of('/') + 1);
-    if (url.empty())  // Root
+    const auto notSlashIndex = url.find_last_not_of('/');
+    if (notSlashIndex == string::npos)  // Root
     {
-        url = '/';
+        url.resize(1);
         return true;
     }
+    url.resize(notSlashIndex + 1);
     return false;
 }
 static inline void removeDuplicateSlashes(string& url)

--- a/lib/tests/unittests/SlashRemoverTest.cc
+++ b/lib/tests/unittests/SlashRemoverTest.cc
@@ -19,6 +19,14 @@ DROGON_TEST(SlashRemoverTest)
     removeExcessiveSlashes(cleanUrl);
     CHECK(cleanUrl == "/home/page");
 
+    cleanUrl = "///home//page";
+    removeExcessiveSlashes(cleanUrl);
+    CHECK(cleanUrl == "/home/page");
+
+    cleanUrl = "/home/page/";
+    removeExcessiveSlashes(cleanUrl);
+    CHECK(cleanUrl == "/home/page");
+
     cleanUrl = root;
     removeTrailingSlashes(cleanUrl);
     CHECK(cleanUrl == "/");

--- a/lib/tests/unittests/SlashRemoverTest.cc
+++ b/lib/tests/unittests/SlashRemoverTest.cc
@@ -5,19 +5,19 @@ using std::string;
 
 DROGON_TEST(SlashRemoverTest)
 {
-    const string url = "///home//", root = "///";
+    const string url = "///home//page//", root = "///";
 
     string cleanUrl = url;
     removeTrailingSlashes(cleanUrl);
-    CHECK(cleanUrl == "///home");
+    CHECK(cleanUrl == "///home//page");
 
     cleanUrl = url;
     removeDuplicateSlashes(cleanUrl);
-    CHECK(cleanUrl == "/home/");
+    CHECK(cleanUrl == "/home/page/");
 
     cleanUrl = url;
     removeExcessiveSlashes(cleanUrl);
-    CHECK(cleanUrl == "/home");
+    CHECK(cleanUrl == "/home/page");
 
     cleanUrl = root;
     removeTrailingSlashes(cleanUrl);

--- a/lib/tests/unittests/SlashRemoverTest.cc
+++ b/lib/tests/unittests/SlashRemoverTest.cc
@@ -5,33 +5,39 @@ using std::string;
 
 DROGON_TEST(SlashRemoverTest)
 {
-    const string url = "///home//page//", root = "///";
+    const string url = "///home//page//", urlNoTrail = "///home//page",
+                 urlNoDup = "/home/page/", urlNoExcess = "/home/page",
+                 root = "///", rootNoExcess = "/";
 
     string cleanUrl = url;
     removeTrailingSlashes(cleanUrl);
-    CHECK(cleanUrl == "///home//page");
+    CHECK(cleanUrl == urlNoTrail);
 
     cleanUrl = url;
     removeDuplicateSlashes(cleanUrl);
-    CHECK(cleanUrl == "/home/page/");
+    CHECK(cleanUrl == urlNoDup);
 
     cleanUrl = url;
     removeExcessiveSlashes(cleanUrl);
-    CHECK(cleanUrl == "/home/page");
+    CHECK(cleanUrl == urlNoExcess);
 
-    cleanUrl = "///home//page";
+    cleanUrl = urlNoTrail;
     removeExcessiveSlashes(cleanUrl);
-    CHECK(cleanUrl == "/home/page");
+    CHECK(cleanUrl == urlNoExcess);
 
-    cleanUrl = "/home/page/";
+    cleanUrl = urlNoDup;
     removeExcessiveSlashes(cleanUrl);
-    CHECK(cleanUrl == "/home/page");
+    CHECK(cleanUrl == urlNoExcess);
 
     cleanUrl = root;
     removeTrailingSlashes(cleanUrl);
-    CHECK(cleanUrl == "/");
+    CHECK(cleanUrl == rootNoExcess);
 
     cleanUrl = root;
     removeDuplicateSlashes(cleanUrl);
-    CHECK(cleanUrl == "/");
+    CHECK(cleanUrl == rootNoExcess);
+
+    cleanUrl = root;
+    removeExcessiveSlashes(cleanUrl);
+    CHECK(cleanUrl == rootNoExcess);
 }


### PR DESCRIPTION
In trailing slash remover, in the case of a root url, the resizing will no longer make the string empty for a later reassignment to `'/'`.
Changed the test case url to have at least two levels of depth for better test coverage for the duplicate slash remover.