### PR TITLE
Update test_cmake.csp

### DIFF
--- a/drogon_ctl/templates/test_cmake.csp
+++ b/drogon_ctl/templates/test_cmake.csp
@@ -6,7 +6,7 @@ add_executable(${PROJECT_NAME} test_main.cc)
 # ##############################################################################
 # If you include the drogon source code locally in your project, use this method
 # to add drogon 
-# target_link_libraries(${PROJECT_NAME}_test PRIVATE drogon)
+# target_link_libraries(${PROJECT_NAME} PRIVATE drogon)
 #
 # and comment out the following lines
 target_link_libraries(${PROJECT_NAME} PRIVATE Drogon::Drogon)


### PR DESCRIPTION
_test not needed for submodule target_link_libraries since it was added in project