### PR TITLE
fix race condition when setting the secure flag during test

### DIFF
--- a/lib/tests/integration_test/client/main.cc
+++ b/lib/tests/integration_test/client/main.cc
@@ -59,11 +59,11 @@ void doTest(const HttpClientPtr &client, std::shared_ptr<test::Case> TEST_CTX)
                                 auto &id = resp->getCookie("JSESSIONID");
                                 REQUIRE(id);
 
+                                haveCert = resp->peerCertificate() != nullptr;
+
                                 sessionID = id;
                                 client->addCookie(id);
                                 waitCookie.set_value(1);
-
-                                haveCert = resp->peerCertificate() != nullptr;
                             });
         f.get();
         CHECK(haveCert == client->secure());


### PR DESCRIPTION
This PR fixes a very subtle race condition in the integration test client, the existing code set `waitCookie` too early. Thus when the check `haveCert == client->secure()` below can run before assigning value.

This was not even reproducible on x86. Somehow very reproducible on a IBM s390x machine.