### PR TITLE
Fix htonll/ntohll redefinition

### DIFF
--- a/orm_lib/inc/drogon/orm/SqlBinder.h
+++ b/orm_lib/inc/drogon/orm/SqlBinder.h
@@ -71,6 +71,7 @@ constexpr T htonT(T value) noexcept
 #endif
 }
 
+#ifndef _WIN32
 inline uint64_t htonll(uint64_t value)
 {
     return htonT<uint64_t>(value);
@@ -80,6 +81,7 @@ inline uint64_t ntohll(uint64_t value)
 {
     return htonll(value);
 }
+#endif
 #endif
 
 namespace drogon


### PR DESCRIPTION
SqlBinder.h includes winsock2.h (`#ifdef _WIN32`), then defines htonll/ntohll for `__MINGW32__` 
( `#if defined __linux__ || defined __FreeBSD__ || defined __OpenBSD__ || defined __MINGW32__` ).
This leads to the errors below when building with MSYS2 environment.
`#ifndef _WIN32` guard around redefinitions fixes the errors.

```
[build] In file included from XXX/include/drogon/orm/DbClient.h:24:
[build] XXX/include/drogon/orm/SqlBinder.h:74:17: error: redefinition of 'htonll'
[build]    74 | inline uint64_t htonll(uint64_t value)
[build]       |                 ^
[build] XXX/include/winsock2.h:1015:34: note: previous definition is here
[build]  1015 |   __forceinline unsigned __int64 htonll(unsigned __int64 Value) { return (((unsigned __int64)htonl(Value & 0xFFFFFFFFUL)) << 32) | htonl((u_long)(Value >> 32)); }
[build]       |                                  ^
```
