### PR TITLE
Fix a wrong return in StaticFileRouter

### DIFF
--- a/lib/src/StaticFileRouter.cc
+++ b/lib/src/StaticFileRouter.cc
@@ -237,8 +237,8 @@ void StaticFileRouter::route(
                                                    contentType);
                         }
                     });
-                return;
             }
+            return;
         }
     }
     std::string directoryPath =


### PR DESCRIPTION
A bug introduced by #1871 

Resolve #1915 