### PR TITLE
Set concurrency to prevent blocking CI queue

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   BUILD_TYPE: Release


### PR DESCRIPTION
Only on PRs, this update automatically stops previous CI runnings in the same PR. This can prevent the CI queue from being stuck from many commits on PRs. This does not affect the branches on this repo.