### PR TITLE
Make `isBase64()` and `isInteger()` take `string_view`

### DIFF
--- a/lib/inc/drogon/utils/Utilities.h
+++ b/lib/inc/drogon/utils/Utilities.h
@@ -58,10 +58,10 @@ struct CanConvertFromStringStream
 namespace utils
 {
 /// Determine if the string is an integer
-DROGON_EXPORT bool isInteger(const std::string &str);
+DROGON_EXPORT bool isInteger(string_view str);
 
 /// Determine if the string is base64 encoded
-DROGON_EXPORT bool isBase64(const std::string &str);
+DROGON_EXPORT bool isBase64(string_view str);
 
 /// Generate random a string
 /**

--- a/lib/inc/drogon/utils/Utilities.h
+++ b/lib/inc/drogon/utils/Utilities.h
@@ -58,8 +58,12 @@ struct CanConvertFromStringStream
 namespace utils
 {
 /// Determine if the string is an integer
+DROGON_EXPORT bool isInteger(const std::string &str);
+/// Determine if the string is an integer
 DROGON_EXPORT bool isInteger(string_view str);
 
+/// Determine if the string is base64 encoded
+DROGON_EXPORT bool isBase64(const std::string &str);
 /// Determine if the string is base64 encoded
 DROGON_EXPORT bool isBase64(string_view str);
 

--- a/lib/src/Utilities.cc
+++ b/lib/src/Utilities.cc
@@ -139,7 +139,7 @@ static inline bool isBase64(unsigned char c)
     return false;
 }
 
-bool isInteger(const std::string &str)
+bool isInteger(string_view str)
 {
     for (auto const &c : str)
     {
@@ -149,7 +149,7 @@ bool isInteger(const std::string &str)
     return true;
 }
 
-bool isBase64(const std::string &str)
+bool isBase64(string_view str)
 {
     for (auto c : str)
         if (!isBase64(c))

--- a/lib/src/Utilities.cc
+++ b/lib/src/Utilities.cc
@@ -139,16 +139,28 @@ static inline bool isBase64(unsigned char c)
     return false;
 }
 
+bool isInteger(const std::string &str)
+{
+    for (auto c : str)
+        if (c < '0' || c > '9')
+            return false;
+    return true;
+}
 bool isInteger(string_view str)
 {
-    for (auto const &c : str)
-    {
-        if (c > '9' || c < '0')
+    for (auto c : str)
+        if (c < '0' || c > '9')
             return false;
-    }
     return true;
 }
 
+bool isBase64(const std::string &str)
+{
+    for (auto c : str)
+        if (!isBase64(c))
+            return false;
+    return true;
+}
 bool isBase64(string_view str)
 {
     for (auto c : str)


### PR DESCRIPTION
Allows `string_view` to be passed in instead of `const std::string&`. This prevents copying for cases such as `isInteger("123")`.