### PR TITLE
Enable build/include_order for cpplint

### DIFF
--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -28,7 +28,6 @@ filter=-build/namespaces
 filter=-build/include
 filter=-build/header_guard
 filter=-build/include_what_you_use
-filter=-build/include_order
 filter=-runtime/explicit
 filter=-runtime/string
 filter=-runtime/int


### PR DESCRIPTION
cf. https://github.com/drogonframework/drogon/issues/1927