### PR TITLE
FIX int mapping to int64_t instead of uint64_t

### DIFF
--- a/drogon_ctl/create_model.cc
+++ b/drogon_ctl/create_model.cc
@@ -693,7 +693,7 @@ void create_model::createModelClassFromSqlite3(
 
             if (type.find("int") != std::string::npos)
             {
-                info.colType_ = "uint64_t";
+                info.colType_ = "int64_t";
                 info.colLength_ = 8;
             }
             else if (type.find("char") != std::string::npos || type == "text" ||


### PR DESCRIPTION
Negative numbers were not passing json validation

Ideally we should have a test which breaks in the old version and is now fixed, but I'm unsure where to start there.