### PR TITLE
Introduce cpplint

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -19,3 +19,14 @@ jobs:
 
       - name: Check formatting
         run: ./format.sh && git diff --exit-code
+
+  cpplint:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install cpplint
+        run: pip install cpplint
+
+      - name: Run lint
+        run: cpplint --recursive .

--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -1,0 +1,42 @@
+# Stop searching for additional config files.
+set noparent
+
+exclude_files=trantor
+exclude_files=build
+
+# Use non-const reference rather than a pointer.
+filter=-runtime/references
+
+# CHECK macros are from Drogon, not Google Test.
+filter=-readability/check
+
+# Don't warn about the use of C++11 features.
+filter=-build/c++11
+
+filter=-build/include_subdir
+
+# We prioritize clang-format for now.
+filter=-whitespace
+
+# We don't require a username in TODO comments.
+filter=-readability/todo
+
+# TODO: Fix these.
+filter=-legal/copyright
+filter=-build/storage_class
+filter=-build/namespaces
+filter=-build/include
+filter=-build/header_guard
+filter=-build/include_what_you_use
+filter=-build/include_order
+filter=-build/explicit_make_pair
+filter=-runtime/explicit
+filter=-runtime/string
+filter=-runtime/int
+filter=-readability/multiline_string
+filter=-readability/inheritance
+filter=-readability/casting
+filter=-readability/alt_tokens
+filter=-readability/braces
+filter=-readability/fn_size
+filter=-runtime/threadsafe_fn


### PR DESCRIPTION
This patch introduces cpplint without modifying the current code base. The next step should be to enable each filter per PR.

---

cf. https://github.com/drogonframework/drogon/issues/1927