### PR TITLE
Pass HttpRequestPtr to custom error handlers

### DIFF
--- a/lib/inc/drogon/HttpAppFramework.h
+++ b/lib/inc/drogon/HttpAppFramework.h
@@ -175,6 +175,16 @@ class DROGON_EXPORT HttpAppFramework : public trantor::NonCopyable
                                       const HttpRequestPtr &req)>
             &&resp_generator) = 0;
 
+    virtual HttpAppFramework &setCustomErrorHandler(
+        std::function<HttpResponsePtr(HttpStatusCode)> &&resp_generator)
+    {
+        return setCustomErrorHandler(
+            [cb = std::move(resp_generator)](HttpStatusCode code,
+                                             const HttpRequestPtr &) {
+                return cb(code);
+            });
+    }
+
     /// Get custom error handler
     /**
      * @return A const-reference to the error handler set using

--- a/lib/inc/drogon/HttpAppFramework.h
+++ b/lib/inc/drogon/HttpAppFramework.h
@@ -175,7 +175,7 @@ class DROGON_EXPORT HttpAppFramework : public trantor::NonCopyable
                                       const HttpRequestPtr &req)>
             &&resp_generator) = 0;
 
-    virtual HttpAppFramework &setCustomErrorHandler(
+    HttpAppFramework &setCustomErrorHandler(
         std::function<HttpResponsePtr(HttpStatusCode)> &&resp_generator)
     {
         return setCustomErrorHandler(

--- a/lib/inc/drogon/HttpAppFramework.h
+++ b/lib/inc/drogon/HttpAppFramework.h
@@ -171,7 +171,9 @@ class DROGON_EXPORT HttpAppFramework : public trantor::NonCopyable
      * be sent to the client to provide a custom layout.
      */
     virtual HttpAppFramework &setCustomErrorHandler(
-        std::function<HttpResponsePtr(HttpStatusCode)> &&resp_generator) = 0;
+        std::function<HttpResponsePtr(HttpStatusCode,
+                                      const HttpRequestPtr &req)>
+            &&resp_generator) = 0;
 
     /// Get custom error handler
     /**
@@ -179,8 +181,9 @@ class DROGON_EXPORT HttpAppFramework : public trantor::NonCopyable
      * setCustomErrorHandler. If none was provided, the default error handler is
      * returned.
      */
-    virtual const std::function<HttpResponsePtr(HttpStatusCode)>
-        &getCustomErrorHandler() const = 0;
+    virtual const std::function<HttpResponsePtr(HttpStatusCode,
+                                                const HttpRequestPtr &req)> &
+    getCustomErrorHandler() const = 0;
 
     /// Get the plugin object registered in the framework
     /**
@@ -1391,8 +1394,8 @@ class DROGON_EXPORT HttpAppFramework : public trantor::NonCopyable
      *
      * @return std::pair<size_t, std::string>
      */
-    virtual const std::pair<unsigned int, std::string>
-        &getFloatPrecisionInJson() const noexcept = 0;
+    virtual const std::pair<unsigned int, std::string> &
+    getFloatPrecisionInJson() const noexcept = 0;
     /// Create a database client
     /**
      * @param dbType The database type is one of

--- a/lib/inc/drogon/HttpAppFramework.h
+++ b/lib/inc/drogon/HttpAppFramework.h
@@ -182,8 +182,8 @@ class DROGON_EXPORT HttpAppFramework : public trantor::NonCopyable
      * returned.
      */
     virtual const std::function<HttpResponsePtr(HttpStatusCode,
-                                                const HttpRequestPtr &req)> &
-    getCustomErrorHandler() const = 0;
+                                                const HttpRequestPtr &req)>
+        &getCustomErrorHandler() const = 0;
 
     /// Get the plugin object registered in the framework
     /**
@@ -1394,8 +1394,8 @@ class DROGON_EXPORT HttpAppFramework : public trantor::NonCopyable
      *
      * @return std::pair<size_t, std::string>
      */
-    virtual const std::pair<unsigned int, std::string> &
-    getFloatPrecisionInJson() const noexcept = 0;
+    virtual const std::pair<unsigned int, std::string>
+        &getFloatPrecisionInJson() const noexcept = 0;
     /// Create a database client
     /**
      * @param dbType The database type is one of

--- a/lib/inc/drogon/HttpResponse.h
+++ b/lib/inc/drogon/HttpResponse.h
@@ -17,6 +17,7 @@
 #include <trantor/net/Certificate.h>
 #include <drogon/DrClassMap.h>
 #include <drogon/Cookie.h>
+#include <drogon/HttpRequest.h>
 #include <drogon/HttpTypes.h>
 #include <drogon/HttpViewData.h>
 #include <drogon/utils/Utilities.h>
@@ -199,14 +200,16 @@ class DROGON_EXPORT HttpResponse
     virtual void removeHeader(std::string key) = 0;
 
     /// Get all headers of the response
-    virtual const std::
-        unordered_map<std::string, std::string, utils::internal::SafeStringHash>
-            &headers() const = 0;
+    virtual const std::unordered_map<std::string,
+                                     std::string,
+                                     utils::internal::SafeStringHash> &
+    headers() const = 0;
 
     /// Get all headers of the response
-    const std::
-        unordered_map<std::string, std::string, utils::internal::SafeStringHash>
-            &getHeaders() const
+    const std::unordered_map<std::string,
+                             std::string,
+                             utils::internal::SafeStringHash> &
+    getHeaders() const
     {
         return headers();
     }
@@ -235,13 +238,13 @@ class DROGON_EXPORT HttpResponse
 
     /// Get all cookies.
     virtual const std::
-        unordered_map<std::string, Cookie, utils::internal::SafeStringHash>
-            &cookies() const = 0;
+        unordered_map<std::string, Cookie, utils::internal::SafeStringHash> &
+        cookies() const = 0;
 
     /// Get all cookies.
     const std::
-        unordered_map<std::string, Cookie, utils::internal::SafeStringHash>
-            &getCookies() const
+        unordered_map<std::string, Cookie, utils::internal::SafeStringHash> &
+        getCookies() const
     {
         return cookies();
     }
@@ -368,7 +371,8 @@ class DROGON_EXPORT HttpResponse
     static HttpResponsePtr newHttpResponse(HttpStatusCode code,
                                            ContentType type);
     /// Create a response which returns a 404 page.
-    static HttpResponsePtr newNotFoundResponse();
+    static HttpResponsePtr newNotFoundResponse(
+        const HttpRequestPtr &req = HttpRequestPtr());
     /// Create a response which returns a json object. Its content-type is set
     /// to application/json.
     static HttpResponsePtr newHttpJsonResponse(const Json::Value &data);
@@ -384,7 +388,8 @@ class DROGON_EXPORT HttpResponse
      */
     static HttpResponsePtr newHttpViewResponse(
         const std::string &viewName,
-        const HttpViewData &data = HttpViewData());
+        const HttpViewData &data = HttpViewData(),
+        const HttpRequestPtr &req = HttpRequestPtr());
 
     /// Create a response that returns a redirection page, redirecting to
     /// another page located in the location parameter.
@@ -411,7 +416,8 @@ class DROGON_EXPORT HttpResponse
         const std::string &fullPath,
         const std::string &attachmentFileName = "",
         ContentType type = CT_NONE,
-        const std::string &typeString = "");
+        const std::string &typeString = "",
+        const HttpRequestPtr &req = HttpRequestPtr());
 
     /// Create a response that returns part of a file to the client.
     /**
@@ -437,7 +443,8 @@ class DROGON_EXPORT HttpResponse
         bool setContentRange = true,
         const std::string &attachmentFileName = "",
         ContentType type = CT_NONE,
-        const std::string &typeString = "");
+        const std::string &typeString = "",
+        const HttpRequestPtr &req = HttpRequestPtr());
 
     /// Create a response that returns a file to the client from buffer in
     /// memory/stack
@@ -479,7 +486,8 @@ class DROGON_EXPORT HttpResponse
         const std::function<std::size_t(char *, std::size_t)> &callback,
         const std::string &attachmentFileName = "",
         ContentType type = CT_NONE,
-        const std::string &typeString = "");
+        const std::string &typeString = "",
+        const HttpRequestPtr &req = HttpRequestPtr());
 
     /**
      * @brief Create a custom HTTP response object. For using this template,
@@ -511,8 +519,8 @@ class DROGON_EXPORT HttpResponse
      * newStreamResponse) returns the callback function. Otherwise a
      * null function.
      */
-    virtual const std::function<std::size_t(char *, std::size_t)>
-        &streamCallback() const = 0;
+    virtual const std::function<std::size_t(char *, std::size_t)> &
+    streamCallback() const = 0;
 
     /**
      * @brief Returns the content type associated with the response

--- a/lib/inc/drogon/HttpResponse.h
+++ b/lib/inc/drogon/HttpResponse.h
@@ -200,16 +200,14 @@ class DROGON_EXPORT HttpResponse
     virtual void removeHeader(std::string key) = 0;
 
     /// Get all headers of the response
-    virtual const std::unordered_map<std::string,
-                                     std::string,
-                                     utils::internal::SafeStringHash> &
-    headers() const = 0;
+    virtual const std::
+        unordered_map<std::string, std::string, utils::internal::SafeStringHash>
+            &headers() const = 0;
 
     /// Get all headers of the response
-    const std::unordered_map<std::string,
-                             std::string,
-                             utils::internal::SafeStringHash> &
-    getHeaders() const
+    const std::
+        unordered_map<std::string, std::string, utils::internal::SafeStringHash>
+            &getHeaders() const
     {
         return headers();
     }
@@ -238,13 +236,13 @@ class DROGON_EXPORT HttpResponse
 
     /// Get all cookies.
     virtual const std::
-        unordered_map<std::string, Cookie, utils::internal::SafeStringHash> &
-        cookies() const = 0;
+        unordered_map<std::string, Cookie, utils::internal::SafeStringHash>
+            &cookies() const = 0;
 
     /// Get all cookies.
     const std::
-        unordered_map<std::string, Cookie, utils::internal::SafeStringHash> &
-        getCookies() const
+        unordered_map<std::string, Cookie, utils::internal::SafeStringHash>
+            &getCookies() const
     {
         return cookies();
     }
@@ -519,8 +517,8 @@ class DROGON_EXPORT HttpResponse
      * newStreamResponse) returns the callback function. Otherwise a
      * null function.
      */
-    virtual const std::function<std::size_t(char *, std::size_t)> &
-    streamCallback() const = 0;
+    virtual const std::function<std::size_t(char *, std::size_t)>
+        &streamCallback() const = 0;
 
     /**
      * @brief Returns the content type associated with the response

--- a/lib/src/HttpAppFrameworkImpl.cc
+++ b/lib/src/HttpAppFrameworkImpl.cc
@@ -1214,9 +1214,8 @@ HttpAppFramework &HttpAppFrameworkImpl::setCustomErrorHandler(
     return *this;
 }
 
-const std::function<HttpResponsePtr(HttpStatusCode,
-                                    const HttpRequestPtr &req)> &
-HttpAppFrameworkImpl::getCustomErrorHandler() const
+const std::function<HttpResponsePtr(HttpStatusCode, const HttpRequestPtr &req)>
+    &HttpAppFrameworkImpl::getCustomErrorHandler() const
 {
     return customErrorHandler_;
 }

--- a/lib/src/HttpAppFrameworkImpl.cc
+++ b/lib/src/HttpAppFrameworkImpl.cc
@@ -1034,8 +1034,8 @@ void HttpAppFrameworkImpl::forward(
         req->setPassThrough(true);
         clientPtr->sendRequest(
             req,
-            [callback = std::move(callback),
-             req = req](ReqResult result, const HttpResponsePtr &resp) {
+            [callback = std::move(callback), req](ReqResult result,
+                                                  const HttpResponsePtr &resp) {
                 if (result == ReqResult::Ok)
                 {
                     resp->setPassThrough(true);
@@ -1214,8 +1214,9 @@ HttpAppFramework &HttpAppFrameworkImpl::setCustomErrorHandler(
     return *this;
 }
 
-const std::function<HttpResponsePtr(HttpStatusCode, const HttpRequestPtr &req)>
-    &HttpAppFrameworkImpl::getCustomErrorHandler() const
+const std::function<HttpResponsePtr(HttpStatusCode,
+                                    const HttpRequestPtr &req)> &
+HttpAppFrameworkImpl::getCustomErrorHandler() const
 {
     return customErrorHandler_;
 }

--- a/lib/src/HttpAppFrameworkImpl.h
+++ b/lib/src/HttpAppFrameworkImpl.h
@@ -33,7 +33,8 @@ class EventLoopThreadPool;
 
 namespace drogon
 {
-HttpResponsePtr defaultErrorHandler(HttpStatusCode code);
+HttpResponsePtr defaultErrorHandler(HttpStatusCode code,
+                                    const HttpRequestPtr &req);
 void defaultExceptionHandler(const std::exception &,
                              const HttpRequestPtr &,
                              std::function<void(const HttpResponsePtr &)> &&);
@@ -108,8 +109,9 @@ class HttpAppFrameworkImpl final : public HttpAppFramework
     }
 
     HttpAppFramework &setCustomErrorHandler(
-        std::function<HttpResponsePtr(HttpStatusCode)> &&resp_generator)
-        override;
+        std::function<HttpResponsePtr(HttpStatusCode,
+                                      const HttpRequestPtr &req)>
+            &&resp_generator) override;
 
     const HttpResponsePtr &getCustom404Page();
 
@@ -146,8 +148,8 @@ class HttpAppFrameworkImpl final : public HttpAppFramework
         return *this;
     }
 
-    const std::vector<std::function<void(const HttpResponsePtr &)>>
-        &getResponseCreationAdvices() const
+    const std::vector<std::function<void(const HttpResponsePtr &)>> &
+    getResponseCreationAdvices() const
     {
         return responseCreationAdvices_;
     }
@@ -619,8 +621,9 @@ class HttpAppFrameworkImpl final : public HttpAppFramework
     }
 
     bool areAllDbClientsAvailable() const noexcept override;
-    const std::function<HttpResponsePtr(HttpStatusCode)>
-        &getCustomErrorHandler() const override;
+    const std::function<HttpResponsePtr(HttpStatusCode,
+                                        const HttpRequestPtr &req)> &
+    getCustomErrorHandler() const override;
 
     bool isUsingCustomErrorHandler() const
     {
@@ -764,8 +767,8 @@ class HttpAppFrameworkImpl final : public HttpAppFramework
     Json::Value jsonConfig_;
     Json::Value jsonRuntimeConfig_;
     HttpResponsePtr custom404_;
-    std::function<HttpResponsePtr(HttpStatusCode)> customErrorHandler_ =
-        &defaultErrorHandler;
+    std::function<HttpResponsePtr(HttpStatusCode, const HttpRequestPtr &req)>
+        customErrorHandler_ = &defaultErrorHandler;
     static InitBeforeMainFunction initFirst_;
     bool enableServerHeader_{true};
     bool enableDateHeader_{true};

--- a/lib/src/HttpAppFrameworkImpl.h
+++ b/lib/src/HttpAppFrameworkImpl.h
@@ -148,8 +148,8 @@ class HttpAppFrameworkImpl final : public HttpAppFramework
         return *this;
     }
 
-    const std::vector<std::function<void(const HttpResponsePtr &)>> &
-    getResponseCreationAdvices() const
+    const std::vector<std::function<void(const HttpResponsePtr &)>>
+        &getResponseCreationAdvices() const
     {
         return responseCreationAdvices_;
     }
@@ -622,8 +622,8 @@ class HttpAppFrameworkImpl final : public HttpAppFramework
 
     bool areAllDbClientsAvailable() const noexcept override;
     const std::function<HttpResponsePtr(HttpStatusCode,
-                                        const HttpRequestPtr &req)> &
-    getCustomErrorHandler() const override;
+                                        const HttpRequestPtr &req)>
+        &getCustomErrorHandler() const override;
 
     bool isUsingCustomErrorHandler() const
     {

--- a/lib/src/HttpControllersRouter.cc
+++ b/lib/src/HttpControllersRouter.cc
@@ -516,11 +516,11 @@ void HttpControllersRouter::route(
         // Invalid Http Method
         if (req->method() != Options)
         {
-            callback(app().getCustomErrorHandler()(k405MethodNotAllowed));
+            callback(app().getCustomErrorHandler()(k405MethodNotAllowed, req));
         }
         else
         {
-            callback(app().getCustomErrorHandler()(k403Forbidden));
+            callback(app().getCustomErrorHandler()(k403Forbidden, req));
         }
         return;
     }

--- a/lib/src/HttpResponseImpl.cc
+++ b/lib/src/HttpResponseImpl.cc
@@ -174,7 +174,7 @@ HttpResponsePtr HttpResponse::newNotFoundResponse(const HttpRequestPtr &req)
                             .isUsingCustomErrorHandler())
                     {
                         resp = app().getCustomErrorHandler()(k404NotFound, req);
-                        resp->setExpiredTime(0);
+                        resp->setExpiredTime(-1);
                     }
                     else
                     {

--- a/lib/src/HttpServer.cc
+++ b/lib/src/HttpServer.cc
@@ -38,20 +38,20 @@ using namespace drogon;
 using namespace trantor;
 
 static void defaultHttpAsyncCallback(
-    const HttpRequestPtr &,
+    const HttpRequestPtr &req,
     std::function<void(const HttpResponsePtr &resp)> &&callback)
 {
-    auto resp = HttpResponse::newNotFoundResponse();
+    auto resp = HttpResponse::newNotFoundResponse(req);
     resp->setCloseConnection(true);
     callback(resp);
 }
 
 static void defaultWebSockAsyncCallback(
-    const HttpRequestPtr &,
+    const HttpRequestPtr &req,
     std::function<void(const HttpResponsePtr &resp)> &&callback,
     const WebSocketConnectionImplPtr &)
 {
-    auto resp = HttpResponse::newNotFoundResponse();
+    auto resp = HttpResponse::newNotFoundResponse(req);
     resp->setCloseConnection(true);
     callback(resp);
 }

--- a/lib/src/HttpSimpleControllersRouter.cc
+++ b/lib/src/HttpSimpleControllersRouter.cc
@@ -110,11 +110,12 @@ void HttpSimpleControllersRouter::route(
             // Invalid Http Method
             if (req->method() != Options)
             {
-                callback(app().getCustomErrorHandler()(k405MethodNotAllowed));
+                callback(
+                    app().getCustomErrorHandler()(k405MethodNotAllowed, req));
             }
             else
             {
-                callback(app().getCustomErrorHandler()(k403Forbidden));
+                callback(app().getCustomErrorHandler()(k403Forbidden, req));
             }
             return;
         }
@@ -275,7 +276,7 @@ void HttpSimpleControllersRouter::doControllerHandler(
     {
         const std::string &ctrlName = ctrlBinderPtr->controllerName_;
         LOG_ERROR << "can't find controller " << ctrlName;
-        auto res = drogon::HttpResponse::newNotFoundResponse();
+        auto res = drogon::HttpResponse::newNotFoundResponse(req);
         invokeCallback(callback, req, res);
     }
 }

--- a/lib/src/IntranetIpFilter.cc
+++ b/lib/src/IntranetIpFilter.cc
@@ -25,6 +25,6 @@ void IntranetIpFilter::doFilter(const HttpRequestPtr &req,
         fccb();
         return;
     }
-    auto res = drogon::HttpResponse::newNotFoundResponse();
+    auto res = drogon::HttpResponse::newNotFoundResponse(req);
     fcb(res);
 }

--- a/lib/src/LocalHostFilter.cc
+++ b/lib/src/LocalHostFilter.cc
@@ -25,6 +25,6 @@ void LocalHostFilter::doFilter(const HttpRequestPtr &req,
         fccb();
         return;
     }
-    auto res = drogon::HttpResponse::newNotFoundResponse();
+    auto res = drogon::HttpResponse::newNotFoundResponse(req);
     fcb(res);
 }

--- a/lib/src/PromExporter.cc
+++ b/lib/src/PromExporter.cc
@@ -22,7 +22,7 @@ void PromExporter::initAndStart(const Json::Value &config)
             auto thisPtr = weakPtr.lock();
             if (!thisPtr)
             {
-                auto resp = HttpResponse::newNotFoundResponse();
+                auto resp = HttpResponse::newNotFoundResponse(req);
                 callback(resp);
                 return;
             }

--- a/lib/src/Redirector.cc
+++ b/lib/src/Redirector.cc
@@ -34,7 +34,7 @@ void Redirector::initAndStart(const Json::Value &config)
             {
                 if (!handler(req, protocol, host, pathChanged))
                 {
-                    return HttpResponse::newNotFoundResponse();
+                    return HttpResponse::newNotFoundResponse(req);
                 }
             }
             for (auto &handler : thisPtr->pathRewriteHandlers_)

--- a/lib/src/StaticFileRouter.cc
+++ b/lib/src/StaticFileRouter.cc
@@ -26,8 +26,8 @@
 #include <sys/file.h>
 #elif !defined(__MINGW32__)
 #define stat _wstati64
-#define S_ISREG(m) (((m) & 0170000) == (0100000))
-#define S_ISDIR(m) (((m) & 0170000) == (0040000))
+#define S_ISREG(m) (((m)&0170000) == (0100000))
+#define S_ISDIR(m) (((m)&0170000) == (0040000))
 #endif
 #include <sys/stat.h>
 #include <filesystem>

--- a/lib/src/WebsocketControllersRouter.cc
+++ b/lib/src/WebsocketControllersRouter.cc
@@ -200,12 +200,12 @@ void WebsocketControllersRouter::route(
                 // Invalid Http Method
                 if (req->method() != Options)
                 {
-                    callback(
-                        app().getCustomErrorHandler()(k405MethodNotAllowed));
+                    callback(app().getCustomErrorHandler()(k405MethodNotAllowed,
+                                                           req));
                 }
                 else
                 {
-                    callback(app().getCustomErrorHandler()(k403Forbidden));
+                    callback(app().getCustomErrorHandler()(k403Forbidden, req));
                 }
                 return;
             }
@@ -299,7 +299,7 @@ void WebsocketControllersRouter::route(
             return;
         }
     }
-    auto resp = drogon::HttpResponse::newNotFoundResponse();
+    auto resp = drogon::HttpResponse::newNotFoundResponse(req);
     resp->setCloseConnection(true);
     callback(resp);
 }


### PR DESCRIPTION
Resolves #1811.
Passing request data to custom error handlers allows to generate a user-specific response (authorization state, language, details on why access is denied, where to redirect to etc.).