### PR TITLE
Removed const string& from base64

### DIFF
--- a/lib/inc/drogon/utils/Utilities.h
+++ b/lib/inc/drogon/utils/Utilities.h
@@ -129,10 +129,12 @@ inline std::string base64Encode(string_view data,
 }
 
 /// Encode the string to base64 format with no padding.
-DROGON_EXPORT std::string base64EncodeUnpadded(
-    const unsigned char *bytes_to_encode,
-    unsigned int in_len,
-    bool url_safe = false);
+inline std::string base64EncodeUnpadded(const unsigned char *bytes_to_encode,
+                                        unsigned int in_len,
+                                        bool url_safe = false)
+{
+    return base64Encode(bytes_to_encode, in_len, url_safe, false);
+}
 
 /// Encode the string to base64 format with no padding.
 inline std::string base64EncodeUnpadded(string_view data, bool url_safe = false)

--- a/lib/src/Utilities.cc
+++ b/lib/src/Utilities.cc
@@ -139,13 +139,6 @@ static inline bool isBase64(unsigned char c)
     return false;
 }
 
-bool isInteger(const std::string &str)
-{
-    for (auto c : str)
-        if (c < '0' || c > '9')
-            return false;
-    return true;
-}
 bool isInteger(string_view str)
 {
     for (auto c : str)
@@ -154,13 +147,6 @@ bool isInteger(string_view str)
     return true;
 }
 
-bool isBase64(const std::string &str)
-{
-    for (auto c : str)
-        if (!isBase64(c))
-            return false;
-    return true;
-}
 bool isBase64(string_view str)
 {
     for (auto c : str)
@@ -458,13 +444,6 @@ std::string base64Encode(const unsigned char *bytes_to_encode,
                 ret += '=';
     }
     return ret;
-}
-
-std::string base64EncodeUnpadded(const unsigned char *bytes_to_encode,
-                                 unsigned int in_len,
-                                 bool url_safe)
-{
-    return base64Encode(bytes_to_encode, in_len, url_safe, false);
 }
 
 std::vector<char> base64DecodeToVector(string_view encoded_string)


### PR DESCRIPTION
While I was at it, I made the unpadded base64 encode function inline, it had no need to be a complete function call.