### PR TITLE
Separation of the activation of the options BUILD_CTL and BUILD_EXAMPLES

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,9 +4,6 @@ project(drogon)
 
 message(STATUS "compiler: " ${CMAKE_CXX_COMPILER_ID})
 
-# If your cross compile is failing, you should set
-# CMAKE_SYSTEM_NAME in your toolchain file
-
 option(BUILD_CTL "Build drogon_ctl" ON)
 option(BUILD_EXAMPLES "Build examples" ON)
 option(BUILD_ORM "Build orm" ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,14 +6,9 @@ message(STATUS "compiler: " ${CMAKE_CXX_COMPILER_ID})
 
 # If your cross compile is failing, you should set
 # CMAKE_SYSTEM_NAME in your toolchain file
-if (NOT CMAKE_CROSSCOMPILING)
-    set(BUILD_PROGRAMS ON)
-else ()
-    set(BUILD_PROGRAMS OFF)
-endif ()
 
-option(BUILD_CTL "Build drogon_ctl" ${BUILD_PROGRAMS})
-option(BUILD_EXAMPLES "Build examples" ${BUILD_PROGRAMS})
+option(BUILD_CTL "Build drogon_ctl" ON)
+option(BUILD_EXAMPLES "Build examples" ON)
 option(BUILD_ORM "Build orm" ON)
 option(COZ_PROFILING "Use coz for profiling" OFF)
 option(BUILD_SHARED_LIBS "Build drogon as a shared lib" OFF)

--- a/README.md
+++ b/README.md
@@ -184,6 +184,18 @@ In addition, you can also find that all handler interfaces are in asynchronous m
 
 After compiling all of the above source files, we get a very simple web application. This is a good start. **For more information, please visit the [wiki](https://github.com/an-tao/drogon/wiki/ENG-01-Overview)**
 
+## Cross-compilation
+
+Drogon supports cross-compilation, you should define the `CMAKE_SYSTEM_NAME` in toolchain file, for example:
+    
+```cmake
+set(CMAKE_SYSTEM_NAME Linux)
+set(CMAKE_SYSTEM_PROCESSOR arm)
+```
+
+You can disable building options for examples and drogon_ctl by settings `BUILD_EXAMPLES` and `BUILD_CTL` to `OFF` in the toolchain file.
+
+
 ## Contributions
 
 This project exists thanks to all the people who contribute code. 

--- a/README.md
+++ b/README.md
@@ -195,6 +195,22 @@ set(CMAKE_SYSTEM_PROCESSOR arm)
 
 You can disable building options for examples and drogon_ctl by settings `BUILD_EXAMPLES` and `BUILD_CTL` to `OFF` in the toolchain file.
 
+## Building options
+
+Drogon provides some building options, you can enable or disable them by setting the corresponding variables to `ON` or `OFF` in the cmake command line, cmake file etc...
+
+| Option name | Description | Default value |
+| :--- | :--- | :--- |
+| BUILD_CTL | Build drogon_ctl | ON |
+| BUILD_EXAMPLES | Build examples | ON |
+| BUILD_ORM | Build orm | ON |
+| COZ_PROFILING | Use coz for profiling | OFF |
+| BUILD_SHARED_LIBS | Build drogon as a shared lib | OFF |
+| BUILD_DOC | Build Doxygen documentation | OFF |
+| BUILD_BROTLI | Build Brotli | ON |
+| BUILD_YAML_CONFIG | Build yaml config | ON |
+| USE_SUBMODULE | Use trantor as a submodule | ON |
+
 
 ## Contributions
 


### PR DESCRIPTION
This allows to build the examples and/or the drogon_ctl, developers can activate or not according to needs rather than forcing the activation or not of these two options

I also updated the readme with **Building options** and **Cross-compilation** sections