### PR TITLE
Remove macos-11 CI; not supported by Homebrew

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -70,7 +70,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        osver: [11, 12, 13]
+        osver: [12, 13]
     steps:
       - name: Checkout Drogon source code
         uses: actions/checkout@v4


### PR DESCRIPTION
Since Homebrew and Apple do not support macOS 11, it seems nothing makes sense to support it.

https://github.com/drogonframework/drogon/actions/runs/7347142805/job/20003921233#step:3:14