### PR TITLE
Add CI tests with more compilers

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -124,8 +124,6 @@ jobs:
         link: [SHARED, STATIC]
         compiler:
           - cxx: g++
-            ver: 8
-          - cxx: g++
             ver: 9
           - cxx: g++
             ver: 10

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -66,8 +66,11 @@ jobs:
         run: ./test.sh -w
 
   macos:
-    name: macos/clang
-    runs-on: macos-latest
+    runs-on: macos-${{ matrix.osver }}
+    strategy:
+      fail-fast: false
+      matrix:
+        osver: [11, 12, 13]
     steps:
       - name: Checkout Drogon source code
         uses: actions/checkout@v4
@@ -121,11 +124,37 @@ jobs:
         link: [SHARED, STATIC]
         compiler:
           - cxx: g++
+            ver: 8
+          - cxx: g++
+            ver: 9
+          - cxx: g++
+            ver: 10
+          - cxx: g++
             ver: 11
           - cxx: g++
             ver: 12
           - cxx: g++
             ver: 13
+          - cxx: clang++
+            ver: 5
+          - cxx: clang++
+            ver: 6
+          - cxx: clang++
+            ver: 7
+          - cxx: clang++
+            ver: 8
+          - cxx: clang++
+            ver: 9
+          - cxx: clang++
+            ver: 10
+          - cxx: clang++
+            ver: 11
+          - cxx: clang++
+            ver: 12
+          - cxx: clang++
+            ver: 13
+          - cxx: clang++
+            ver: 14
           - cxx: clang++
             ver: 15
           - cxx: clang++

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -191,11 +191,11 @@ jobs:
           sudo apt-get -y install postgresql-all
 
       - name: Install Clang
-        if: startsWith(matrix.compiler.cxx, 'clang') && compiler.ver < 13
-        run: sudo apt-get install clang-${{ compiler.ver }}
+        if: startsWith(matrix.compiler.cxx, 'clang') && matrix.compiler.ver < 13
+        run: sudo apt-get install clang-${{ matrix.compiler.ver }}
 
       - name: Install Clang
-        if: startsWith(matrix.compiler.cxx, 'clang') && compiler.ver >= 13
+        if: startsWith(matrix.compiler.cxx, 'clang') && matrix.compiler.ver >= 13
         run: |
           wget https://apt.llvm.org/llvm.sh
           chmod +x ./llvm.sh

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -133,11 +133,11 @@ jobs:
           - cxx: clang++
             ver: 17
         include:
-          - feature: coroutines
-            link: STATIC
+          - link: STATIC
             compiler:
               cxx: g++
               ver: 13
+              feature: coroutines
     env:
       CXX: ${{ matrix.compiler.cxx }}-${{ matrix.compiler.ver }}
     steps:
@@ -176,7 +176,7 @@ jobs:
       - name: Create Build Environment & Configure Cmake
         # Some projects don't allow in-source building, so create a separate build directory
         # We'll use this as our working directory for all subsequent commands
-        if: matrix.feature != 'coroutines'
+        if: matrix.compiler.feature != 'coroutines'
         run: |
           cmake -B build -G Ninja          \
             -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
@@ -186,7 +186,7 @@ jobs:
       - name: Create Build Environment & Configure Cmake (coroutines)
         # Some projects don't allow in-source building, so create a separate build directory
         # We'll use this as our working directory for all subsequent commands
-        if: matrix.feature == 'coroutines'
+        if: matrix.compiler.feature == 'coroutines'
         run: |
           cmake -B build -G Ninja            \
             -DCMAKE_BUILD_TYPE=$BUILD_TYPE   \

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -191,7 +191,11 @@ jobs:
           sudo apt-get -y install postgresql-all
 
       - name: Install Clang
-        if: startsWith(matrix.compiler.cxx, 'clang')
+        if: startsWith(matrix.compiler.cxx, 'clang') && compiler.ver < 13
+        run: sudo apt-get install clang-${{ compiler.ver }}
+
+      - name: Install Clang
+        if: startsWith(matrix.compiler.cxx, 'clang') && compiler.ver >= 13
         run: |
           wget https://apt.llvm.org/llvm.sh
           chmod +x ./llvm.sh

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -79,8 +79,8 @@ jobs:
           fetch-depth: 0
 
       - name: Install dependencies
-        # Already installed: brotli, zlib, postgresql@14, lz4, sqlite3
-        run: brew install ninja jsoncpp mariadb hiredis redis spdlog
+        # Already installed: brotli, zlib, lz4, sqlite3
+        run: brew install ninja jsoncpp mariadb hiredis redis spdlog postgresql@14
 
       - name: Create Build Environment & Configure Cmake
         # Some projects don't allow in-source building, so create a separate build directory

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -114,18 +114,32 @@ jobs:
         run: ./test.sh -t
 
   ubuntu:
-    name: ${{ matrix.buildname }}
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
+        link: [SHARED, STATIC]
+        compiler:
+          - cxx: g++
+            ver: 11
+          - cxx: g++
+            ver: 12
+          - cxx: g++
+            ver: 13
+          - cxx: clang++
+            ver: 15
+          - cxx: clang++
+            ver: 16
+          - cxx: clang++
+            ver: 17
         include:
-          - buildname: "ubuntu-22.04/gcc"
-            link: SHARED
-          - buildname: "ubuntu-22.04/gcc"
+          - feature: coroutines
             link: STATIC
-          - buildname: "ubuntu-22.04/coroutines"
-            link: STATIC
+            compiler:
+              cxx: g++
+              ver: 13
+    env:
+      CXX: ${{ matrix.compiler.cxx }}-${{ matrix.compiler.ver }}
     steps:
       - name: Checkout Drogon source code
         uses: actions/checkout@v4
@@ -147,6 +161,13 @@ jobs:
           sudo apt-get --purge remove postgresql postgresql-doc postgresql-common postgresql-client-common
           sudo apt-get -y install postgresql-all
 
+      - name: Install Clang
+        if: startsWith(matrix.compiler.cxx, 'clang')
+        run: |
+          wget https://apt.llvm.org/llvm.sh
+          chmod +x ./llvm.sh
+          sudo ./llvm.sh ${{ matrix.compiler.ver }}
+
       - name: Export `shared`
         run: |
           [[ ${{ matrix.link }} == "SHARED" ]] && shared="ON" || shared="OFF"
@@ -155,7 +176,7 @@ jobs:
       - name: Create Build Environment & Configure Cmake
         # Some projects don't allow in-source building, so create a separate build directory
         # We'll use this as our working directory for all subsequent commands
-        if: matrix.buildname != 'ubuntu-22.04/coroutines'
+        if: matrix.feature != 'coroutines'
         run: |
           cmake -B build -G Ninja          \
             -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
@@ -165,7 +186,7 @@ jobs:
       - name: Create Build Environment & Configure Cmake (coroutines)
         # Some projects don't allow in-source building, so create a separate build directory
         # We'll use this as our working directory for all subsequent commands
-        if: matrix.buildname == 'ubuntu-22.04/coroutines'
+        if: matrix.feature == 'coroutines'
         run: |
           cmake -B build -G Ninja            \
             -DCMAKE_BUILD_TYPE=$BUILD_TYPE   \

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -136,18 +136,6 @@ jobs:
           - cxx: g++
             ver: 13
           - cxx: clang++
-            ver: 5
-          - cxx: clang++
-            ver: 6
-          - cxx: clang++
-            ver: 7
-          - cxx: clang++
-            ver: 8
-          - cxx: clang++
-            ver: 9
-          - cxx: clang++
-            ver: 10
-          - cxx: clang++
             ver: 11
           - cxx: clang++
             ver: 12


### PR DESCRIPTION
As a framework, it is important to verify that Drogon is compilable with various compilers. For macOS, the clang version depends on the OS version.