### PR TITLE
Simplify traits in utils

### DIFF
--- a/lib/inc/drogon/utils/OStringStream.h
+++ b/lib/inc/drogon/utils/OStringStream.h
@@ -21,23 +21,16 @@ namespace drogon
 {
 namespace internal
 {
-template <typename T>
-struct CanConvertToString
+template <typename T, typename = void>
+struct CanConvertToString : std::false_type
 {
-    using Type = std::remove_reference_t<std::remove_cv_t<T>>;
+};
 
-  private:
-    using yes = std::true_type;
-    using no = std::false_type;
-
-    template <typename U>
-    static auto test(int) -> decltype(std::to_string(U{}), yes());
-
-    template <typename>
-    static no test(...);
-
-  public:
-    static constexpr bool value = std::is_same_v<decltype(test<Type>(0)), yes>;
+template <typename T>
+struct CanConvertToString<
+    T,
+    std::void_t<decltype(std::to_string(std::declval<T>()))>> : std::true_type
+{
 };
 }  // namespace internal
 

--- a/lib/tests/CMakeLists.txt
+++ b/lib/tests/CMakeLists.txt
@@ -26,6 +26,7 @@ set(UNITTEST_SOURCES
     unittests/ControllerCreationTest.cc
     unittests/MultiPartParserTest.cc
     unittests/SlashRemoverTest.cc
+    unittests/UtilitiesTest.cc
     unittests/UuidUnittest.cc
 )
 
@@ -113,7 +114,7 @@ if (BUILD_CTL)
             $<TARGET_FILE_DIR:integration_test_server>/a-directory)
 endif(BUILD_CTL)
 
-set(COOKIE_SAME_SITE 
+set(COOKIE_SAME_SITE
   main_CookieSameSite.cc
   CookieSameSite.cc
 )

--- a/lib/tests/unittests/OStringStreamTest.cc
+++ b/lib/tests/unittests/OStringStreamTest.cc
@@ -1,10 +1,28 @@
 #include <drogon/utils/OStringStream.h>
 #include <drogon/drogon_test.h>
 #include <string>
+#include <string_view>
 #include <iostream>
 
 DROGON_TEST(OStringStreamTest)
 {
+    SUBSECTION(CanConvertToString)
+    {
+        using drogon::internal::CanConvertToString;
+
+        static_assert(CanConvertToString<int>::value);
+        static_assert(CanConvertToString<long>::value);
+        static_assert(CanConvertToString<long long>::value);
+        static_assert(CanConvertToString<unsigned>::value);
+        static_assert(CanConvertToString<unsigned long>::value);
+        static_assert(CanConvertToString<unsigned long long>::value);
+        static_assert(CanConvertToString<float>::value);
+        static_assert(CanConvertToString<double>::value);
+        static_assert(CanConvertToString<long double>::value);
+        static_assert(!CanConvertToString<std::string>::value);
+        static_assert(!CanConvertToString<std::string_view>::value);
+    }
+
     SUBSECTION(integer)
     {
         drogon::OStringStream ss;

--- a/lib/tests/unittests/UtilitiesTest.cc
+++ b/lib/tests/unittests/UtilitiesTest.cc
@@ -1,6 +1,8 @@
 #include <string>
 #include <string_view>
 #include <istream>
+#include <array>
+#include <vector>
 #include <drogon/utils/Utilities.h>
 #include <drogon/drogon_test.h>
 

--- a/lib/tests/unittests/UtilitiesTest.cc
+++ b/lib/tests/unittests/UtilitiesTest.cc
@@ -1,0 +1,99 @@
+#include <string>
+#include <string_view>
+#include <istream>
+#include <drogon/utils/Utilities.h>
+#include <drogon/drogon_test.h>
+
+struct ConvertibleFromStringStream
+{
+    friend std::istream &operator>>(std::istream &os,
+                                    ConvertibleFromStringStream &)
+    {
+        return os;
+    }
+};
+
+struct NotConvertibleFromStringStream
+{
+};
+
+DROGON_TEST(CanConvertFromStringStream)
+{
+    using drogon::internal::CanConvertFromStringStream;
+
+    static_assert(CanConvertFromStringStream<unsigned short>::value);
+    static_assert(CanConvertFromStringStream<unsigned int>::value);
+    static_assert(CanConvertFromStringStream<long>::value);
+    static_assert(CanConvertFromStringStream<unsigned long>::value);
+    static_assert(CanConvertFromStringStream<long long>::value);
+    static_assert(CanConvertFromStringStream<unsigned long long>::value);
+    static_assert(CanConvertFromStringStream<float>::value);
+    static_assert(CanConvertFromStringStream<double>::value);
+    static_assert(CanConvertFromStringStream<long double>::value);
+    static_assert(CanConvertFromStringStream<bool>::value);
+    static_assert(CanConvertFromStringStream<void *>::value);
+    static_assert(CanConvertFromStringStream<short>::value);
+    static_assert(CanConvertFromStringStream<int>::value);
+
+    static_assert(
+        CanConvertFromStringStream<ConvertibleFromStringStream>::value);
+    static_assert(
+        !CanConvertFromStringStream<NotConvertibleFromStringStream>::value);
+}
+
+struct ConstructibleFromString
+{
+    ConstructibleFromString(const std::string &)
+    {
+    }
+};
+
+struct NotConstructibleFromString
+{
+};
+
+DROGON_TEST(CanConstructFromString)
+{
+    using drogon::internal::CanConstructFromString;
+
+    static_assert(CanConstructFromString<ConstructibleFromString>::value);
+    static_assert(!CanConstructFromString<NotConstructibleFromString>::value);
+    static_assert(!CanConstructFromString<int>::value);
+    static_assert(!CanConstructFromString<double>::value);
+    static_assert(CanConstructFromString<std::string>::value);
+    static_assert(CanConstructFromString<std::string_view>::value);
+    static_assert(CanConstructFromString<const std::string>::value);
+    static_assert(!CanConstructFromString<std::string &>::value);
+    static_assert(CanConstructFromString<const std::string &>::value);
+    static_assert(!CanConstructFromString<std::string *>::value);
+}
+
+struct ConvertibleFromString
+{
+    ConvertibleFromString &operator=(const std::string &)
+    {
+        return *this;
+    }
+};
+
+struct NotConvertibleFromString
+{
+};
+
+DROGON_TEST(CanConvertFromString)
+{
+    using drogon::internal::CanConvertFromString;
+
+    static_assert(CanConvertFromString<ConvertibleFromString>::value);
+    static_assert(!CanConvertFromString<NotConvertibleFromString>::value);
+    static_assert(CanConvertFromString<std::string>::value);
+    static_assert(!CanConvertFromString<const std::string>::value);
+    static_assert(!CanConvertFromString<const std::string &>::value);
+    static_assert(!CanConvertFromString<std::string *>::value);
+    static_assert(CanConvertFromString<std::string_view>::value);
+    static_assert(!CanConvertFromString<const char *>::value);
+    static_assert(!CanConvertFromString<std::vector<char>>::value);
+    static_assert(!CanConvertFromString<std::array<char, 5>>::value);
+    static_assert(!CanConvertFromString<int>::value);
+    static_assert(!CanConvertFromString<double>::value);
+}


### PR DESCRIPTION
This patch simplifies traits defined in utils.  Due to the simplicity, this potentially improves compilation performance.

* CanConvertFromStringStream:
    * Use SFINAE.
    * If the `std::declval<std::stringstream &>() >> std::declval<T &>()` expression is invalid, this specialization will be discarded and fall back to the false_type case.
* CanConvertToString:
    * Likewise.
    * We don't need remove_cvref since std::to_string does not require cv-qualifiers or a ref-qualifier.
* CanConstructFromString:
    * This is equivalent to `std::is_constructible<T, std::string>`
* CanConvertFromString:
    * This is equivalent to `std::is_assignable<T &, std::string>`