### PR TITLE
Update build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -92,9 +92,9 @@ else
     make_flags="$make_flags -j$parallel"
 fi
 
-if [ "$1" = "-t" ]; then
+if [ "X$1" = "X-t" ]; then
     build_drogon 1
-elif [ "$1" = "-tshared" ]; then
+elif [ "X$1" = "X-tshared" ]; then
     build_drogon 2
 else
     build_drogon 0


### PR DESCRIPTION
It is recommended to use the letter 'X' when comparing strings because if the string is a - it causes issues according to the book with the turtle.