### PR TITLE
Fix #1901

### DIFF
--- a/orm_lib/inc/drogon/orm/SqlBinder.h
+++ b/orm_lib/inc/drogon/orm/SqlBinder.h
@@ -71,7 +71,7 @@ constexpr T htonT(T value) noexcept
 #endif
 }
 
-#ifndef _WIN32
+#if (!defined _WIN32) || (defined _WIN32 && _WIN32_WINNT < _WIN32_WINNT_WIN8)
 inline uint64_t htonll(uint64_t value)
 {
     return htonT<uint64_t>(value);


### PR DESCRIPTION
Adds condition ` || _WIN32_WINNT < _WIN32_WINNT_WIN8` around `htonll` and `ntohll` to reflect `winsock2.h`'s `#if _WIN32_WINNT >= _WIN32_WINNT_WIN8`.
The root cause is in trantor's `CMakeLists.txt`, which explicitly and unconditionally sets `-D_WIN32_WINNT=0x0601`.
