### PR TITLE
Base64 improvements

### DIFF
--- a/lib/inc/drogon/utils/Utilities.h
+++ b/lib/inc/drogon/utils/Utilities.h
@@ -112,7 +112,7 @@ DROGON_EXPORT std::string base64Encode(const unsigned char *bytes_to_encode,
                                        bool padded = true);
 
 /// Encode the string to base64 format.
-inline std::string base64Encode(const string_view &data,
+inline std::string base64Encode(string_view data,
                                 bool url_safe = false,
                                 bool padded = true)
 {
@@ -129,8 +129,7 @@ DROGON_EXPORT std::string base64EncodeUnpadded(
     bool url_safe = false);
 
 /// Encode the string to base64 format with no padding.
-inline std::string base64EncodeUnpadded(const string_view &data,
-                                        bool url_safe = false)
+inline std::string base64EncodeUnpadded(string_view data, bool url_safe = false)
 {
     return base64Encode(data, url_safe, false);
 }
@@ -139,9 +138,9 @@ inline std::string base64EncodeUnpadded(const string_view &data,
 DROGON_EXPORT size_t base64DecodedLength(unsigned int in_len);
 
 /// Decode the base64 format string.
-DROGON_EXPORT std::string base64Decode(const std::string &encoded_string);
+DROGON_EXPORT std::string base64Decode(string_view encoded_string);
 DROGON_EXPORT std::vector<char> base64DecodeToVector(
-    const std::string &encoded_string);
+    string_view encoded_string);
 
 /// Check if the string need decoding
 DROGON_EXPORT bool needUrlDecoding(const char *begin, const char *end);

--- a/lib/inc/drogon/utils/Utilities.h
+++ b/lib/inc/drogon/utils/Utilities.h
@@ -122,9 +122,11 @@ DROGON_EXPORT size_t base64DecodedLength(unsigned int in_len,
                                          uint8_t padding = 0);
 
 /// Decode the base64 format string.
-DROGON_EXPORT std::string base64Decode(const std::string &encoded_string);
+DROGON_EXPORT std::string base64Decode(const std::string &encoded_string,
+                                       bool *out_valid = nullptr);
 DROGON_EXPORT std::vector<char> base64DecodeToVector(
-    const std::string &encoded_string);
+    const std::string &encoded_string,
+    bool *out_valid = nullptr);
 
 /// Check if the string need decoding
 DROGON_EXPORT bool needUrlDecoding(const char *begin, const char *end);

--- a/lib/inc/drogon/utils/Utilities.h
+++ b/lib/inc/drogon/utils/Utilities.h
@@ -60,6 +60,9 @@ namespace utils
 /// Determine if the string is an integer
 DROGON_EXPORT bool isInteger(const std::string &str);
 
+/// Determine if the string is base64 encoded
+DROGON_EXPORT bool isBase64(const std::string &str);
+
 /// Generate random a string
 /**
  * @param length The string length

--- a/lib/inc/drogon/utils/Utilities.h
+++ b/lib/inc/drogon/utils/Utilities.h
@@ -98,6 +98,10 @@ DROGON_EXPORT std::set<std::string> splitStringToSet(
 /// Get UUID string.
 DROGON_EXPORT std::string getUuid();
 
+/// Get the encoded length of base64.
+DROGON_EXPORT size_t base64EncodedLength(unsigned int in_len,
+                                         bool padded = true);
+
 /// Encode the string to base64 format.
 DROGON_EXPORT std::string base64Encode(const unsigned char *bytes_to_encode,
                                        unsigned int in_len,
@@ -109,6 +113,10 @@ DROGON_EXPORT std::string base64EncodeUnpadded(
     const unsigned char *bytes_to_encode,
     unsigned int in_len,
     bool url_safe = false);
+
+/// Get the decoded length of base64.
+DROGON_EXPORT size_t base64DecodedLength(unsigned int in_len,
+                                         uint8_t padding = 0);
 
 /// Decode the base64 format string.
 DROGON_EXPORT std::string base64Decode(const std::string &encoded_string);

--- a/lib/inc/drogon/utils/Utilities.h
+++ b/lib/inc/drogon/utils/Utilities.h
@@ -101,7 +101,14 @@ DROGON_EXPORT std::string getUuid();
 /// Encode the string to base64 format.
 DROGON_EXPORT std::string base64Encode(const unsigned char *bytes_to_encode,
                                        unsigned int in_len,
-                                       bool url_safe = false);
+                                       bool url_safe = false,
+                                       bool padded = true);
+
+/// Encode the string to base64 format with no padding.
+DROGON_EXPORT std::string base64EncodeUnpadded(
+    const unsigned char *bytes_to_encode,
+    unsigned int in_len,
+    bool url_safe = false);
 
 /// Decode the base64 format string.
 DROGON_EXPORT std::string base64Decode(const std::string &encoded_string);

--- a/lib/inc/drogon/utils/Utilities.h
+++ b/lib/inc/drogon/utils/Utilities.h
@@ -112,9 +112,9 @@ DROGON_EXPORT std::string base64Encode(const unsigned char *bytes_to_encode,
                                        bool padded = true);
 
 /// Encode the string to base64 format.
-DROGON_EXPORT inline std::string base64Encode(const string_view &data,
-                                              bool url_safe = false,
-                                              bool padded = true)
+inline std::string base64Encode(const string_view &data,
+                                bool url_safe = false,
+                                bool padded = true)
 {
     return base64Encode((unsigned char *)data.data(),
                         data.size(),
@@ -129,8 +129,7 @@ DROGON_EXPORT std::string base64EncodeUnpadded(
     bool url_safe = false);
 
 /// Encode the string to base64 format with no padding.
-DROGON_EXPORT inline std::string base64Encode(const string_view &data,
-                                              bool url_safe = false)
+inline std::string base64Encode(const string_view &data, bool url_safe = false)
 {
     return base64Encode(data, url_safe, false);
 }

--- a/lib/inc/drogon/utils/Utilities.h
+++ b/lib/inc/drogon/utils/Utilities.h
@@ -111,11 +111,29 @@ DROGON_EXPORT std::string base64Encode(const unsigned char *bytes_to_encode,
                                        bool url_safe = false,
                                        bool padded = true);
 
+/// Encode the string to base64 format.
+DROGON_EXPORT inline std::string base64Encode(const string_view &data,
+                                              bool url_safe = false,
+                                              bool padded = true)
+{
+    return base64Encode((unsigned char *)data.data(),
+                        data.size(),
+                        url_safe,
+                        padded);
+}
+
 /// Encode the string to base64 format with no padding.
 DROGON_EXPORT std::string base64EncodeUnpadded(
     const unsigned char *bytes_to_encode,
     unsigned int in_len,
     bool url_safe = false);
+
+/// Encode the string to base64 format with no padding.
+DROGON_EXPORT inline std::string base64Encode(const string_view &data,
+                                              bool url_safe = false)
+{
+    return base64Encode(data, url_safe, false);
+}
 
 /// Get the decoded length of base64.
 DROGON_EXPORT size_t base64DecodedLength(unsigned int in_len);

--- a/lib/inc/drogon/utils/Utilities.h
+++ b/lib/inc/drogon/utils/Utilities.h
@@ -129,7 +129,8 @@ DROGON_EXPORT std::string base64EncodeUnpadded(
     bool url_safe = false);
 
 /// Encode the string to base64 format with no padding.
-inline std::string base64Encode(const string_view &data, bool url_safe = false)
+inline std::string base64EncodeUnpadded(const string_view &data,
+                                        bool url_safe = false)
 {
     return base64Encode(data, url_safe, false);
 }

--- a/lib/inc/drogon/utils/Utilities.h
+++ b/lib/inc/drogon/utils/Utilities.h
@@ -139,11 +139,9 @@ inline std::string base64EncodeUnpadded(const string_view &data,
 DROGON_EXPORT size_t base64DecodedLength(unsigned int in_len);
 
 /// Decode the base64 format string.
-DROGON_EXPORT std::string base64Decode(const std::string &encoded_string,
-                                       bool *out_valid = nullptr);
+DROGON_EXPORT std::string base64Decode(const std::string &encoded_string);
 DROGON_EXPORT std::vector<char> base64DecodeToVector(
-    const std::string &encoded_string,
-    bool *out_valid = nullptr);
+    const std::string &encoded_string);
 
 /// Check if the string need decoding
 DROGON_EXPORT bool needUrlDecoding(const char *begin, const char *end);

--- a/lib/inc/drogon/utils/Utilities.h
+++ b/lib/inc/drogon/utils/Utilities.h
@@ -118,8 +118,7 @@ DROGON_EXPORT std::string base64EncodeUnpadded(
     bool url_safe = false);
 
 /// Get the decoded length of base64.
-DROGON_EXPORT size_t base64DecodedLength(unsigned int in_len,
-                                         uint8_t padding = 0);
+DROGON_EXPORT size_t base64DecodedLength(unsigned int in_len);
 
 /// Decode the base64 format string.
 DROGON_EXPORT std::string base64Decode(const std::string &encoded_string,

--- a/lib/src/Utilities.cc
+++ b/lib/src/Utilities.cc
@@ -465,7 +465,8 @@ size_t base64DecodedLength(unsigned int in_len, uint8_t padding)
     return ((in_len - padding) * 3) / 4;
 }
 
-std::vector<char> base64DecodeToVector(const std::string &encoded_string)
+std::vector<char> base64DecodeToVector(const std::string &encoded_string,
+                                       bool *out_valid)
 {
     auto in_len = encoded_string.size();
     int i = 0;
@@ -475,9 +476,18 @@ std::vector<char> base64DecodeToVector(const std::string &encoded_string)
     ret.reserve(base64DecodedLength(
         in_len, in_len - (encoded_string.find_last_not_of('=') + 1)));
 
-    while (in_len-- && (encoded_string[in_] != '=') &&
-           isBase64(encoded_string[in_]))
+    if (out_valid)
+        *out_valid = true;
+
+    while (in_len-- && (encoded_string[in_] != '='))
     {
+        if (!isBase64(encoded_string[in_]))
+        {
+            if (out_valid)
+                *out_valid = false;
+            break;
+        }
+
         char_array_4[i++] = encoded_string[in_];
         ++in_;
         if (i == 4)
@@ -523,7 +533,7 @@ std::vector<char> base64DecodeToVector(const std::string &encoded_string)
     return ret;
 }
 
-std::string base64Decode(const std::string &encoded_string)
+std::string base64Decode(const std::string &encoded_string, bool *out_valid)
 {
     auto in_len = encoded_string.size();
     int i = 0;
@@ -533,9 +543,18 @@ std::string base64Decode(const std::string &encoded_string)
     ret.reserve(base64DecodedLength(
         in_len, in_len - (encoded_string.find_last_not_of('=') + 1)));
 
-    while (in_len-- && (encoded_string[in_] != '=') &&
-           isBase64(encoded_string[in_]))
+    if (out_valid)
+        *out_valid = true;
+
+    while (in_len-- && (encoded_string[in_] != '='))
     {
+        if (!isBase64(encoded_string[in_]))
+        {
+            if (out_valid)
+                *out_valid = false;
+            break;
+        }
+
         char_array_4[i++] = encoded_string[in_];
         ++in_;
         if (i == 4)

--- a/lib/src/Utilities.cc
+++ b/lib/src/Utilities.cc
@@ -149,6 +149,14 @@ bool isInteger(const std::string &str)
     return true;
 }
 
+bool isBase64(const std::string &str)
+{
+    for (auto c : str)
+        if (!isBase64(c))
+            return false;
+    return true;
+}
+
 std::string genRandomString(int length)
 {
     static const char char_space[] =

--- a/lib/src/Utilities.cc
+++ b/lib/src/Utilities.cc
@@ -465,7 +465,7 @@ size_t base64DecodedLength(unsigned int in_len)
     return (in_len * 3) / 4;
 }
 
-std::vector<char> base64DecodeToVector(const std::string &encoded_string)
+std::vector<char> base64DecodeToVector(string_view encoded_string)
 {
     auto in_len = encoded_string.size();
     int i = 0;
@@ -527,7 +527,7 @@ std::vector<char> base64DecodeToVector(const std::string &encoded_string)
     return ret;
 }
 
-std::string base64Decode(const std::string &encoded_string)
+std::string base64Decode(string_view encoded_string)
 {
     auto in_len = encoded_string.size();
     int i = 0;

--- a/lib/src/Utilities.cc
+++ b/lib/src/Utilities.cc
@@ -465,8 +465,7 @@ size_t base64DecodedLength(unsigned int in_len)
     return (in_len * 3) / 4;
 }
 
-std::vector<char> base64DecodeToVector(const std::string &encoded_string,
-                                       bool *out_valid)
+std::vector<char> base64DecodeToVector(const std::string &encoded_string)
 {
     auto in_len = encoded_string.size();
     int i = 0;
@@ -475,16 +474,12 @@ std::vector<char> base64DecodeToVector(const std::string &encoded_string,
     std::vector<char> ret;
     ret.reserve(base64DecodedLength(in_len));
 
-    if (out_valid)
-        *out_valid = true;
-
     while (in_len-- && (encoded_string[in_] != '='))
     {
         if (!isBase64(encoded_string[in_]))
         {
-            if (out_valid)
-                *out_valid = false;
-            break;
+            ++in_;
+            continue;
         }
 
         char_array_4[i++] = encoded_string[in_];
@@ -532,7 +527,7 @@ std::vector<char> base64DecodeToVector(const std::string &encoded_string,
     return ret;
 }
 
-std::string base64Decode(const std::string &encoded_string, bool *out_valid)
+std::string base64Decode(const std::string &encoded_string)
 {
     auto in_len = encoded_string.size();
     int i = 0;
@@ -541,16 +536,12 @@ std::string base64Decode(const std::string &encoded_string, bool *out_valid)
     std::string ret;
     ret.reserve(base64DecodedLength(in_len));
 
-    if (out_valid)
-        *out_valid = true;
-
     while (in_len-- && (encoded_string[in_] != '='))
     {
         if (!isBase64(encoded_string[in_]))
         {
-            if (out_valid)
-                *out_valid = false;
-            break;
+            ++in_;
+            continue;
         }
 
         char_array_4[i++] = encoded_string[in_];

--- a/lib/src/Utilities.cc
+++ b/lib/src/Utilities.cc
@@ -460,9 +460,9 @@ std::string base64EncodeUnpadded(const unsigned char *bytes_to_encode,
     return base64Encode(bytes_to_encode, in_len, url_safe, false);
 }
 
-size_t base64DecodedLength(unsigned int in_len, uint8_t padding)
+size_t base64DecodedLength(unsigned int in_len)
 {
-    return ((in_len - padding) * 3) / 4;
+    return (in_len * 3) / 4;
 }
 
 std::vector<char> base64DecodeToVector(const std::string &encoded_string,
@@ -473,8 +473,7 @@ std::vector<char> base64DecodeToVector(const std::string &encoded_string,
     int in_{0};
     char char_array_4[4], char_array_3[3];
     std::vector<char> ret;
-    ret.reserve(base64DecodedLength(
-        in_len, in_len - (encoded_string.find_last_not_of('=') + 1)));
+    ret.reserve(base64DecodedLength(in_len));
 
     if (out_valid)
         *out_valid = true;
@@ -540,8 +539,7 @@ std::string base64Decode(const std::string &encoded_string, bool *out_valid)
     int in_{0};
     unsigned char char_array_4[4], char_array_3[3];
     std::string ret;
-    ret.reserve(base64DecodedLength(
-        in_len, in_len - (encoded_string.find_last_not_of('=') + 1)));
+    ret.reserve(base64DecodedLength(in_len));
 
     if (out_valid)
         *out_valid = true;

--- a/lib/src/Utilities.cc
+++ b/lib/src/Utilities.cc
@@ -389,9 +389,11 @@ std::string getUuid()
 
 std::string base64Encode(const unsigned char *bytes_to_encode,
                          unsigned int in_len,
-                         bool url_safe)
+                         bool url_safe,
+                         bool padded)
 {
     std::string ret;
+    ret.reserve(padded ? ((in_len + 3 - 1) / 3) * 4 : (in_len * 8 + 6 - 1) / 6);
     int i = 0;
     unsigned char char_array_3[3];
     unsigned char char_array_4[4];
@@ -431,12 +433,19 @@ std::string base64Encode(const unsigned char *bytes_to_encode,
         for (int j = 0; (j < i + 1); ++j)
             ret += charSet[char_array_4[j]];
 
-        while ((i++ < 3))
-            ret += '=';
+        if (padded)
+            while ((i++ < 3))
+                ret += '=';
     }
     return ret;
 }
 
+std::string base64EncodeUnpadded(const unsigned char *bytes_to_encode,
+                                 unsigned int in_len,
+                                 bool url_safe)
+{
+    return base64Encode(bytes_to_encode, in_len, url_safe, false);
+}
 std::vector<char> base64DecodeToVector(const std::string &encoded_string)
 {
     auto in_len = encoded_string.size();

--- a/lib/tests/unittests/Base64Test.cc
+++ b/lib/tests/unittests/Base64Test.cc
@@ -5,8 +5,7 @@
 DROGON_TEST(Base64)
 {
     std::string in{"drogon framework"};
-    auto encoded = drogon::utils::base64Encode((const unsigned char *)in.data(),
-                                               (unsigned int)in.length());
+    auto encoded = drogon::utils::base64Encode(in);
     auto decoded = drogon::utils::base64Decode(encoded);
     CHECK(encoded == "ZHJvZ29uIGZyYW1ld29yaw==");
     CHECK(decoded == in);
@@ -14,8 +13,7 @@ DROGON_TEST(Base64)
     SUBSECTION(Unpadded)
     {
         std::string in{"drogon framework"};
-        auto encoded = drogon::utils::base64EncodeUnpadded(
-            (const unsigned char *)in.data(), (unsigned int)in.length());
+        auto encoded = drogon::utils::base64EncodeUnpadded(in);
         auto decoded = drogon::utils::base64Decode(encoded);
         CHECK(encoded == "ZHJvZ29uIGZyYW1ld29yaw");
         CHECK(decoded == in);
@@ -29,12 +27,9 @@ DROGON_TEST(Base64)
         {
             in.append(1, char(i));
         }
-        auto out = drogon::utils::base64Encode((const unsigned char *)in.data(),
-                                               (unsigned int)in.length());
+        auto out = drogon::utils::base64Encode(in.data());
         auto out2 = drogon::utils::base64Decode(out);
-        auto encoded =
-            drogon::utils::base64Encode((const unsigned char *)in.data(),
-                                        (unsigned int)in.length());
+        auto encoded = drogon::utils::base64Encode(in);
         auto decoded = drogon::utils::base64Decode(encoded);
         CHECK(decoded == in);
     }
@@ -42,10 +37,7 @@ DROGON_TEST(Base64)
     SUBSECTION(URLSafe)
     {
         std::string in{"drogon framework"};
-        auto encoded =
-            drogon::utils::base64Encode((const unsigned char *)in.data(),
-                                        (unsigned int)in.length(),
-                                        true);
+        auto encoded = drogon::utils::base64Encode(in, true);
         auto decoded = drogon::utils::base64Decode(encoded);
         CHECK(encoded == "ZHJvZ29uIGZyYW1ld29yaw==");
         CHECK(decoded == in);
@@ -54,8 +46,7 @@ DROGON_TEST(Base64)
     SUBSECTION(UnpaddedURLSafe)
     {
         std::string in{"drogon framework"};
-        auto encoded = drogon::utils::base64EncodeUnpadded(
-            (const unsigned char *)in.data(), (unsigned int)in.length(), true);
+        auto encoded = drogon::utils::base64EncodeUnpadded(in, true);
         auto decoded = drogon::utils::base64Decode(encoded);
         CHECK(encoded == "ZHJvZ29uIGZyYW1ld29yaw");
         CHECK(decoded == in);
@@ -69,10 +60,7 @@ DROGON_TEST(Base64)
         {
             in.append(1, char(i));
         }
-        auto encoded =
-            drogon::utils::base64Encode((const unsigned char *)in.data(),
-                                        (unsigned int)in.length(),
-                                        true);
+        auto encoded = drogon::utils::base64Encode(in, true);
         auto decoded = drogon::utils::base64Decode(encoded);
         CHECK(decoded == in);
     }

--- a/lib/tests/unittests/Base64Test.cc
+++ b/lib/tests/unittests/Base64Test.cc
@@ -11,6 +11,16 @@ DROGON_TEST(Base64)
     CHECK(encoded == "ZHJvZ29uIGZyYW1ld29yaw==");
     CHECK(decoded == in);
 
+    SUBSECTION(Unpadded)
+    {
+        std::string in{"drogon framework"};
+        auto encoded = drogon::utils::base64EncodeUnpadded(
+            (const unsigned char *)in.data(), (unsigned int)in.length());
+        auto decoded = drogon::utils::base64Decode(encoded);
+        CHECK(encoded == "ZHJvZ29uIGZyYW1ld29yaw");
+        CHECK(decoded == in);
+    }
+
     SUBSECTION(LongString)
     {
         std::string in;
@@ -38,6 +48,16 @@ DROGON_TEST(Base64)
                                         true);
         auto decoded = drogon::utils::base64Decode(encoded);
         CHECK(encoded == "ZHJvZ29uIGZyYW1ld29yaw==");
+        CHECK(decoded == in);
+    }
+
+    SUBSECTION(UnpaddedURLSafe)
+    {
+        std::string in{"drogon framework"};
+        auto encoded = drogon::utils::base64EncodeUnpadded(
+            (const unsigned char *)in.data(), (unsigned int)in.length(), true);
+        auto decoded = drogon::utils::base64Decode(encoded);
+        CHECK(encoded == "ZHJvZ29uIGZyYW1ld29yaw");
         CHECK(decoded == in);
     }
 

--- a/lib/tests/unittests/Base64Test.cc
+++ b/lib/tests/unittests/Base64Test.cc
@@ -27,7 +27,7 @@ DROGON_TEST(Base64)
         {
             in.append(1, char(i));
         }
-        auto out = drogon::utils::base64Encode(in.data());
+        auto out = drogon::utils::base64Encode(in);
         auto out2 = drogon::utils::base64Decode(out);
         auto encoded = drogon::utils::base64Encode(in);
         auto decoded = drogon::utils::base64Decode(encoded);

--- a/lib/tests/unittests/Base64Test.cc
+++ b/lib/tests/unittests/Base64Test.cc
@@ -10,6 +10,20 @@ DROGON_TEST(Base64)
     CHECK(encoded == "ZHJvZ29uIGZyYW1ld29yaw==");
     CHECK(decoded == in);
 
+    SUBSECTION(InvalidChars)
+    {
+        auto decoded =
+            drogon::utils::base64Decode("ZHJvZ2*9uIGZy**YW1ld2***9yaw*=*=");
+        CHECK(decoded == in);
+    }
+
+    SUBSECTION(InvalidCharsNoPadding)
+    {
+        auto decoded =
+            drogon::utils::base64Decode("ZHJvZ2*9uIGZy**YW1ld2***9yaw**");
+        CHECK(decoded == in);
+    }
+
     SUBSECTION(Unpadded)
     {
         std::string in{"drogon framework"};


### PR DESCRIPTION
- Add the ability to encode to base64 with no padding.
- Optimized the reallocation of the `ret` string by reserving enough space needed.
- Add length calculator functions for pre-allocation or checks.
- Add `isBase64` function for checking base64 encoded strings.
- In base64 decoders ignore invalid characters.