### PR TITLE
Add `session_cookie_key` config option

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -106,6 +106,8 @@
         //string value of SameSite attribute of the Set-Cookie HTTP respone header
         //valid value is either 'Null' (default), 'Lax', 'Strict' or 'None'
         "session_same_site" : "Null",
+        //session_cookie_key: The cookie key of the session, "JSESSIONID" by default
+        "session_cookie_key": "JSESSIONID",
         //document_root: Root path of HTTP document, defaut path is ./
         "document_root": "./",
         //home_page: Set the HTML file of the home page, the default value is "index.html"

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -92,6 +92,8 @@ app:
   # string value of SameSite attribute of the Set-Cookie HTTP respone header
   # valid value is either 'Null' (default), 'Lax', 'Strict' or 'None'
   session_same_site: 'Null'
+  # session_cookie_key: The cookie key of the session, "JSESSIONID" by default
+  session_cookie_key: 'JSESSIONID'
   # document_root: Root path of HTTP document, defaut path is ./
   document_root: ./
   # home_page: Set the HTML file of the home page, the default value is "index.html"

--- a/drogon_ctl/templates/config_json.csp
+++ b/drogon_ctl/templates/config_json.csp
@@ -106,6 +106,8 @@
         //string value of SameSite attribute of the Set-Cookie HTTP respone header
         //valid value is either 'Null' (default), 'Lax', 'Strict' or 'None'
         "session_same_site" : "Null",
+        //session_cookie_key: The cookie key of the session, "JSESSIONID" by default
+        "session_cookie_key": "JSESSIONID",
         //document_root: Root path of HTTP document, defaut path is ./
         "document_root": "./",
         //home_page: Set the HTML file of the home page, the default value is "index.html"

--- a/drogon_ctl/templates/config_yaml.csp
+++ b/drogon_ctl/templates/config_yaml.csp
@@ -92,6 +92,8 @@ app:
   # string value of SameSite attribute of the Set-Cookie HTTP respone header
   # valid value is either 'Null' (default), 'Lax', 'Strict' or 'None'
   session_same_site: 'Null'
+  //session_cookie_key: The cookie key of the session, "JSESSIONID" by default
+  "session_cookie_key": "JSESSIONID",
   # document_root: Root path of HTTP document, defaut path is ./
   document_root: ./
   # home_page: Set the HTML file of the home page, the default value is "index.html"

--- a/examples/redis_cache/config.json
+++ b/examples/redis_cache/config.json
@@ -41,6 +41,8 @@
         //enable_session: False by default
         "enable_session": false,
         "session_timeout": 0,
+        //session_cookie_key: The cookie key of the session, "JSESSIONID" by default
+        "session_cookie_key": "JSESSIONID",
         //document_root: Root path of HTTP document, defaut path is ./
         "document_root": "./",
         //home_page: Set the HTML file of the home page, the default value is "index.html"

--- a/examples/simple_reverse_proxy/config.json
+++ b/examples/simple_reverse_proxy/config.json
@@ -22,6 +22,8 @@
         //enable_session: False by default
         "enable_session": false,
         "session_timeout": 0,
+        //session_cookie_key: The cookie key of the session, "JSESSIONID" by default
+        "session_cookie_key": "JSESSIONID",
         //document_root: Root path of HTTP document, defaut path is ./
         "document_root": "./",
         //home_page: Set the HTML file of the home page, the default value is "index.html"

--- a/lib/inc/drogon/HttpAppFramework.h
+++ b/lib/inc/drogon/HttpAppFramework.h
@@ -813,6 +813,7 @@ class DROGON_EXPORT HttpAppFramework : public trantor::NonCopyable
     /**
      * @param timeout The number of seconds which is the timeout of a session
      * @param sameSite The default value of SameSite attribute
+     * @param cookieKey The key of the session cookie
      *
      * @note
      * Session support is disabled by default.
@@ -823,7 +824,8 @@ class DROGON_EXPORT HttpAppFramework : public trantor::NonCopyable
      */
     virtual HttpAppFramework &enableSession(
         const size_t timeout = 0,
-        Cookie::SameSite sameSite = Cookie::SameSite::kNull) = 0;
+        Cookie::SameSite sameSite = Cookie::SameSite::kNull,
+        const std::string &cookieKey = "JSESSIONID") = 0;
 
     /// A wrapper of the above method.
     /**
@@ -835,9 +837,10 @@ class DROGON_EXPORT HttpAppFramework : public trantor::NonCopyable
      */
     inline HttpAppFramework &enableSession(
         const std::chrono::duration<double> &timeout,
-        Cookie::SameSite sameSite = Cookie::SameSite::kNull)
+        Cookie::SameSite sameSite = Cookie::SameSite::kNull,
+        const std::string &cookieKey = "JSESSIONID")
     {
-        return enableSession((size_t)timeout.count(), sameSite);
+        return enableSession((size_t)timeout.count(), sameSite, cookieKey);
     }
 
     /// Register an advice called when starting a new session.

--- a/lib/src/ConfigLoader.cc
+++ b/lib/src/ConfigLoader.cc
@@ -270,9 +270,11 @@ static void loadApp(const Json::Value &app)
     auto enableSession = app.get("enable_session", false).asBool();
     auto timeout = app.get("session_timeout", 0).asUInt64();
     auto sameSite = app.get("session_same_site", "Null").asString();
+    auto cookieKey = app.get("session_cookie_key", "JSESSIONID").asString();
     if (enableSession)
         drogon::app().enableSession(timeout,
-                                    Cookie::convertString2SameSite(sameSite));
+                                    Cookie::convertString2SameSite(sameSite),
+                                    cookieKey);
     else
         drogon::app().disableSession();
     // document root

--- a/lib/src/HttpAppFrameworkImpl.cc
+++ b/lib/src/HttpAppFrameworkImpl.cc
@@ -775,7 +775,7 @@ void HttpAppFrameworkImpl::findSessionForRequest(const HttpRequestImplPtr &req)
 {
     if (useSession_)
     {
-        std::string sessionId = req->getCookie("JSESSIONID");
+        std::string sessionId = req->getCookie(sessionCookieKey_);
         bool needSetJsessionid = false;
         if (sessionId.empty())
         {
@@ -857,20 +857,22 @@ void HttpAppFrameworkImpl::callCallback(
                 auto newResp = std::make_shared<HttpResponseImpl>(
                     *static_cast<HttpResponseImpl *>(resp.get()));
                 newResp->setExpiredTime(-1);  // make it temporary
-                auto jsessionid = Cookie("JSESSIONID", sessionPtr->sessionId());
-                jsessionid.setPath("/");
-                jsessionid.setSameSite(sessionSameSite_);
-                newResp->addCookie(std::move(jsessionid));
+                auto sessionid =
+                    Cookie(sessionCookieKey_, sessionPtr->sessionId());
+                sessionid.setPath("/");
+                sessionid.setSameSite(sessionSameSite_);
+                newResp->addCookie(std::move(sessionid));
                 sessionPtr->hasSet();
                 callback(newResp);
                 return;
             }
             else
             {
-                auto jsessionid = Cookie("JSESSIONID", sessionPtr->sessionId());
-                jsessionid.setPath("/");
-                jsessionid.setSameSite(sessionSameSite_);
-                resp->addCookie(std::move(jsessionid));
+                auto sessionid =
+                    Cookie(sessionCookieKey_, sessionPtr->sessionId());
+                sessionid.setPath("/");
+                sessionid.setSameSite(sessionSameSite_);
+                resp->addCookie(std::move(sessionid));
                 sessionPtr->hasSet();
                 callback(resp);
                 return;

--- a/lib/src/HttpAppFrameworkImpl.h
+++ b/lib/src/HttpAppFrameworkImpl.h
@@ -230,11 +230,13 @@ class HttpAppFrameworkImpl final : public HttpAppFramework
 
     HttpAppFramework &enableSession(
         const size_t timeout,
-        Cookie::SameSite sameSite = Cookie::SameSite::kNull) override
+        Cookie::SameSite sameSite = Cookie::SameSite::kNull,
+        const std::string &cookieKey = "JSESSIONID") override
     {
         useSession_ = true;
         sessionTimeout_ = timeout;
         sessionSameSite_ = sameSite;
+        sessionCookieKey_ = cookieKey;
         return *this;
     }
 
@@ -695,6 +697,7 @@ class HttpAppFrameworkImpl final : public HttpAppFramework
     // cookies;
     size_t sessionTimeout_{0};
     Cookie::SameSite sessionSameSite_{Cookie::SameSite::kNull};
+    std::string sessionCookieKey_{"JSESSIONID"};
     size_t idleConnectionTimeout_{60};
     bool useSession_{false};
     std::string serverHeader_{"server: drogon/" + drogon::getVersion() +


### PR DESCRIPTION
Allows sessions to have a different cookie key, instead of the hard-coded `"JSESSION"`.