### PR TITLE
SlashRemover optimization

### DIFF
--- a/lib/src/SlashRemover.cc
+++ b/lib/src/SlashRemover.cc
@@ -51,23 +51,20 @@ static inline size_t findDuplicateSlashes(string_view url)
     if (len < 2)
         return string::npos;
 
-    size_t a = 1;
-    while (a < len)
+    bool startedPair = true;  // Always starts with a slash
+    for (size_t a = 1; a < len; ++a)
     {
-        if (url[a] != '/')
+        if (url[a] != '/')  // Broken pair
         {
-            a += 2;  // No need to check again on this same char
+            startedPair = false;
             continue;
         }
-        if (url[a - 1] != '/')
-        {
-            ++a;
-            continue;
-        }
-        break;
+        if (startedPair)  // Matching pair
+            return a;
+        startedPair = true;
     }
 
-    return a < len ? a : string::npos;
+    return string::npos;
 }
 
 static inline void removeDuplicateSlashes(string& url, size_t start)
@@ -107,23 +104,21 @@ static inline std::pair<size_t, size_t> findExcessiveSlashes(string_view url)
 
     // Look for a duplicate pair
     size_t dupIdx = 1;
-    while (dupIdx < trailIdx)
+    for (bool startedPair = true; dupIdx < trailIdx;
+         ++dupIdx)  // Always starts with a slash
     {
-        if (url[dupIdx] != '/')
+        if (url[dupIdx] != '/')  // Broken pair
         {
-            dupIdx += 2;  // No need to check again on this same char
+            startedPair = false;
             continue;
         }
-        if (url[dupIdx - 1] != '/')
-        {
-            ++dupIdx;
-            continue;
-        }
-        break;
+        if (startedPair)  // Matching pair
+            break;
+        startedPair = true;
     }
 
     // Found no duplicate
-    if (dupIdx >= trailIdx)
+    if (dupIdx == trailIdx)
         return {
             trailIdx != len - 1
                 ?  // If has gone past last char, then there is a trailing slash

--- a/lib/src/SlashRemover.cc
+++ b/lib/src/SlashRemover.cc
@@ -52,8 +52,20 @@ static inline size_t findDuplicateSlashes(string_view url)
         return string::npos;
 
     size_t a = 1;
-    for (; a < len && (url[a - 1] != '/' || url[a] != '/'); ++a)
-        ;
+    while (a < len)
+    {
+        if (url[a] != '/')
+        {
+            a += 2;  // No need to check again on this same char
+            continue;
+        }
+        if (url[a - 1] != '/')
+        {
+            ++a;
+            continue;
+        }
+        break;
+    }
 
     return a < len ? a : string::npos;
 }
@@ -95,12 +107,23 @@ static inline std::pair<size_t, size_t> findExcessiveSlashes(string_view url)
 
     // Look for a duplicate pair
     size_t dupIdx = 1;
-    for (; dupIdx < trailIdx && (url[dupIdx - 1] != '/' || url[dupIdx] != '/');
-         ++dupIdx)
-        ;
+    while (dupIdx < trailIdx)
+    {
+        if (url[dupIdx] != '/')
+        {
+            dupIdx += 2;  // No need to check again on this same char
+            continue;
+        }
+        if (url[dupIdx - 1] != '/')
+        {
+            ++dupIdx;
+            continue;
+        }
+        break;
+    }
 
     // Found no duplicate
-    if (dupIdx == trailIdx)
+    if (dupIdx >= trailIdx)
         return {
             trailIdx != len - 1
                 ?  // If has gone past last char, then there is a trailing slash

--- a/lib/tests/unittests/SlashRemoverTest.cc
+++ b/lib/tests/unittests/SlashRemoverTest.cc
@@ -6,117 +6,174 @@ using std::string;
 
 DROGON_TEST(SlashRemoverTest)
 {
-    const string url = "///home//page//", urlNoTrail = "///home//page",
-                 urlNoDup = "/home/page/", urlNoExcess = "/home/page",
-                 root = "///", rootNoExcess = "/";
-
     string cleanUrl;
 
-    // Full
-    removeTrailingSlashes(cleanUrl, findTrailingSlashes(url), url);
-    CHECK(cleanUrl == urlNoTrail);
+    {  // Regular URL
+        const string urlNoTrail = "///home//page", urlNoDup = "/home/page/",
+                     urlNoExcess = "/home/page";
 
-    cleanUrl = url;
-    removeDuplicateSlashes(cleanUrl, findDuplicateSlashes(url));
-    CHECK(cleanUrl == urlNoDup);
+        SUBSECTION(Full)
+        {
+            const string url = "///home//page//";
+            removeTrailingSlashes(cleanUrl, findTrailingSlashes(url), url);
+            CHECK(cleanUrl == urlNoTrail);
 
-    removeExcessiveSlashes(cleanUrl, findExcessiveSlashes(url), url);
-    CHECK(cleanUrl == urlNoExcess);
+            cleanUrl = url;
+            removeDuplicateSlashes(cleanUrl, findDuplicateSlashes(url));
+            CHECK(cleanUrl == urlNoDup);
 
-    // Partial
-    removeExcessiveSlashes(cleanUrl,
-                           findExcessiveSlashes(urlNoTrail),
-                           urlNoTrail);
-    CHECK(cleanUrl == urlNoExcess);
+            removeExcessiveSlashes(cleanUrl, findExcessiveSlashes(url), url);
+            CHECK(cleanUrl == urlNoExcess);
+        }
 
-    removeExcessiveSlashes(cleanUrl, findExcessiveSlashes(urlNoDup), urlNoDup);
-    CHECK(cleanUrl == urlNoExcess);
+        SUBSECTION(Partial)
+        {
+            removeExcessiveSlashes(cleanUrl,
+                                   findExcessiveSlashes(urlNoTrail),
+                                   urlNoTrail);
+            CHECK(cleanUrl == urlNoExcess);
 
-    // Root
-    cleanUrl = root;
-    removeTrailingSlashes(cleanUrl, findTrailingSlashes(root), root);
-    CHECK(cleanUrl == rootNoExcess);
-
-    cleanUrl = root;
-    removeDuplicateSlashes(cleanUrl, findDuplicateSlashes(root));
-    CHECK(cleanUrl == rootNoExcess);
-
-    removeExcessiveSlashes(cleanUrl, findExcessiveSlashes(root), root);
-    CHECK(cleanUrl == rootNoExcess);
-
-    // Test precedence when both match the same place
-    const string url2 = "/a///", url2NoDup = "/a/", url2NoExcess = "/a";
-
-    removeTrailingSlashes(cleanUrl, findTrailingSlashes(url2), url2);
-    CHECK(cleanUrl == url2NoExcess);
-
-    cleanUrl = url2;
-    removeDuplicateSlashes(cleanUrl, findDuplicateSlashes(url2));
-    CHECK(cleanUrl == url2NoDup);
-
-    removeExcessiveSlashes(cleanUrl, findExcessiveSlashes(url2), url2);
-    CHECK(cleanUrl == url2NoExcess);
-
-    // Test when trail does not match
-    const string url3 = "///a", url3NoExcess = "/a";
-
-    cleanUrl.clear();
-    {
-        auto find = findTrailingSlashes(url3);
-        if (find != string::npos)
-            removeTrailingSlashes(cleanUrl, find, url3);
+            removeExcessiveSlashes(cleanUrl,
+                                   findExcessiveSlashes(urlNoDup),
+                                   urlNoDup);
+            CHECK(cleanUrl == urlNoExcess);
+        }
     }
-    CHECK(cleanUrl.empty());
 
-    cleanUrl = url3;
-    removeDuplicateSlashes(cleanUrl, findDuplicateSlashes(url3));
-    CHECK(cleanUrl == url3NoExcess);
-
-    removeExcessiveSlashes(cleanUrl, findExcessiveSlashes(url3), url3);
-    CHECK(cleanUrl == url3NoExcess);
-
-    // Test when duplicate does not match
-    const string url4 = "/a/", url4NoExcess = "/a";
-
-    removeTrailingSlashes(cleanUrl, findTrailingSlashes(url4), url4);
-    CHECK(cleanUrl == url4NoExcess);
-
-    cleanUrl = url4;
+    SUBSECTION(Root)
     {
-        auto find = findDuplicateSlashes(cleanUrl);
-        if (find != string::npos)
-            removeDuplicateSlashes(cleanUrl, find);
+        const string urlNoExcess = "/";
+
+        {  // Overlapping indices
+            const string url = "//";
+
+            cleanUrl = url;
+            removeTrailingSlashes(cleanUrl, findTrailingSlashes(url), url);
+            CHECK(cleanUrl == urlNoExcess);
+
+            cleanUrl = url;
+            removeDuplicateSlashes(cleanUrl, findDuplicateSlashes(url));
+            CHECK(cleanUrl == urlNoExcess);
+
+            removeExcessiveSlashes(cleanUrl, findExcessiveSlashes(url), url);
+            CHECK(cleanUrl == urlNoExcess);
+        }
+
+        {  // Intersecting indices
+            const string url = "///";
+
+            cleanUrl = url;
+            removeTrailingSlashes(cleanUrl, findTrailingSlashes(url), url);
+            CHECK(cleanUrl == urlNoExcess);
+
+            cleanUrl = url;
+            removeDuplicateSlashes(cleanUrl, findDuplicateSlashes(url));
+            CHECK(cleanUrl == urlNoExcess);
+
+            removeExcessiveSlashes(cleanUrl, findExcessiveSlashes(url), url);
+            CHECK(cleanUrl == urlNoExcess);
+        }
     }
-    CHECK(cleanUrl == url4);
 
-    cleanUrl = url4;
-    removeExcessiveSlashes(cleanUrl, findExcessiveSlashes(url4), url4);
-    CHECK(cleanUrl == url4NoExcess);
-
-    // Test when neither match
-    const string url5 = "/a";
-
-    cleanUrl.clear();
+    SUBSECTION(Overlap)
     {
-        auto find = findTrailingSlashes(url5);
-        if (find != string::npos)
-            removeTrailingSlashes(cleanUrl, find, url5);
-    }
-    CHECK(cleanUrl.empty());
+        const string urlNoDup = "/a/", urlNoExcess = "/a";
 
-    cleanUrl = url5;
-    {
-        auto find = findDuplicateSlashes(cleanUrl);
-        if (find != string::npos)
-            removeDuplicateSlashes(cleanUrl, find);
-    }
-    CHECK(cleanUrl == url5);
+        {  // Overlapping indices
+            const string url = "/a//";
 
-    cleanUrl.clear();
-    {
-        auto find = findExcessiveSlashes(url5);
-        if (find.first != string::npos || find.second != string::npos)
-            removeExcessiveSlashes(cleanUrl, find, url5);
+            removeTrailingSlashes(cleanUrl, findTrailingSlashes(url), url);
+            CHECK(cleanUrl == urlNoExcess);
+
+            cleanUrl = url;
+            removeDuplicateSlashes(cleanUrl, findDuplicateSlashes(url));
+            CHECK(cleanUrl == urlNoDup);
+
+            removeExcessiveSlashes(cleanUrl, findExcessiveSlashes(url), url);
+            CHECK(cleanUrl == urlNoExcess);
+        }
+
+        {  // Intersecting indices
+            const string url = "/a///";
+
+            removeTrailingSlashes(cleanUrl, findTrailingSlashes(url), url);
+            CHECK(cleanUrl == urlNoExcess);
+
+            cleanUrl = url;
+            removeDuplicateSlashes(cleanUrl, findDuplicateSlashes(url));
+            CHECK(cleanUrl == urlNoDup);
+
+            removeExcessiveSlashes(cleanUrl, findExcessiveSlashes(url), url);
+            CHECK(cleanUrl == urlNoExcess);
+        }
     }
-    CHECK(cleanUrl.empty());
+
+    SUBSECTION(NoTrail)
+    {
+        const string url = "//a", urlNoExcess = "/a";
+
+        cleanUrl.clear();
+        {
+            auto find = findTrailingSlashes(url);
+            if (find != string::npos)
+                removeTrailingSlashes(cleanUrl, find, url);
+        }
+        CHECK(cleanUrl.empty());
+
+        cleanUrl = url;
+        removeDuplicateSlashes(cleanUrl, findDuplicateSlashes(url));
+        CHECK(cleanUrl == urlNoExcess);
+
+        removeExcessiveSlashes(cleanUrl, findExcessiveSlashes(url), url);
+        CHECK(cleanUrl == urlNoExcess);
+    }
+
+    SUBSECTION(NoDuplicate)
+    {
+        const string url = "/a/", urlNoExcess = "/a";
+
+        removeTrailingSlashes(cleanUrl, findTrailingSlashes(url), url);
+        CHECK(cleanUrl == urlNoExcess);
+
+        cleanUrl = url;
+        {
+            auto find = findDuplicateSlashes(cleanUrl);
+            if (find != string::npos)
+                removeDuplicateSlashes(cleanUrl, find);
+        }
+        CHECK(cleanUrl == url);
+
+        cleanUrl = url;
+        removeExcessiveSlashes(cleanUrl, findExcessiveSlashes(url), url);
+        CHECK(cleanUrl == urlNoExcess);
+    }
+
+    SUBSECTION(None)
+    {
+        const string url = "/a";
+
+        cleanUrl.clear();
+        {
+            auto find = findTrailingSlashes(url);
+            if (find != string::npos)
+                removeTrailingSlashes(cleanUrl, find, url);
+        }
+        CHECK(cleanUrl.empty());
+
+        cleanUrl = url;
+        {
+            auto find = findDuplicateSlashes(cleanUrl);
+            if (find != string::npos)
+                removeDuplicateSlashes(cleanUrl, find);
+        }
+        CHECK(cleanUrl == url);
+
+        cleanUrl.clear();
+        {
+            auto find = findExcessiveSlashes(url);
+            if (find.first != string::npos || find.second != string::npos)
+                removeExcessiveSlashes(cleanUrl, find, url);
+        }
+        CHECK(cleanUrl.empty());
+    }
 }

--- a/lib/tests/unittests/SlashRemoverTest.cc
+++ b/lib/tests/unittests/SlashRemoverTest.cc
@@ -1,5 +1,6 @@
 #include <drogon/drogon_test.h>
 #include <../../lib/src/SlashRemover.cc>
+#include <string>
 
 using std::string;
 
@@ -9,35 +10,114 @@ DROGON_TEST(SlashRemoverTest)
                  urlNoDup = "/home/page/", urlNoExcess = "/home/page",
                  root = "///", rootNoExcess = "/";
 
-    string cleanUrl = url;
-    removeTrailingSlashes(cleanUrl);
+    string cleanUrl;
+
+    // Full
+    removeTrailingSlashes(cleanUrl, findTrailingSlashes(url), url);
     CHECK(cleanUrl == urlNoTrail);
 
     cleanUrl = url;
-    removeDuplicateSlashes(cleanUrl);
+    removeDuplicateSlashes(cleanUrl, findDuplicateSlashes(url));
     CHECK(cleanUrl == urlNoDup);
 
-    cleanUrl = url;
-    removeExcessiveSlashes(cleanUrl);
+    removeExcessiveSlashes(cleanUrl, findExcessiveSlashes(url), url);
     CHECK(cleanUrl == urlNoExcess);
 
-    cleanUrl = urlNoTrail;
-    removeExcessiveSlashes(cleanUrl);
+    // Partial
+    removeExcessiveSlashes(cleanUrl,
+                           findExcessiveSlashes(urlNoTrail),
+                           urlNoTrail);
     CHECK(cleanUrl == urlNoExcess);
 
-    cleanUrl = urlNoDup;
-    removeExcessiveSlashes(cleanUrl);
+    removeExcessiveSlashes(cleanUrl, findExcessiveSlashes(urlNoDup), urlNoDup);
     CHECK(cleanUrl == urlNoExcess);
 
+    // Root
     cleanUrl = root;
-    removeTrailingSlashes(cleanUrl);
+    removeTrailingSlashes(cleanUrl, findTrailingSlashes(root), root);
     CHECK(cleanUrl == rootNoExcess);
 
     cleanUrl = root;
-    removeDuplicateSlashes(cleanUrl);
+    removeDuplicateSlashes(cleanUrl, findDuplicateSlashes(root));
     CHECK(cleanUrl == rootNoExcess);
 
-    cleanUrl = root;
-    removeExcessiveSlashes(cleanUrl);
+    removeExcessiveSlashes(cleanUrl, findExcessiveSlashes(root), root);
     CHECK(cleanUrl == rootNoExcess);
+
+    // Test precedence when both match the same place
+    const string url2 = "/a///", url2NoTrail = "/a", url2NoDup = "/a/",
+                 url2NoExcess = url2NoTrail;
+
+    removeTrailingSlashes(cleanUrl, findTrailingSlashes(url2), url2);
+    CHECK(cleanUrl == url2NoTrail);
+
+    cleanUrl = url2;
+    removeDuplicateSlashes(cleanUrl, findDuplicateSlashes(url2));
+    CHECK(cleanUrl == url2NoDup);
+
+    removeExcessiveSlashes(cleanUrl, findExcessiveSlashes(url2), url2);
+    CHECK(cleanUrl == url2NoExcess);
+
+    // Test when trail does not match
+    const string url3 = "///a", url3NoDup = "/a", url3NoExcess = url3NoDup;
+
+    cleanUrl.clear();
+    {
+        auto find = findTrailingSlashes(url3);
+        if (find != string::npos)
+            removeTrailingSlashes(cleanUrl, find, url3);
+    }
+    CHECK(cleanUrl.empty());
+
+    cleanUrl = url3;
+    removeDuplicateSlashes(cleanUrl, findDuplicateSlashes(url3));
+    CHECK(cleanUrl == url3NoDup);
+
+    removeExcessiveSlashes(cleanUrl, findExcessiveSlashes(url3), url3);
+    CHECK(cleanUrl == url3NoExcess);
+
+    // Test when duplicate does not match
+    const string url4 = "/a/", url4NoTrail = "/a", url4NoExcess = url4NoTrail;
+
+    removeTrailingSlashes(cleanUrl, findTrailingSlashes(url4), url4);
+    CHECK(cleanUrl == url4NoTrail);
+
+    cleanUrl.clear();
+    {
+        auto find = findDuplicateSlashes(url4);
+        if (find != string::npos)
+            removeDuplicateSlashes(cleanUrl, find);
+    }
+    CHECK(cleanUrl.empty());
+
+    cleanUrl = url4;
+    removeExcessiveSlashes(cleanUrl, findExcessiveSlashes(url4), url4);
+    CHECK(cleanUrl == url4NoExcess);
+
+    // Test when neither match
+    const string url5 = "/a", url5NoExcess = url5;
+
+    cleanUrl.clear();
+    {
+        auto find = findTrailingSlashes(url5);
+        if (find != string::npos)
+            removeTrailingSlashes(cleanUrl, find, url5);
+    }
+    CHECK(cleanUrl.empty());
+
+    cleanUrl.clear();
+    {
+        auto find = findDuplicateSlashes(url5);
+        if (find != string::npos)
+            removeDuplicateSlashes(cleanUrl, find);
+    }
+    CHECK(cleanUrl.empty());
+
+    cleanUrl.clear();
+    {
+        auto find = findExcessiveSlashes(url5);
+        if (find.first != string::npos || find.second != string::npos)
+            removeExcessiveSlashes(cleanUrl, find, url5);
+    }
+    CHECK(cleanUrl.empty());
 }

--- a/lib/tests/unittests/SlashRemoverTest.cc
+++ b/lib/tests/unittests/SlashRemoverTest.cc
@@ -45,11 +45,10 @@ DROGON_TEST(SlashRemoverTest)
     CHECK(cleanUrl == rootNoExcess);
 
     // Test precedence when both match the same place
-    const string url2 = "/a///", url2NoTrail = "/a", url2NoDup = "/a/",
-                 url2NoExcess = url2NoTrail;
+    const string url2 = "/a///", url2NoDup = "/a/", url2NoExcess = "/a";
 
     removeTrailingSlashes(cleanUrl, findTrailingSlashes(url2), url2);
-    CHECK(cleanUrl == url2NoTrail);
+    CHECK(cleanUrl == url2NoExcess);
 
     cleanUrl = url2;
     removeDuplicateSlashes(cleanUrl, findDuplicateSlashes(url2));
@@ -59,7 +58,7 @@ DROGON_TEST(SlashRemoverTest)
     CHECK(cleanUrl == url2NoExcess);
 
     // Test when trail does not match
-    const string url3 = "///a", url3NoDup = "/a", url3NoExcess = url3NoDup;
+    const string url3 = "///a", url3NoExcess = "/a";
 
     cleanUrl.clear();
     {
@@ -71,31 +70,31 @@ DROGON_TEST(SlashRemoverTest)
 
     cleanUrl = url3;
     removeDuplicateSlashes(cleanUrl, findDuplicateSlashes(url3));
-    CHECK(cleanUrl == url3NoDup);
+    CHECK(cleanUrl == url3NoExcess);
 
     removeExcessiveSlashes(cleanUrl, findExcessiveSlashes(url3), url3);
     CHECK(cleanUrl == url3NoExcess);
 
     // Test when duplicate does not match
-    const string url4 = "/a/", url4NoTrail = "/a", url4NoExcess = url4NoTrail;
+    const string url4 = "/a/", url4NoExcess = "/a";
 
     removeTrailingSlashes(cleanUrl, findTrailingSlashes(url4), url4);
-    CHECK(cleanUrl == url4NoTrail);
+    CHECK(cleanUrl == url4NoExcess);
 
-    cleanUrl.clear();
+    cleanUrl = url4;
     {
-        auto find = findDuplicateSlashes(url4);
+        auto find = findDuplicateSlashes(cleanUrl);
         if (find != string::npos)
             removeDuplicateSlashes(cleanUrl, find);
     }
-    CHECK(cleanUrl.empty());
+    CHECK(cleanUrl == url4);
 
     cleanUrl = url4;
     removeExcessiveSlashes(cleanUrl, findExcessiveSlashes(url4), url4);
     CHECK(cleanUrl == url4NoExcess);
 
     // Test when neither match
-    const string url5 = "/a", url5NoExcess = url5;
+    const string url5 = "/a";
 
     cleanUrl.clear();
     {
@@ -105,13 +104,13 @@ DROGON_TEST(SlashRemoverTest)
     }
     CHECK(cleanUrl.empty());
 
-    cleanUrl.clear();
+    cleanUrl = url5;
     {
-        auto find = findDuplicateSlashes(url5);
+        auto find = findDuplicateSlashes(cleanUrl);
         if (find != string::npos)
             removeDuplicateSlashes(cleanUrl, find);
     }
-    CHECK(cleanUrl.empty());
+    CHECK(cleanUrl == url5);
 
     cleanUrl.clear();
     {


### PR DESCRIPTION
Removes regex and uses loops instead.
Does not copy the entirety of `req->path()` for trailing slash remover, as we remove its last N slash characters anyway.
It's one pass, meaning lookup, replacement, and erasure all happen in one swipe through the path.