### PR TITLE
Use ninja to build faster

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -90,7 +90,7 @@ jobs:
       - name: Build
         working-directory: ./build
         # Execute the build.  You can specify a specific target with "--target <NAME>"
-        run: ninja && sudo make install
+        run: ninja && sudo ninja install
 
       - name: Prepare for testing
         run: |
@@ -172,7 +172,7 @@ jobs:
       - name: Build
         working-directory: ./build
         # Execute the build.  You can specify a specific target with "--target <NAME>"
-        run: ninja && sudo make install
+        run: ninja && sudo ninja install
 
       - name: Prepare for testing
         run: |

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -100,7 +100,7 @@ jobs:
     - name: (macOS) Install dependencies
       if: runner.os == 'macOS'
       # Already installed: brotli, zlib, postgresql@14, lz4, sqlite3
-      run: brew install jsoncpp mariadb hiredis redis
+      run: brew install ninja jsoncpp mariadb hiredis redis
 
     - name: (Linux) Install dependencies
       if: runner.os == 'Linux'
@@ -109,7 +109,7 @@ jobs:
         sudo apt update
         # These aren't available or don't work well in vcpkg
         sudo apt-get install -y libjsoncpp-dev uuid-dev libssl-dev zlib1g-dev libsqlite3-dev
-        sudo apt-get install -y libbrotli-dev
+        sudo apt-get install -y ninja-build libbrotli-dev
     - name: (Linux) Install gcc-10
       if: matrix.buildname == 'ubuntu-22.04/gcc-10'
       run: sudo apt-get install -y gcc-10 g++-10
@@ -129,7 +129,7 @@ jobs:
       # We'll use this as our working directory for all subsequent commands
       if: matrix.buildname != 'ubuntu-22.04/gcc-10'
       run: |
-        cmake -B build                   \
+        cmake -B build -G Ninja          \
           -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
           -DBUILD_TESTING=on             \
           -DBUILD_SHARED_LIBS=$shared
@@ -139,7 +139,7 @@ jobs:
       # We'll use this as our working directory for all subsequent commands
       if: matrix.buildname == 'ubuntu-22.04/gcc-10'
       run: |
-        cmake -B build                     \
+        cmake -B build -G Ninja            \
           -DCMAKE_BUILD_TYPE=$BUILD_TYPE   \
           -DBUILD_TESTING=on               \
           -DCMAKE_CXX_FLAGS="-fcoroutines" \
@@ -151,7 +151,7 @@ jobs:
     - name: Build
       working-directory: ./build
       # Execute the build.  You can specify a specific target with "--target <NAME>"
-      run: make -j $(nproc) && sudo make install
+      run: ninja && sudo ninja install
 
     - name: (macOS) Prepare for testing
       if: runner.os == 'macOS'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -45,13 +45,13 @@ jobs:
       run: |
         sudo apt update
         sudo apt-get install -y libjsoncpp-dev uuid-dev libssl-dev zlib1g-dev libsqlite3-dev
-        sudo apt-get install -y libbrotli-dev
+        sudo apt-get install -y ninja-build libbrotli-dev
 
     - name: Create Build Environment & Configure Cmake
       run: |
-        cmake -B build \
+        cmake -B build -G Ninja          \
           -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
-          -DBUILD_TESTING=on \
+          -DBUILD_TESTING=on             \
           -DBUILD_SHARED_LIBS=$SHARED
 
     # Initializes the CodeQL tools for scanning.
@@ -68,7 +68,7 @@ jobs:
 
     - name: Build
       working-directory: ./build
-      run: make -j $(nproc) && sudo make install
+      run: ninja && sudo ninja install
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2


### PR DESCRIPTION
Comparison with https://github.com/drogonframework/drogon/actions/runs/5991466219?pr=1754:

* Ubuntu 22.04 (Shared): 6m 38s -> 5m 27s
* Ubuntu 22.04 (Static): 7m 9s -> 6m 52s
* Ubuntu 22.04 (Coroutines): cannot compare since coroutine one uses GCC 11 while this PR uses GCC 10
* CodeQL: 13m 51s -> 12m 42s
* macOS: 7m 8s -> 11m 3s

These comparisons might not be reliable since CPU clock speed is not consistent on GitHub Actions IIRC.