### PR TITLE
add optional Criteria && || operator support

### DIFF
--- a/orm_lib/src/Criteria.cc
+++ b/orm_lib/src/Criteria.cc
@@ -21,8 +21,16 @@ namespace orm
 {
 const Criteria operator&&(Criteria cond1, Criteria cond2)
 {
-    assert(cond1);
-    assert(cond2);
+    bool cond1valid = (bool)cond1, cond2valid = (bool)cond2;
+    assert(cond1valid || cond2valid);
+    if (cond1valid && !cond2valid)
+    {
+        return cond1;
+    }
+    if (!cond1valid && cond2valid)
+    {
+        return cond2;
+    }
     Criteria cond;
     cond.conditionString_ = "( ";
     cond.conditionString_ += cond1.conditionString_;
@@ -47,8 +55,16 @@ const Criteria operator&&(Criteria cond1, Criteria cond2)
 
 const Criteria operator||(Criteria cond1, Criteria cond2)
 {
-    assert(cond1);
-    assert(cond2);
+    bool cond1valid = (bool)cond1, cond2valid = (bool)cond2;
+    assert(cond1valid || cond2valid);
+    if (cond1valid && !cond2valid)
+    {
+        return cond1;
+    }
+    if (!cond1valid && cond2valid)
+    {
+        return cond2;
+    }
     Criteria cond;
     cond.conditionString_ = "( ";
     cond.conditionString_ += cond1.conditionString_;


### PR DESCRIPTION
I noticed operator&&(Criteria,Criteria) and operator||(Criteria,Criteria) need both Criteria has non empty conditionString.When I use drogon build an API which has optional query parameter,it is difficult to dynamically construct a Criteria like this:
```
auto LikeService::count(std::optional<int64_t> gid, std::string uid){
orm::CoroMapper<Likes> mapper = ....;
  Criteria criteria;
  if (uid.size()) {
    criteria = criteria && Criteria(Likes::Cols::_user_id, uid);
  }
  if (gid) {
    criteria = criteria && Criteria(Likes::Cols::_good_id, *gid);
  }
  co_return co_await mapper.count(criteria);
}
```
This small patch return the Criteria which not empty when other is empty.It should not break API.