### PR TITLE
Use clang-format-17

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -17,8 +17,17 @@ jobs:
       - name: Install dos2unix
         run: sudo apt-get install -y dos2unix
 
+      - name: Install clang-format-17
+        run: |
+          wget https://apt.llvm.org/llvm.sh
+          chmod +x ./llvm.sh
+          sudo ./llvm.sh 17
+          sudo apt-get install -y clang-format-17
+
       - name: Check formatting
         run: ./format.sh && git diff --exit-code
+        env:
+          CLANG_FORMAT: clang-format-17
 
   cpplint:
     runs-on: ubuntu-22.04

--- a/format.sh
+++ b/format.sh
@@ -3,10 +3,10 @@
 # You can customize the clang-format path by setting the CLANG_FORMAT environment variable
 CLANG_FORMAT=${CLANG_FORMAT:-clang-format}
 
-# Check if clang-format version is 14 to avoid inconsistent formatting
+# Check if clang-format version is 17 to avoid inconsistent formatting
 $CLANG_FORMAT --version
-if [[ ! $($CLANG_FORMAT --version) =~ "version 14" ]]; then
-    echo "Error: clang-format version must be 14"
+if [[ ! $($CLANG_FORMAT --version) =~ "version 17" ]]; then
+    echo "Error: clang-format version must be 17"
     exit 1
 fi
 

--- a/lib/inc/drogon/DrClassMap.h
+++ b/lib/inc/drogon/DrClassMap.h
@@ -138,7 +138,7 @@ class DROGON_EXPORT DrClassMap
 
   protected:
     static std::unordered_map<std::string,
-                              std::pair<DrAllocFunc, DrSharedAllocFunc>>
-        &getMap();
+                              std::pair<DrAllocFunc, DrSharedAllocFunc>> &
+    getMap();
 };
 }  // namespace drogon

--- a/lib/inc/drogon/HttpAppFramework.h
+++ b/lib/inc/drogon/HttpAppFramework.h
@@ -194,8 +194,8 @@ class DROGON_EXPORT HttpAppFramework : public trantor::NonCopyable
      * returned.
      */
     virtual const std::function<HttpResponsePtr(HttpStatusCode,
-                                                const HttpRequestPtr &req)>
-        &getCustomErrorHandler() const = 0;
+                                                const HttpRequestPtr &req)> &
+    getCustomErrorHandler() const = 0;
 
     /// Get the plugin object registered in the framework
     /**
@@ -1421,8 +1421,8 @@ class DROGON_EXPORT HttpAppFramework : public trantor::NonCopyable
      *
      * @return std::pair<size_t, std::string>
      */
-    virtual const std::pair<unsigned int, std::string>
-        &getFloatPrecisionInJson() const noexcept = 0;
+    virtual const std::pair<unsigned int, std::string> &
+    getFloatPrecisionInJson() const noexcept = 0;
     /// Create a database client
     /**
      * @param dbType The database type is one of

--- a/lib/inc/drogon/HttpRequest.h
+++ b/lib/inc/drogon/HttpRequest.h
@@ -162,27 +162,31 @@ class DROGON_EXPORT HttpRequest
     virtual const std::string &getCookie(const std::string &field) const = 0;
 
     /// Get all headers of the request
-    virtual const std::
-        unordered_map<std::string, std::string, utils::internal::SafeStringHash>
-            &headers() const = 0;
+    virtual const std::unordered_map<std::string,
+                                     std::string,
+                                     utils::internal::SafeStringHash> &
+    headers() const = 0;
 
     /// Get all headers of the request
-    const std::
-        unordered_map<std::string, std::string, utils::internal::SafeStringHash>
-            &getHeaders() const
+    const std::unordered_map<std::string,
+                             std::string,
+                             utils::internal::SafeStringHash> &
+    getHeaders() const
     {
         return headers();
     }
 
     /// Get all cookies of the request
-    virtual const std::
-        unordered_map<std::string, std::string, utils::internal::SafeStringHash>
-            &cookies() const = 0;
+    virtual const std::unordered_map<std::string,
+                                     std::string,
+                                     utils::internal::SafeStringHash> &
+    cookies() const = 0;
 
     /// Get all cookies of the request
-    const std::
-        unordered_map<std::string, std::string, utils::internal::SafeStringHash>
-            &getCookies() const
+    const std::unordered_map<std::string,
+                             std::string,
+                             utils::internal::SafeStringHash> &
+    getCookies() const
     {
         return cookies();
     }
@@ -300,14 +304,16 @@ class DROGON_EXPORT HttpRequest
     }
 
     /// Get parameters of the request.
-    virtual const std::
-        unordered_map<std::string, std::string, utils::internal::SafeStringHash>
-            &parameters() const = 0;
+    virtual const std::unordered_map<std::string,
+                                     std::string,
+                                     utils::internal::SafeStringHash> &
+    parameters() const = 0;
 
     /// Get parameters of the request.
-    const std::
-        unordered_map<std::string, std::string, utils::internal::SafeStringHash>
-            &getParameters() const
+    const std::unordered_map<std::string,
+                             std::string,
+                             utils::internal::SafeStringHash> &
+    getParameters() const
     {
         return parameters();
     }

--- a/lib/inc/drogon/HttpResponse.h
+++ b/lib/inc/drogon/HttpResponse.h
@@ -244,14 +244,16 @@ class DROGON_EXPORT HttpResponse
     virtual void removeHeader(std::string key) = 0;
 
     /// Get all headers of the response
-    virtual const std::
-        unordered_map<std::string, std::string, utils::internal::SafeStringHash>
-            &headers() const = 0;
+    virtual const std::unordered_map<std::string,
+                                     std::string,
+                                     utils::internal::SafeStringHash> &
+    headers() const = 0;
 
     /// Get all headers of the response
-    const std::
-        unordered_map<std::string, std::string, utils::internal::SafeStringHash>
-            &getHeaders() const
+    const std::unordered_map<std::string,
+                             std::string,
+                             utils::internal::SafeStringHash> &
+    getHeaders() const
     {
         return headers();
     }
@@ -280,13 +282,13 @@ class DROGON_EXPORT HttpResponse
 
     /// Get all cookies.
     virtual const std::
-        unordered_map<std::string, Cookie, utils::internal::SafeStringHash>
-            &cookies() const = 0;
+        unordered_map<std::string, Cookie, utils::internal::SafeStringHash> &
+        cookies() const = 0;
 
     /// Get all cookies.
     const std::
-        unordered_map<std::string, Cookie, utils::internal::SafeStringHash>
-            &getCookies() const
+        unordered_map<std::string, Cookie, utils::internal::SafeStringHash> &
+        getCookies() const
     {
         return cookies();
     }
@@ -580,8 +582,8 @@ class DROGON_EXPORT HttpResponse
      * newStreamResponse) returns the callback function. Otherwise a
      * null function.
      */
-    virtual const std::function<std::size_t(char *, std::size_t)>
-        &streamCallback() const = 0;
+    virtual const std::function<std::size_t(char *, std::size_t)> &
+    streamCallback() const = 0;
 
     /**
      * @brief If the response is a async stream response (i.e. created by

--- a/lib/src/DrClassMap.cc
+++ b/lib/src/DrClassMap.cc
@@ -22,8 +22,8 @@ namespace drogon
 {
 namespace internal
 {
-static std::unordered_map<std::string, std::shared_ptr<DrObjectBase>>
-    &getObjsMap()
+static std::unordered_map<std::string, std::shared_ptr<DrObjectBase>> &
+getObjsMap()
 {
     static std::unordered_map<std::string, std::shared_ptr<DrObjectBase>>
         singleInstanceMap;
@@ -112,8 +112,8 @@ std::vector<std::string> DrClassMap::getAllClassName()
     return ret;
 }
 
-std::unordered_map<std::string, std::pair<DrAllocFunc, DrSharedAllocFunc>>
-    &DrClassMap::getMap()
+std::unordered_map<std::string, std::pair<DrAllocFunc, DrSharedAllocFunc>> &
+DrClassMap::getMap()
 {
     static std::unordered_map<std::string,
                               std::pair<DrAllocFunc, DrSharedAllocFunc>>

--- a/lib/src/HttpAppFrameworkImpl.cc
+++ b/lib/src/HttpAppFrameworkImpl.cc
@@ -1039,8 +1039,9 @@ HttpAppFramework &HttpAppFrameworkImpl::setCustomErrorHandler(
     return *this;
 }
 
-const std::function<HttpResponsePtr(HttpStatusCode, const HttpRequestPtr &req)>
-    &HttpAppFrameworkImpl::getCustomErrorHandler() const
+const std::function<HttpResponsePtr(HttpStatusCode,
+                                    const HttpRequestPtr &req)> &
+HttpAppFrameworkImpl::getCustomErrorHandler() const
 {
     return customErrorHandler_;
 }

--- a/lib/src/HttpAppFrameworkImpl.h
+++ b/lib/src/HttpAppFrameworkImpl.h
@@ -586,8 +586,8 @@ class HttpAppFrameworkImpl final : public HttpAppFramework
 
     bool areAllDbClientsAvailable() const noexcept override;
     const std::function<HttpResponsePtr(HttpStatusCode,
-                                        const HttpRequestPtr &req)>
-        &getCustomErrorHandler() const override;
+                                        const HttpRequestPtr &req)> &
+    getCustomErrorHandler() const override;
 
     bool isUsingCustomErrorHandler() const
     {

--- a/lib/src/HttpRequestImpl.h
+++ b/lib/src/HttpRequestImpl.h
@@ -169,9 +169,10 @@ class HttpRequestImpl : public HttpRequest
         pathEncode_ = pathEncode;
     }
 
-    const std::
-        unordered_map<std::string, std::string, utils::internal::SafeStringHash>
-            &parameters() const override
+    const std::unordered_map<std::string,
+                             std::string,
+                             utils::internal::SafeStringHash> &
+    parameters() const override
     {
         parseParametersOnce();
         return parameters_;
@@ -341,16 +342,18 @@ class HttpRequestImpl : public HttpRequest
         return defaultVal;
     }
 
-    const std::
-        unordered_map<std::string, std::string, utils::internal::SafeStringHash>
-            &headers() const override
+    const std::unordered_map<std::string,
+                             std::string,
+                             utils::internal::SafeStringHash> &
+    headers() const override
     {
         return headers_;
     }
 
-    const std::
-        unordered_map<std::string, std::string, utils::internal::SafeStringHash>
-            &cookies() const override
+    const std::unordered_map<std::string,
+                             std::string,
+                             utils::internal::SafeStringHash> &
+    cookies() const override
     {
         return cookies_;
     }

--- a/lib/src/HttpResponseImpl.h
+++ b/lib/src/HttpResponseImpl.h
@@ -133,9 +133,10 @@ class DROGON_EXPORT HttpResponseImpl : public HttpResponse
         removeHeaderBy(key);
     }
 
-    const std::
-        unordered_map<std::string, std::string, utils::internal::SafeStringHash>
-            &headers() const override
+    const std::unordered_map<std::string,
+                             std::string,
+                             utils::internal::SafeStringHash> &
+    headers() const override
     {
         return headers_;
     }
@@ -206,8 +207,8 @@ class DROGON_EXPORT HttpResponseImpl : public HttpResponse
     }
 
     const std::
-        unordered_map<std::string, Cookie, utils::internal::SafeStringHash>
-            &cookies() const override
+        unordered_map<std::string, Cookie, utils::internal::SafeStringHash> &
+        cookies() const override
     {
         return cookies_;
     }

--- a/lib/src/StaticFileRouter.cc
+++ b/lib/src/StaticFileRouter.cc
@@ -26,8 +26,8 @@
 #include <sys/file.h>
 #elif !defined(__MINGW32__)
 #define stat _wstati64
-#define S_ISREG(m) (((m)&0170000) == (0100000))
-#define S_ISDIR(m) (((m)&0170000) == (0040000))
+#define S_ISREG(m) (((m) & 0170000) == (0100000))
+#define S_ISDIR(m) (((m) & 0170000) == (0040000))
 #endif
 #include <sys/stat.h>
 #include <filesystem>

--- a/lib/src/WebSocketConnectionImpl.cc
+++ b/lib/src/WebSocketConnectionImpl.cc
@@ -88,7 +88,7 @@ void WebSocketConnectionImpl::sendWsData(const char *msg,
     {
         bytesFormatted[1] = 126;
         bytesFormatted[2] = ((len >> 8) & 255);
-        bytesFormatted[3] = ((len)&255);
+        bytesFormatted[3] = ((len) & 255);
         LOG_TRACE << "bytes[2]=" << (size_t)bytesFormatted[2];
         LOG_TRACE << "bytes[3]=" << (size_t)bytesFormatted[3];
         indexStartRawData = 4;
@@ -103,7 +103,7 @@ void WebSocketConnectionImpl::sendWsData(const char *msg,
         bytesFormatted[6] = ((len >> 24) & 255);
         bytesFormatted[7] = ((len >> 16) & 255);
         bytesFormatted[8] = ((len >> 8) & 255);
-        bytesFormatted[9] = ((len)&255);
+        bytesFormatted[9] = ((len) & 255);
 
         indexStartRawData = 10;
     }


### PR DESCRIPTION
Since, on my machine, I can no longer install clang-format-14 in an easy way, it would be great if we could use clang-format-17 instead.