### PR TITLE
Added isHead() method to HttpRequest, to preserve information about the original method for use in the controller

### DIFF
--- a/lib/inc/drogon/HttpRequest.h
+++ b/lib/inc/drogon/HttpRequest.h
@@ -123,6 +123,14 @@ class DROGON_EXPORT HttpRequest
         return method();
     }
 
+    /**
+     * @brief Check if the method is or was HttpMethod::Head
+     * @details Allows to know that an incoming request is a HEAD request, since drogon sets the
+     *          method to HttpMethod::Get before calling the controller
+     * @return true if method() returns HttpMethod::Head, or HttpMethod::Get but was previously HttpMethod::Head
+     */
+    virtual bool isHead() const = 0;
+
     /// Get the header string identified by the key parameter.
     /**
      * @note

--- a/lib/inc/drogon/HttpRequest.h
+++ b/lib/inc/drogon/HttpRequest.h
@@ -125,9 +125,11 @@ class DROGON_EXPORT HttpRequest
 
     /**
      * @brief Check if the method is or was HttpMethod::Head
-     * @details Allows to know that an incoming request is a HEAD request, since drogon sets the
-     *          method to HttpMethod::Get before calling the controller
-     * @return true if method() returns HttpMethod::Head, or HttpMethod::Get but was previously HttpMethod::Head
+     * @details Allows to know that an incoming request is a HEAD request, since
+     *          drogon sets the method to HttpMethod::Get before calling the
+     *          controller
+     * @return true if method() returns HttpMethod::Head, or HttpMethod::Get but
+     *              was previously HttpMethod::Head
      */
     virtual bool isHead() const = 0;
 

--- a/lib/src/HttpRequestImpl.h
+++ b/lib/src/HttpRequestImpl.h
@@ -124,7 +124,8 @@ class HttpRequestImpl : public HttpRequest
     bool isHead() const override
     {
         return (method_ == HttpMethod::Head) ||
-                ((method_ == HttpMethod::Get) && (previousMethod_ == HttpMethod::Head));
+               ((method_ == HttpMethod::Get) &&
+                (previousMethod_ == HttpMethod::Head));
     }
 
     const char *methodString() const override;

--- a/lib/src/HttpRequestImpl.h
+++ b/lib/src/HttpRequestImpl.h
@@ -55,6 +55,7 @@ class HttpRequestImpl : public HttpRequest
     void reset()
     {
         method_ = Invalid;
+        previousMethod_ = Invalid;
         version_ = Version::kUnknown;
         flagForParsingJson_ = false;
         headers_.clear();
@@ -110,6 +111,7 @@ class HttpRequestImpl : public HttpRequest
 
     void setMethod(const HttpMethod method) override
     {
+        previousMethod_ = method_;
         method_ = method;
         return;
     }
@@ -117,6 +119,12 @@ class HttpRequestImpl : public HttpRequest
     HttpMethod method() const override
     {
         return method_;
+    }
+
+    bool isHead() const override
+    {
+        return (method_ == HttpMethod::Head) ||
+                ((method_ == HttpMethod::Get) && (previousMethod_ == HttpMethod::Head));
     }
 
     const char *methodString() const override;
@@ -576,6 +584,7 @@ class HttpRequestImpl : public HttpRequest
     mutable bool flagForParsingParameters_{false};
     mutable bool flagForParsingJson_{false};
     HttpMethod method_{Invalid};
+    HttpMethod previousMethod_{Invalid};
     Version version_{Version::kUnknown};
     std::string path_;
     std::string originalPath_;


### PR DESCRIPTION
Proposal to fix the issue #1728

This adds a way for the HttpController path routing methods to know if the HttpRequest they get have been initiated by a GET or a HEAD.
It allows to differentiate between them, therefore avoiding the overhead of internal processing and generation of a body that is then dropped when the request was HEAD.

Simple example: HEAD /huge_file -> don't put in in the body of the HttpResponse!

I think it's the most lighweight and compatible solution.

Another solution would be to keep the method (not overriding it with HttpMethod::Get), but that would be problematic for existing softwares using drogon, since they should register the HttpMethod::Head method for all the paths. And there could be other internal side effects I'm not aware of.

The cleanest one, but that would probably require much more work, would be to 1. keep the Head method, and 2. to call the HttpController path routing method for HttpMethod::Get if no method has been registered for HttpMethod::Head.
But… I don't think that it would bring much in comparison to my proposal. After all, a Head answer is nearly the same as a Get answer, but without body. It should not be necessary to have separate methods in the HttpController.
