### PR TITLE
Drop C++14 Support

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -81,11 +81,6 @@ jobs:
             buildname: 'ubuntu-20.04/gcc-10'
             link: STATIC
             triplet: x64-linux
-          - os: ubuntu-20.04
-            buildname: 'ubuntu-20.04/c++14'
-            link: STATIC
-            triplet: x64-linux
-            compiler: gcc_64
           - os: macos-latest
             buildname: 'macos/clang'
             link: STATIC
@@ -116,11 +111,6 @@ jobs:
     - name: (Linux) Install gcc-10
       if: matrix.buildname == 'ubuntu-20.04/gcc-10'
       run: sudo apt-get install -y gcc-10 g++-10
-    - name: (Linux) Install boost
-      if: matrix.buildname == 'ubuntu-20.04/c++14'
-      run: |
-        sudo apt-get update
-        sudo apt-get -y install libboost-all-dev
 
     - name: (Linux) Install postgresql
       if: matrix.os == 'ubuntu-20.04'
@@ -134,7 +124,7 @@ jobs:
     - name: Create Build Environment & Configure Cmake
       # Some projects don't allow in-source building, so create a separate build directory
       # We'll use this as our working directory for all subsequent commands
-      if: matrix.buildname != 'ubuntu-20.04/gcc-10' && matrix.buildname != 'ubuntu-20.04/c++14'
+      if: matrix.buildname != 'ubuntu-20.04/gcc-10'
       run: |
         cmake -B build                   \
           -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
@@ -154,17 +144,6 @@ jobs:
       env:
         CC: gcc-10
         CXX: g++-10
-
-    - name: Create Build Environment & Configure Cmake (C++14)
-      # Some projects don't allow in-source building, so create a separate build directory
-      # We'll use this as our working directory for all subsequent commands
-      if: matrix.buildname == 'ubuntu-20.04/C++14'
-      run: |
-        cmake -B build                   \
-          -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
-          -DBUILD_TESTING=on             \
-          -DCMAKE_CXX_STANDARD=14        \
-          -DBUILD_SHARED_LIBS=$shared
 
     - name: Build
       working-directory: ./build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,10 +88,8 @@ if (NOT "${CMAKE_CXX_STANDARD}" STREQUAL "")
     set(DROGON_CXX_STANDARD ${CMAKE_CXX_STANDARD})
 elseif (HAS_ANY AND HAS_STRING_VIEW AND HAS_COROUTINE)
     set(DROGON_CXX_STANDARD 20)
-elseif (HAS_ANY AND HAS_STRING_VIEW)
-    set(DROGON_CXX_STANDARD 17)
 else ()
-    set(DROGON_CXX_STANDARD 14)
+    set(DROGON_CXX_STANDARD 17)
 endif ()
 if(USE_SUBMODULE)
     target_include_directories(
@@ -139,16 +137,7 @@ endif()
 
 # Check for C++ filesystem support
 set(NEED_BOOST_FS 0)
-if (DROGON_CXX_STANDARD EQUAL 14)
-    # With C++14, use Boost to support any and string_view
-    message(STATUS "use c++14")
-    find_package(Boost 1.61.0 REQUIRED)
-    message(STATUS "Using Boost filesystem, string_view and any")
-    message(STATUS "Boost include dir: " ${Boost_INCLUDE_DIR})
-    target_link_libraries(${PROJECT_NAME} PUBLIC Boost::boost)
-    list(APPEND INCLUDE_DIRS_FOR_DYNAMIC_VIEW ${Boost_INCLUDE_DIR})
-    set(NEED_BOOST_FS 1)
-elseif (DROGON_CXX_STANDARD EQUAL 17)
+if (DROGON_CXX_STANDARD EQUAL 17)
     # With C++17, use Boost if std::filesystem::path is missing
     message(STATUS "use c++17")
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 English | [简体中文](./README.zh-CN.md) | [繁體中文](./README.zh-TW.md)
 ### Overview
-**Drogon** is a C++14/17-based HTTP application framework. Drogon can be used to easily build various types of web application server programs using C++. **Drogon** is the name of a dragon in the American TV series "Game of Thrones" that I really like.
+**Drogon** is a C++17/20 based HTTP application framework. Drogon can be used to easily build various types of web application server programs using C++. **Drogon** is the name of a dragon in the American TV series "Game of Thrones" that I really like.
 
 Drogon is a cross-platform framework, It supports Linux, macOS, FreeBSD, OpenBSD, HaikuOS, and Windows. Its main features are as follows:
 


### PR DESCRIPTION
Related to:
* https://github.com/drogonframework/drogon/issues/1589

This PR is the first step among the tasks:
* Update CMakeLists.txt to use only C++17 or later