### PR TITLE
Fix drogon::util::fromString()

### DIFF
--- a/lib/inc/drogon/utils/Utilities.h
+++ b/lib/inc/drogon/utils/Utilities.h
@@ -468,7 +468,8 @@ T fromString(const std::string &p) noexcept(false)
         // ("1a" should not return 1)
         if (pos != p.size())
             throw std::invalid_argument("Invalid value");
-        if (v > static_cast<unsigned long long>((std::numeric_limits<T>::max)()))
+        if (v >
+            static_cast<unsigned long long>((std::numeric_limits<T>::max)()))
             throw std::out_of_range("Value out of range");
         return static_cast<T>(v);
     }

--- a/lib/inc/drogon/utils/Utilities.h
+++ b/lib/inc/drogon/utils/Utilities.h
@@ -498,7 +498,7 @@ T fromString(const std::string &p) noexcept(false)
             // must except in case of invalid value, not return a default value
             // (else it returns 0 for integers if the string is empty or
             // non-numeric)
-            ss.exceptions(std::ios::iostate::failbit);
+            ss.exceptions(std::ios_base::failbit);
             ss >> value;
             // throw if the whole string could not be parsed
             // ("1a" should not return 1)

--- a/lib/inc/drogon/utils/Utilities.h
+++ b/lib/inc/drogon/utils/Utilities.h
@@ -454,7 +454,8 @@ T fromString(const std::string &p) noexcept(false)
     {
         std::size_t pos;
         auto v = std::stoll(p, &pos);
-        // throw if the whole string could not be parsed ("1a" should not return 1)
+        // throw if the whole string could not be parsed
+        // ("1a" should not return 1)
         if (pos != p.size())
             throw std::invalid_argument("Invalid value");
         if ((v < static_cast<long long>(std::numeric_limits<T>::min())) ||
@@ -467,7 +468,8 @@ T fromString(const std::string &p) noexcept(false)
     {
         std::size_t pos;
         auto v = std::stoull(p, &pos);
-        // throw if the whole string could not be parsed ("1a" should not return 1)
+        // throw if the whole string could not be parsed
+        // ("1a" should not return 1)
         if (pos != p.size())
             throw std::invalid_argument("Invalid value");
         if (v > static_cast<unsigned long long>(std::numeric_limits<T>::max()))
@@ -478,7 +480,8 @@ T fromString(const std::string &p) noexcept(false)
     {
         std::size_t pos;
         auto v = std::stold(p, &pos);
-        // throw if the whole string could not be parsed ("1a" should not return 1)
+        // throw if the whole string could not be parsed
+        // ("1a" should not return 1)
         if (pos != p.size())
             throw std::invalid_argument("Invalid value");
         if ((v < static_cast<long double>(std::numeric_limits<T>::min())) ||
@@ -493,10 +496,12 @@ T fromString(const std::string &p) noexcept(false)
         {
             std::stringstream ss(p);
             // must except in case of invalid value, not return a default value
-            // (else it returns 0 for integers if the string is empty or non-numeric)
-            ss.exceptions(std::ios::exceptions::failbit);
+            // (else it returns 0 for integers if the string is empty or
+            // non-numeric)
+            ss.exceptions(std::ios::iostate::failbit);
             ss >> value;
-            // throw if the whole string could not be parsed ("1a" should not return 1)
+            // throw if the whole string could not be parsed
+            // ("1a" should not return 1)
             if (!ss.eof())
                 std::runtime_error("Bad type conversion");
         }

--- a/lib/inc/drogon/utils/Utilities.h
+++ b/lib/inc/drogon/utils/Utilities.h
@@ -92,6 +92,15 @@ struct CanConvertFromString
 
 }  // namespace internal
 
+/**
+ * @brief Get the HTTP messages corresponding to the HTTP status codes
+ *
+ * @param code HTTP status code
+ *
+ * @return the corresponding message
+ */
+DROGON_EXPORT const std::string_view &statusCodeToString(int code);
+
 namespace utils
 {
 /// Determine if the string is an integer
@@ -434,16 +443,62 @@ DROGON_EXPORT bool secureRandomBytes(void *ptr, size_t size);
  */
 DROGON_EXPORT std::string secureRandomString(size_t size);
 
+// Grrrr M$ macros
+#undef min
+#undef max
+
 template <typename T>
 T fromString(const std::string &p) noexcept(false)
 {
-    if constexpr (internal::CanConvertFromStringStream<T>::value)
+    if constexpr (std::is_integral<T>::value && std::is_signed<T>::value)
+    {
+        std::size_t pos;
+        auto v = std::stoll(p, &pos);
+        // throw if the whole string could not be parsed ("1a" should not return 1)
+        if (pos != p.size())
+            throw std::invalid_argument("Invalid value");
+        if ((v < static_cast<long long>(std::numeric_limits<T>::min())) ||
+            (v > static_cast<long long>(std::numeric_limits<T>::max())))
+            throw std::out_of_range("Value out of range");
+        return static_cast<T>(v);
+    }
+    else if constexpr (std::is_integral<T>::value &&
+                       (!std::is_signed<T>::value))
+    {
+        std::size_t pos;
+        auto v = std::stoull(p, &pos);
+        // throw if the whole string could not be parsed ("1a" should not return 1)
+        if (pos != p.size())
+            throw std::invalid_argument("Invalid value");
+        if (v > static_cast<unsigned long long>(std::numeric_limits<T>::max()))
+            throw std::out_of_range("Value out of range");
+        return static_cast<T>(v);
+    }
+    else if constexpr (std::is_floating_point<T>::value)
+    {
+        std::size_t pos;
+        auto v = std::stold(p, &pos);
+        // throw if the whole string could not be parsed ("1a" should not return 1)
+        if (pos != p.size())
+            throw std::invalid_argument("Invalid value");
+        if ((v < static_cast<long double>(std::numeric_limits<T>::min())) ||
+            (v > static_cast<long double>(std::numeric_limits<T>::max())))
+            throw std::out_of_range("Value out of range");
+        return static_cast<T>(v);
+    }
+    else if constexpr (internal::CanConvertFromStringStream<T>::value)
     {
         T value{};
         if (!p.empty())
         {
             std::stringstream ss(p);
+            // must except in case of invalid value, not return a default value
+            // (else it returns 0 for integers if the string is empty or non-numeric)
+            ss.exceptions(std::ios::exceptions::failbit);
             ss >> value;
+            // throw if the whole string could not be parsed ("1a" should not return 1)
+            if (!ss.eof())
+                std::runtime_error("Bad type conversion");
         }
         return value;
     }
@@ -459,67 +514,71 @@ inline std::string fromString<std::string>(const std::string &p) noexcept(false)
     return p;
 }
 
-template <>
-inline int fromString<int>(const std::string &p) noexcept(false)
-{
-    return std::stoi(p);
-}
-
-template <>
-inline long fromString<long>(const std::string &p) noexcept(false)
-{
-    return std::stol(p);
-}
-
-template <>
-inline long long fromString<long long>(const std::string &p) noexcept(false)
-{
-    return std::stoll(p);
-}
-
-template <>
-inline unsigned long fromString<unsigned long>(const std::string &p) noexcept(
-    false)
-{
-    return std::stoul(p);
-}
-
-template <>
-inline unsigned long long fromString<unsigned long long>(
-    const std::string &p) noexcept(false)
-{
-    return std::stoull(p);
-}
-
-template <>
-inline float fromString<float>(const std::string &p) noexcept(false)
-{
-    return std::stof(p);
-}
-
-template <>
-inline double fromString<double>(const std::string &p) noexcept(false)
-{
-    return std::stod(p);
-}
-
-template <>
-inline long double fromString<long double>(const std::string &p) noexcept(false)
-{
-    return std::stold(p);
-}
+//template <>
+//inline int fromString<int>(const std::string &p) noexcept(false)
+//{
+//    return std::stoi(p);
+//}
+//
+//template <>
+//inline long fromString<long>(const std::string &p) noexcept(false)
+//{
+//    return std::stol(p);
+//}
+//
+//template <>
+//inline long long fromString<long long>(const std::string &p) noexcept(false)
+//{
+//    return std::stoll(p);
+//}
+//
+//template <>
+//inline unsigned long fromString<unsigned long>(const std::string &p) noexcept(
+//    false)
+//{
+//    return std::stoul(p);
+//}
+//
+//template <>
+//inline unsigned long long fromString<unsigned long long>(
+//    const std::string &p) noexcept(false)
+//{
+//    return std::stoull(p);
+//}
+//
+//template <>
+//inline float fromString<float>(const std::string &p) noexcept(false)
+//{
+//    return std::stof(p);
+//}
+//
+//template <>
+//inline double fromString<double>(const std::string &p) noexcept(false)
+//{
+//    return std::stod(p);
+//}
+//
+//template <>
+//inline long double fromString<long double>(const std::string &p) noexcept(false)
+//{
+//    return std::stold(p);
+//}
 
 template <>
 inline bool fromString<bool>(const std::string &p) noexcept(false)
 {
-    if (p == "1")
-    {
-        return true;
-    }
-    if (p == "0")
-    {
-        return false;
-    }
+    if (!p.empty() && std::all_of(p.begin(), p.end(), [](unsigned char c) {
+            return std::isdigit(c);
+        }))
+        return (std::stoll(p) != 0);
+//    if (p == "1")
+//    {
+//        return true;
+//    }
+//    if (p == "0")
+//    {
+//        return false;
+//    }
     std::string l{p};
     std::transform(p.begin(), p.end(), l.begin(), [](unsigned char c) {
         return (char)tolower(c);

--- a/lib/inc/drogon/utils/Utilities.h
+++ b/lib/inc/drogon/utils/Utilities.h
@@ -514,56 +514,6 @@ inline std::string fromString<std::string>(const std::string &p) noexcept(false)
     return p;
 }
 
-//template <>
-//inline int fromString<int>(const std::string &p) noexcept(false)
-//{
-//    return std::stoi(p);
-//}
-//
-//template <>
-//inline long fromString<long>(const std::string &p) noexcept(false)
-//{
-//    return std::stol(p);
-//}
-//
-//template <>
-//inline long long fromString<long long>(const std::string &p) noexcept(false)
-//{
-//    return std::stoll(p);
-//}
-//
-//template <>
-//inline unsigned long fromString<unsigned long>(const std::string &p) noexcept(
-//    false)
-//{
-//    return std::stoul(p);
-//}
-//
-//template <>
-//inline unsigned long long fromString<unsigned long long>(
-//    const std::string &p) noexcept(false)
-//{
-//    return std::stoull(p);
-//}
-//
-//template <>
-//inline float fromString<float>(const std::string &p) noexcept(false)
-//{
-//    return std::stof(p);
-//}
-//
-//template <>
-//inline double fromString<double>(const std::string &p) noexcept(false)
-//{
-//    return std::stod(p);
-//}
-//
-//template <>
-//inline long double fromString<long double>(const std::string &p) noexcept(false)
-//{
-//    return std::stold(p);
-//}
-
 template <>
 inline bool fromString<bool>(const std::string &p) noexcept(false)
 {
@@ -571,14 +521,6 @@ inline bool fromString<bool>(const std::string &p) noexcept(false)
             return std::isdigit(c);
         }))
         return (std::stoll(p) != 0);
-//    if (p == "1")
-//    {
-//        return true;
-//    }
-//    if (p == "0")
-//    {
-//        return false;
-//    }
     std::string l{p};
     std::transform(p.begin(), p.end(), l.begin(), [](unsigned char c) {
         return (char)tolower(c);

--- a/lib/inc/drogon/utils/Utilities.h
+++ b/lib/inc/drogon/utils/Utilities.h
@@ -443,10 +443,6 @@ DROGON_EXPORT bool secureRandomBytes(void *ptr, size_t size);
  */
 DROGON_EXPORT std::string secureRandomString(size_t size);
 
-// Grrrr M$ macros
-#undef min
-#undef max
-
 template <typename T>
 T fromString(const std::string &p) noexcept(false)
 {
@@ -458,8 +454,8 @@ T fromString(const std::string &p) noexcept(false)
         // ("1a" should not return 1)
         if (pos != p.size())
             throw std::invalid_argument("Invalid value");
-        if ((v < static_cast<long long>(std::numeric_limits<T>::min())) ||
-            (v > static_cast<long long>(std::numeric_limits<T>::max())))
+        if ((v < static_cast<long long>((std::numeric_limits<T>::min)())) ||
+            (v > static_cast<long long>((std::numeric_limits<T>::max)())))
             throw std::out_of_range("Value out of range");
         return static_cast<T>(v);
     }
@@ -472,7 +468,7 @@ T fromString(const std::string &p) noexcept(false)
         // ("1a" should not return 1)
         if (pos != p.size())
             throw std::invalid_argument("Invalid value");
-        if (v > static_cast<unsigned long long>(std::numeric_limits<T>::max()))
+        if (v > static_cast<unsigned long long>((std::numeric_limits<T>::max)()))
             throw std::out_of_range("Value out of range");
         return static_cast<T>(v);
     }
@@ -484,8 +480,8 @@ T fromString(const std::string &p) noexcept(false)
         // ("1a" should not return 1)
         if (pos != p.size())
             throw std::invalid_argument("Invalid value");
-        if ((v < static_cast<long double>(std::numeric_limits<T>::min())) ||
-            (v > static_cast<long double>(std::numeric_limits<T>::max())))
+        if ((v < static_cast<long double>((std::numeric_limits<T>::min)())) ||
+            (v > static_cast<long double>((std::numeric_limits<T>::max)())))
             throw std::out_of_range("Value out of range");
         return static_cast<T>(v);
     }


### PR DESCRIPTION
This PR fixes several flaws in drogon::util::fromString():
1. The numerical specialization for standard types (int, long, double aso) are not called when specifying _non-standard_ integer types, like uint32_t (at least with Visual Studio): fromString<uint32_t>() calls the template function using stringstream.
2. The template function did not enable exceptions on stringstream. So, invalid string values caused the function to return an empty or uninitialized value instead of throwing an exception.<br>Example: `fromString<int>("")` and `fromString<int>("something")` both returned 0.
3. Neither the template function nor the specializations checked if the whole string was parsed. So, for example, `fromString<int>("1a")` returned 1 instead of throwing an invalid value exception.
4. I think that fromString<bool>() should accept any non-0 numerical value for true, not only "1"<br>But you are perhaps not ok with that.

I moved therefore the numerical specializations to the template function, and made them more general by using constexpr for signed, unsigned and floating types.

Without these changes, HttpRequest::getOptionalParameter<T>() returns no value on missing parameter **BUT DOES** for invalid parameter values.
For example, HttpRequest::getOptionalParameter<int>("param") returns
- 0 if the parameter value is empty or non-numerical
- the numerical value of the truncated parameter value if it starts with digits but is not a valid number (example: "1 ring" -> 1)

FInally, instead of doing a separate PR for this, I added an export for `drogon::statusCodeToString()` for re-use by the programmers.