### PR TITLE
Fixed issue #1666. Call of std::isspace with char argument instead of…

### DIFF
--- a/lib/src/HttpRequestImpl.cc
+++ b/lib/src/HttpRequestImpl.cc
@@ -76,7 +76,7 @@ void HttpRequestImpl::parseParameters() const
     if (!input.empty())
     {
         string_view::size_type pos = 0;
-        while ((input[pos] == '?' || isspace(input[pos])) &&
+        while ((input[pos] == '?' || isspace(static_cast<unsigned char>(input[pos]))) &&
                pos < input.length())
         {
             ++pos;
@@ -90,7 +90,7 @@ void HttpRequestImpl::parseParameters() const
             {
                 auto key = coo.substr(0, epos);
                 string_view::size_type cpos = 0;
-                while (cpos < key.length() && isspace(key[cpos]))
+                while (cpos < key.length() && isspace(static_cast<unsigned char>(key[cpos])))
                     ++cpos;
                 key = key.substr(cpos);
                 auto pvalue = coo.substr(epos + 1);
@@ -108,7 +108,7 @@ void HttpRequestImpl::parseParameters() const
             {
                 auto key = coo.substr(0, epos);
                 string_view::size_type cpos = 0;
-                while (cpos < key.length() && isspace(key[cpos]))
+                while (cpos < key.length() && isspace(static_cast<unsigned char>(key[cpos])))
                     ++cpos;
                 key = key.substr(cpos);
                 auto pvalue = coo.substr(epos + 1);
@@ -130,7 +130,7 @@ void HttpRequestImpl::parseParameters() const
         type.find("application/x-www-form-urlencoded") != std::string::npos)
     {
         string_view::size_type pos = 0;
-        while ((input[pos] == '?' || isspace(input[pos])) &&
+        while ((input[pos] == '?' || isspace(static_cast<unsigned char>(input[pos]))) &&
                pos < input.length())
         {
             ++pos;
@@ -144,7 +144,7 @@ void HttpRequestImpl::parseParameters() const
             {
                 auto key = coo.substr(0, epos);
                 string_view::size_type cpos = 0;
-                while (cpos < key.length() && isspace(key[cpos]))
+                while (cpos < key.length() && isspace(static_cast<unsigned char>(key[cpos])))
                     ++cpos;
                 key = key.substr(cpos);
                 auto pvalue = coo.substr(epos + 1);
@@ -162,7 +162,7 @@ void HttpRequestImpl::parseParameters() const
             {
                 auto key = coo.substr(0, epos);
                 string_view::size_type cpos = 0;
-                while (cpos < key.length() && isspace(key[cpos]))
+                while (cpos < key.length() && isspace(static_cast<unsigned char>(key[cpos])))
                     ++cpos;
                 key = key.substr(cpos);
                 auto pvalue = coo.substr(epos + 1);
@@ -401,12 +401,12 @@ void HttpRequestImpl::addHeader(const char *start,
                    field.begin(),
                    [](unsigned char c) { return tolower(c); });
     ++colon;
-    while (colon < end && isspace(*colon))
+    while (colon < end && isspace(static_cast<unsigned char>(*colon)))
     {
         ++colon;
     }
     std::string value(colon, end);
-    while (!value.empty() && isspace(value[value.size() - 1]))
+    while (!value.empty() && isspace(static_cast<unsigned char>(value[value.size() - 1])))
     {
         value.resize(value.size() - 1);
     }
@@ -423,13 +423,13 @@ void HttpRequestImpl::addHeader(const char *start,
                 std::string cookie_name = coo.substr(0, epos);
                 std::string::size_type cpos = 0;
                 while (cpos < cookie_name.length() &&
-                       isspace(cookie_name[cpos]))
+                       isspace(static_cast<unsigned char>(cookie_name[cpos])))
                     ++cpos;
                 cookie_name = cookie_name.substr(cpos);
                 std::string cookie_value = coo.substr(epos + 1);
                 cpos = 0;
                 while (cpos < cookie_value.length() &&
-                       isspace(cookie_value[cpos]))
+                       isspace(static_cast<unsigned char>(cookie_value[cpos])))
                     ++cpos;
                 cookie_value = cookie_value.substr(cpos);
                 cookies_[std::move(cookie_name)] = std::move(cookie_value);
@@ -445,13 +445,13 @@ void HttpRequestImpl::addHeader(const char *start,
                 std::string cookie_name = coo.substr(0, epos);
                 std::string::size_type cpos = 0;
                 while (cpos < cookie_name.length() &&
-                       isspace(cookie_name[cpos]))
+                       isspace(static_cast<unsigned char>(cookie_name[cpos])))
                     ++cpos;
                 cookie_name = cookie_name.substr(cpos);
                 std::string cookie_value = coo.substr(epos + 1);
                 cpos = 0;
                 while (cpos < cookie_value.length() &&
-                       isspace(cookie_value[cpos]))
+                       isspace(static_cast<unsigned char>(cookie_value[cpos])))
                     ++cpos;
                 cookie_value = cookie_value.substr(cpos);
                 cookies_[std::move(cookie_name)] = std::move(cookie_value);

--- a/lib/src/HttpRequestImpl.cc
+++ b/lib/src/HttpRequestImpl.cc
@@ -76,7 +76,8 @@ void HttpRequestImpl::parseParameters() const
     if (!input.empty())
     {
         string_view::size_type pos = 0;
-        while ((input[pos] == '?' || isspace(static_cast<unsigned char>(input[pos]))) &&
+        while ((input[pos] == '?' ||
+                isspace(static_cast<unsigned char>(input[pos]))) &&
                pos < input.length())
         {
             ++pos;
@@ -90,7 +91,8 @@ void HttpRequestImpl::parseParameters() const
             {
                 auto key = coo.substr(0, epos);
                 string_view::size_type cpos = 0;
-                while (cpos < key.length() && isspace(static_cast<unsigned char>(key[cpos])))
+                while (cpos < key.length() &&
+                       isspace(static_cast<unsigned char>(key[cpos])))
                     ++cpos;
                 key = key.substr(cpos);
                 auto pvalue = coo.substr(epos + 1);
@@ -108,7 +110,8 @@ void HttpRequestImpl::parseParameters() const
             {
                 auto key = coo.substr(0, epos);
                 string_view::size_type cpos = 0;
-                while (cpos < key.length() && isspace(static_cast<unsigned char>(key[cpos])))
+                while (cpos < key.length() &&
+                       isspace(static_cast<unsigned char>(key[cpos])))
                     ++cpos;
                 key = key.substr(cpos);
                 auto pvalue = coo.substr(epos + 1);
@@ -130,7 +133,8 @@ void HttpRequestImpl::parseParameters() const
         type.find("application/x-www-form-urlencoded") != std::string::npos)
     {
         string_view::size_type pos = 0;
-        while ((input[pos] == '?' || isspace(static_cast<unsigned char>(input[pos]))) &&
+        while ((input[pos] == '?' ||
+                isspace(static_cast<unsigned char>(input[pos]))) &&
                pos < input.length())
         {
             ++pos;
@@ -144,7 +148,8 @@ void HttpRequestImpl::parseParameters() const
             {
                 auto key = coo.substr(0, epos);
                 string_view::size_type cpos = 0;
-                while (cpos < key.length() && isspace(static_cast<unsigned char>(key[cpos])))
+                while (cpos < key.length() &&
+                       isspace(static_cast<unsigned char>(key[cpos])))
                     ++cpos;
                 key = key.substr(cpos);
                 auto pvalue = coo.substr(epos + 1);
@@ -162,7 +167,8 @@ void HttpRequestImpl::parseParameters() const
             {
                 auto key = coo.substr(0, epos);
                 string_view::size_type cpos = 0;
-                while (cpos < key.length() && isspace(static_cast<unsigned char>(key[cpos])))
+                while (cpos < key.length() &&
+                       isspace(static_cast<unsigned char>(key[cpos])))
                     ++cpos;
                 key = key.substr(cpos);
                 auto pvalue = coo.substr(epos + 1);
@@ -406,7 +412,8 @@ void HttpRequestImpl::addHeader(const char *start,
         ++colon;
     }
     std::string value(colon, end);
-    while (!value.empty() && isspace(static_cast<unsigned char>(value[value.size() - 1])))
+    while (!value.empty() &&
+           isspace(static_cast<unsigned char>(value[value.size() - 1])))
     {
         value.resize(value.size() - 1);
     }

--- a/lib/src/HttpResponseImpl.cc
+++ b/lib/src/HttpResponseImpl.cc
@@ -765,7 +765,8 @@ void HttpResponseImpl::addHeader(const char *start,
         ++colon;
     }
     std::string value(colon, end);
-    while (!value.empty() && isspace(static_cast<unsigned char>(value[value.size() - 1])))
+    while (!value.empty() &&
+           isspace(static_cast<unsigned char>(value[value.size() - 1])))
     {
         value.resize(value.size() - 1);
     }
@@ -791,14 +792,16 @@ void HttpResponseImpl::addHeader(const char *start,
                     ++cpos;
                 cookie_name = cookie_name.substr(cpos);
                 ++epos;
-                while (epos < coo.length() && isspace(static_cast<unsigned char>(coo[epos])))
+                while (epos < coo.length() &&
+                       isspace(static_cast<unsigned char>(coo[epos])))
                     ++epos;
                 cookie_value = coo.substr(epos);
             }
             else
             {
                 std::string::size_type cpos = 0;
-                while (cpos < coo.length() && isspace(static_cast<unsigned char>(coo[cpos])))
+                while (cpos < coo.length() &&
+                       isspace(static_cast<unsigned char>(coo[cpos])))
                     ++cpos;
                 cookie_name = coo.substr(cpos);
             }

--- a/lib/src/HttpResponseImpl.cc
+++ b/lib/src/HttpResponseImpl.cc
@@ -760,12 +760,12 @@ void HttpResponseImpl::addHeader(const char *start,
         return tolower(c);
     });
     ++colon;
-    while (colon < end && isspace(*colon))
+    while (colon < end && isspace(static_cast<unsigned char>(*colon)))
     {
         ++colon;
     }
     std::string value(colon, end);
-    while (!value.empty() && isspace(value[value.size() - 1]))
+    while (!value.empty() && isspace(static_cast<unsigned char>(value[value.size() - 1])))
     {
         value.resize(value.size() - 1);
     }
@@ -787,18 +787,18 @@ void HttpResponseImpl::addHeader(const char *start,
                 cookie_name = coo.substr(0, epos);
                 std::string::size_type cpos = 0;
                 while (cpos < cookie_name.length() &&
-                       isspace(cookie_name[cpos]))
+                       isspace(static_cast<unsigned char>(cookie_name[cpos])))
                     ++cpos;
                 cookie_name = cookie_name.substr(cpos);
                 ++epos;
-                while (epos < coo.length() && isspace(coo[epos]))
+                while (epos < coo.length() && isspace(static_cast<unsigned char>(coo[epos])))
                     ++epos;
                 cookie_value = coo.substr(epos);
             }
             else
             {
                 std::string::size_type cpos = 0;
-                while (cpos < coo.length() && isspace(coo[cpos]))
+                while (cpos < coo.length() && isspace(static_cast<unsigned char>(coo[cpos])))
                     ++cpos;
                 cookie_name = coo.substr(cpos);
             }

--- a/orm_lib/src/sqlite3_impl/Sqlite3Connection.cc
+++ b/orm_lib/src/sqlite3_impl/Sqlite3Connection.cc
@@ -153,7 +153,7 @@ void Sqlite3Connection::execSqlInQueue(
             return;
         }
         if (!std::all_of(remaining, sql.data() + sql.size(), [](char ch) {
-                return std::isspace(ch);
+                return std::isspace(static_cast<unsigned char>(ch));
             }))
         {
             auto exceptPtr = std::make_exception_ptr(SqlError(


### PR DESCRIPTION
… unsigned char.

As described in issue #1666, the std:isspace function is called in wrong way in some cases (3 files). Character must be send as unsigned char, otherwise library has undefined behaviour (read outside of allocated memory, return undefined values, crash program, terminate program in debug mode). At least it can be exploited by external client sending cookie with values in range 128-254.  This pull request fixes all calls to std::isspace with char argument.