### PR TITLE
Fix an error in the yaml format config file

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -101,7 +101,7 @@
         //is the number of CPU cores
         "number_of_threads": 1,
         //enable_session: False by default
-        "enable_session": false,
+        "enable_session": true,
         "session_timeout": 0,
         //string value of SameSite attribute of the Set-Cookie HTTP response header
         //valid value is either 'Null' (default), 'Lax', 'Strict' or 'None'
@@ -340,5 +340,14 @@
         }
     ],
     //custom_config: custom configuration for users. This object can be get by the app().getCustomConfig() method. 
-    "custom_config": {}
+    "custom_config": {
+        "realm": "drogonRealm",
+        "opaque": "drogonOpaque",
+        "credentials": [
+            {
+                "user": "drogon",
+                "password": "dr0g0n"
+            }
+        ]
+    }
 }

--- a/config.example.json
+++ b/config.example.json
@@ -39,7 +39,7 @@
     "db_clients": [
         {
             //name: Name of the client,'default' by default
-            //"name":"",
+            "name": "default",
             //rdbms: Server type, postgresql,mysql or sqlite3, "postgresql" by default
             "rdbms": "postgresql",
             //filename: Sqlite3 db file name
@@ -74,7 +74,7 @@
     "redis_clients": [
         {
             //name: Name of the client,'default' by default
-            //"name":"",
+            "name": "default",
             //host: Server IP, 127.0.0.1 by default
             "host": "127.0.0.1",
             //port: Server port, 6379 by default
@@ -101,7 +101,7 @@
         //is the number of CPU cores
         "number_of_threads": 1,
         //enable_session: False by default
-        "enable_session": true,
+        "enable_session": false,
         "session_timeout": 0,
         //string value of SameSite attribute of the Set-Cookie HTTP response header
         //valid value is either 'Null' (default), 'Lax', 'Strict' or 'None'
@@ -123,10 +123,10 @@
         "implicit_page": "index.html",
         //static_file_headers: Headers for static files
         /*"static_file_headers": [
-          {
+            {
                 "name": "field-name",
                 "value": "field-value"
-          }
+            }
         ],*/
         //upload_path: The path to save the uploaded file. "uploads" by default. 
         //If the path isn't prefixed with /, ./ or ../,
@@ -215,7 +215,6 @@
         //log: Set log output, drogon output logs to stdout by default
         "log": {
             //use_spdlog: Use spdlog library to log
-            //"use_spdlog": false
             "use_spdlog": false,
             //log_path: Log file path,empty by default,in which case,logs are output to the stdout
             //"log_path": "./",
@@ -327,28 +326,19 @@
             "name": "drogon::plugin::AccessLogger",
             "dependencies": [],
             "config": {
-                    "use_spdlog": false,
-                    "log_path": "",
-                    "log_format": "",
-                    "log_file": "access.log",
-                    "log_size_limit": 0,
-                    "use_local_time": true,
-                    "log_index": 0,
-                    // "show_microseconds": true,
-                    // "custom_time_format": "",
-                    // "use_real_ip": false
+                "use_spdlog": false,
+                "log_path": "",
+                "log_format": "",
+                "log_file": "access.log",
+                "log_size_limit": 0,
+                "use_local_time": true,
+                "log_index": 0,
+                // "show_microseconds": true,
+                // "custom_time_format": "",
+                // "use_real_ip": false
             }
         }
     ],
     //custom_config: custom configuration for users. This object can be get by the app().getCustomConfig() method. 
-    "custom_config": {
-        "realm": "drogonRealm",
-        "opaque": "drogonOpaque",
-        "credentials": [
-            {
-                "user": "drogon",
-                "password": "dr0g0n"
-            }
-        ]
-    }
+    "custom_config": {}
 }

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -3,8 +3,8 @@
 # ssl:The global SSL settings. "key" and "cert" are the path to the SSL key and certificate. While
 #     "conf" is an array of 1 or 2-element tuples that supplies file style options for `SSL_CONF_cmd`.
 # ssl:
-#   cert: ../../trantor/trantor/tests/server.pem
-#   key: ../../trantor/trantor/tests/server.pem
+#   cert: ../../trantor/trantor/tests/server.crt
+#   key: ../../trantor/trantor/tests/server.key
 #   conf: [
 #     # [Options, -SessionTicket],
 #     # [Options, Compression]
@@ -30,11 +30,11 @@
 #     ]
 # db_clients:
 #     # name: Name of the client,'default' by default
-#   - name: ''
+#   - name: default
 #     # rdbms: Server type, postgresql,mysql or sqlite3, "postgresql" by default
 #     rdbms: postgresql
 #     # filename: Sqlite3 db file name
-#     # filename: '',
+#     # filename: ''
 #     # host: Server address,localhost by default
 #     host: 127.0.0.1
 #     # port: Server port, 5432 by default
@@ -50,7 +50,7 @@
 #     is_fast: false
 #     # client_encoding: The character set used by the client. it is empty string by default which 
 #     # means use the default character set.
-#     # client_encoding: '',
+#     # client_encoding: ''
 #     # number_of_connections: 1 by default, if the 'is_fast' is true, the number is the number of  
 #     # connections per IO thread, otherwise it is the total number of all connections.  
 #     number_of_connections: 1
@@ -62,7 +62,7 @@
 #     auto_batch: false
 # redis_clients:
 #     # name: Name of the client,'default' by default
-#   - name: ''
+#   - name: default
 #     # host: Server IP, 127.0.0.1 by default
 #     host: 127.0.0.1
 #     # port: Server port, 6379 by default
@@ -136,9 +136,11 @@ app:
   # mime: A dictionary that extends the internal MIME type support. Maps extensions into new MIME types
   # note: This option only adds MIME to the sever. `file_types` above have to be set for the server to serve them.
   mime: {
-    # text/markdown: md,
-    # text/gemini: [gmi, gemini]
-  }
+    # text/markdown: md
+    # text/gemini:
+    #   - gmi
+    #   - gemini
+    }
   # locations: An array of locations of static files for GET requests.
   locations:
       # uri_prefix: The URI prefix of the location prefixed with "/", the default value is "" that disables the location.
@@ -190,7 +192,7 @@ app:
   # log: Set log output, drogon output logs to stdout by default
   log:
     # use_spdlog: Use spdlog library to log
-    use_spdlog: false,
+    use_spdlog: false
     # log_path: Log file path,empty by default,in which case,logs are output to the stdout
     # log_path: ./
     # logfile_base_name: Log file base name,empty by default which means drogon names logfile as
@@ -199,6 +201,9 @@ app:
     # log_size_limit: 100000000 bytes by default,
     # When the log file size reaches "log_size_limit", the log file is switched.
     log_size_limit: 100000000
+    # max_files: 0 by default,
+    # When the number of old log files exceeds "max_files", the oldest file will be deleted. 0 means never delete.
+    max_files: 0
     # log_level: "DEBUG" by default,options:"TRACE","DEBUG","INFO","WARN"
     # The TRACE level is only valid when built in DEBUG mode.
     log_level: DEBUG
@@ -221,14 +226,14 @@ app:
   # 0 means cache forever, the negative value means no cache
   static_files_cache_time: 5
   # simple_controllers_map: Used to configure mapping from path to simple controller
-  simple_controllers_map:
-    - path: /path/name
-      controller: controllerClassName
-      http_methods:
-        - get
-        - post
-      filters:
-        - FilterClassName
+  # simple_controllers_map:
+  #   - path: /path/name
+  #     controller: controllerClassName
+  #     http_methods:
+  #       - get
+  #       - post
+  #     filters:
+  #       - FilterClassName
   # idle_connection_timeout: Defaults to 60 seconds, the lifetime 
   # of the connection without read or write
   idle_connection_timeout: 60
@@ -277,20 +282,25 @@ app:
 # plugins: Define all plugins running in the application
 plugins:
     # name: The class name of the plugin
-  - name: '' # drogon::plugin::SecureSSLRedirector
+  - name: drogon::plugin::PromExporter
     # dependencies: Plugins that the plugin depends on. It can be commented out
     dependencies: []
     # config: The configuration of the plugin. This json object is the parameter to initialize the plugin.
     # It can be commented out
     config:
-      ssl_redirect_exempt:
-        - .*\.jpg
-      secure_ssl_host: 'localhost:8849'
+      path: /metrics
+  - name: drogon::plugin::AccessLogger
+    dependencies: []
+    config:
+      use_spdlog: false
+      log_path: ''
+      log_format: ''
+      log_file: access.log
+      log_size_limit: 0
+      use_local_time: true
+      log_index: 0
+      # show_microseconds: true
+      # custom_time_format: ''
+      # use_real_ip: false
 # custom_config: custom configuration for users. This object can be get by the app().getCustomConfig() method. 
-custom_config:
-  realm: drogonRealm
-  opaque: drogonOpaque
-  credentials:
-    - user: drogon
-      password: dr0g0n
-
+custom_config: {}

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -303,4 +303,9 @@ plugins:
       # custom_time_format: ''
       # use_real_ip: false
 # custom_config: custom configuration for users. This object can be get by the app().getCustomConfig() method. 
-custom_config: {}
+custom_config:
+  realm: drogonRealm
+  opaque: drogonOpaque
+  credentials:
+    - user: drogon
+      password: dr0g0n

--- a/drogon_ctl/templates/config_json.csp
+++ b/drogon_ctl/templates/config_json.csp
@@ -39,7 +39,7 @@
     "db_clients": [
         {
             //name: Name of the client,'default' by default
-            //"name":"",
+            "name": "default",
             //rdbms: Server type, postgresql,mysql or sqlite3, "postgresql" by default
             "rdbms": "postgresql",
             //filename: Sqlite3 db file name
@@ -74,7 +74,7 @@
     "redis_clients": [
         {
             //name: Name of the client,'default' by default
-            //"name":"",
+            "name": "default",
             //host: Server IP, 127.0.0.1 by default
             "host": "127.0.0.1",
             //port: Server port, 6379 by default
@@ -103,14 +103,14 @@
         //enable_session: False by default
         "enable_session": false,
         "session_timeout": 0,
-        //string value of SameSite attribute of the Set-Cookie HTTP respone header
+        //string value of SameSite attribute of the Set-Cookie HTTP response header
         //valid value is either 'Null' (default), 'Lax', 'Strict' or 'None'
         "session_same_site" : "Null",
         //session_cookie_key: The cookie key of the session, "JSESSIONID" by default
         "session_cookie_key": "JSESSIONID",
         //session_max_age: The max age of the session cookie, -1 by default
         "session_max_age": -1,
-        //document_root: Root path of HTTP document, defaut path is ./
+        //document_root: Root path of HTTP document, default path is ./
         "document_root": "./",
         //home_page: Set the HTML file of the home page, the default value is "index.html"
         //If there isn't any handler registered to the path "/", the home page file in the "document_root" is send to clients as a response
@@ -123,10 +123,10 @@
         "implicit_page": "index.html",
         //static_file_headers: Headers for static files
         /*"static_file_headers": [
-          {
+            {
                 "name": "field-name",
                 "value": "field-value"
-          }
+            }
         ],*/
         //upload_path: The path to save the uploaded file. "uploads" by default. 
         //If the path isn't prefixed with /, ./ or ../,
@@ -184,7 +184,7 @@
         ],
         //max_connections: maximum number of connections, 100000 by default
         "max_connections": 100000,
-        //max_connections_per_ip: maximum number of connections per clinet, 0 by default which means no limit
+        //max_connections_per_ip: maximum number of connections per client, 0 by default which means no limit
         "max_connections_per_ip": 0,
         //Load_dynamic_views: False by default, when set to true, drogon
         //compiles and loads dynamically "CSP View Files" in directories defined
@@ -215,7 +215,6 @@
         //log: Set log output, drogon output logs to stdout by default
         "log": {
             //use_spdlog: Use spdlog library to log
-            //"use_spdlog": false
             "use_spdlog": false,
             //log_path: Log file path,empty by default,in which case,logs are output to the stdout
             //"log_path": "./",
@@ -327,16 +326,16 @@
             "name": "drogon::plugin::AccessLogger",
             "dependencies": [],
             "config": {
-                    "use_spdlog": false,
-                    "log_path": "",
-                    "log_format": "",
-                    "log_file": "access.log",
-                    "log_size_limit": 0,
-                    "use_local_time": true,
-                    "log_index": 0,
-                    // "show_microseconds": true,
-                    // "custom_time_format": "",
-                    // "use_real_ip": false
+                "use_spdlog": false,
+                "log_path": "",
+                "log_format": "",
+                "log_file": "access.log",
+                "log_size_limit": 0,
+                "use_local_time": true,
+                "log_index": 0,
+                // "show_microseconds": true,
+                // "custom_time_format": "",
+                // "use_real_ip": false
             }
         }
     ],

--- a/drogon_ctl/templates/config_yaml.csp
+++ b/drogon_ctl/templates/config_yaml.csp
@@ -87,7 +87,7 @@ app:
   # is the number of CPU cores
   number_of_threads: 1
   # enable_session: False by default
-  enable_session: true
+  enable_session: false
   session_timeout: 0
   # string value of SameSite attribute of the Set-Cookie HTTP response header
   # valid value is either 'Null' (default), 'Lax', 'Strict' or 'None'

--- a/drogon_ctl/templates/config_yaml.csp
+++ b/drogon_ctl/templates/config_yaml.csp
@@ -3,8 +3,8 @@
 # ssl:The global SSL settings. "key" and "cert" are the path to the SSL key and certificate. While
 #     "conf" is an array of 1 or 2-element tuples that supplies file style options for `SSL_CONF_cmd`.
 # ssl:
-#   cert: ../../trantor/trantor/tests/server.pem
-#   key: ../../trantor/trantor/tests/server.pem
+#   cert: ../../trantor/trantor/tests/server.crt
+#   key: ../../trantor/trantor/tests/server.key
 #   conf: [
 #     # [Options, -SessionTicket],
 #     # [Options, Compression]
@@ -30,11 +30,11 @@
 #     ]
 # db_clients:
 #     # name: Name of the client,'default' by default
-#   - name: ''
+#   - name: default
 #     # rdbms: Server type, postgresql,mysql or sqlite3, "postgresql" by default
 #     rdbms: postgresql
 #     # filename: Sqlite3 db file name
-#     # filename: '',
+#     # filename: ''
 #     # host: Server address,localhost by default
 #     host: 127.0.0.1
 #     # port: Server port, 5432 by default
@@ -50,7 +50,7 @@
 #     is_fast: false
 #     # client_encoding: The character set used by the client. it is empty string by default which 
 #     # means use the default character set.
-#     # client_encoding: '',
+#     # client_encoding: ''
 #     # number_of_connections: 1 by default, if the 'is_fast' is true, the number is the number of  
 #     # connections per IO thread, otherwise it is the total number of all connections.  
 #     number_of_connections: 1
@@ -62,7 +62,7 @@
 #     auto_batch: false
 # redis_clients:
 #     # name: Name of the client,'default' by default
-#   - name: ''
+#   - name: default
 #     # host: Server IP, 127.0.0.1 by default
 #     host: 127.0.0.1
 #     # port: Server port, 6379 by default
@@ -89,14 +89,14 @@ app:
   # enable_session: False by default
   enable_session: true
   session_timeout: 0
-  # string value of SameSite attribute of the Set-Cookie HTTP respone header
+  # string value of SameSite attribute of the Set-Cookie HTTP response header
   # valid value is either 'Null' (default), 'Lax', 'Strict' or 'None'
   session_same_site: 'Null'
   # session_cookie_key: The cookie key of the session, "JSESSIONID" by default
   session_cookie_key: 'JSESSIONID'
   # session_max_age: The max age of the session cookie, -1 by default
   session_max_age: -1
-  # document_root: Root path of HTTP document, defaut path is ./
+  # document_root: Root path of HTTP document, default path is ./
   document_root: ./
   # home_page: Set the HTML file of the home page, the default value is "index.html"
   # If there isn't any handler registered to the path "/", the home page file in the "document_root" is send to clients as a response
@@ -136,9 +136,11 @@ app:
   # mime: A dictionary that extends the internal MIME type support. Maps extensions into new MIME types
   # note: This option only adds MIME to the sever. `file_types` above have to be set for the server to serve them.
   mime: {
-    # text/markdown: md,
-    # text/gemini: [gmi, gemini]
-  }
+    # text/markdown: md
+    # text/gemini:
+    #   - gmi
+    #   - gemini
+    }
   # locations: An array of locations of static files for GET requests.
   locations:
       # uri_prefix: The URI prefix of the location prefixed with "/", the default value is "" that disables the location.
@@ -161,7 +163,7 @@ app:
       filters: []
   # max_connections: maximum number of connections, 100000 by default
   max_connections: 100000
-  # max_connections_per_ip: maximum number of connections per clinet, 0 by default which means no limit
+  # max_connections_per_ip: maximum number of connections per client, 0 by default which means no limit
   max_connections_per_ip: 0
   # Load_dynamic_views: False by default, when set to true, drogon
   # compiles and loads dynamically "CSP View Files" in directories defined
@@ -190,7 +192,7 @@ app:
   # log: Set log output, drogon output logs to stdout by default
   log:
     # use_spdlog: Use spdlog library to log
-    use_spdlog: false,
+    use_spdlog: false
     # log_path: Log file path,empty by default,in which case,logs are output to the stdout
     # log_path: ./
     # logfile_base_name: Log file base name,empty by default which means drogon names logfile as
@@ -199,6 +201,9 @@ app:
     # log_size_limit: 100000000 bytes by default,
     # When the log file size reaches "log_size_limit", the log file is switched.
     log_size_limit: 100000000
+    # max_files: 0 by default,
+    # When the number of old log files exceeds "max_files", the oldest file will be deleted. 0 means never delete.
+    max_files: 0
     # log_level: "DEBUG" by default,options:"TRACE","DEBUG","INFO","WARN"
     # The TRACE level is only valid when built in DEBUG mode.
     log_level: DEBUG
@@ -221,14 +226,14 @@ app:
   # 0 means cache forever, the negative value means no cache
   static_files_cache_time: 5
   # simple_controllers_map: Used to configure mapping from path to simple controller
-  simple_controllers_map:
-    - path: /path/name
-      controller: controllerClassName
-      http_methods:
-        - get
-        - post
-      filters:
-        - FilterClassName
+  # simple_controllers_map:
+  #   - path: /path/name
+  #     controller: controllerClassName
+  #     http_methods:
+  #       - get
+  #       - post
+  #     filters:
+  #       - FilterClassName
   # idle_connection_timeout: Defaults to 60 seconds, the lifetime 
   # of the connection without read or write
   idle_connection_timeout: 60
@@ -277,20 +282,25 @@ app:
 # plugins: Define all plugins running in the application
 plugins:
     # name: The class name of the plugin
-  - name: '' # drogon::plugin::SecureSSLRedirector
+  - name: drogon::plugin::PromExporter
     # dependencies: Plugins that the plugin depends on. It can be commented out
     dependencies: []
     # config: The configuration of the plugin. This json object is the parameter to initialize the plugin.
     # It can be commented out
     config:
-      ssl_redirect_exempt:
-        - .*\.jpg
-      secure_ssl_host: 'localhost:8849'
+      path: /metrics
+  - name: drogon::plugin::AccessLogger
+    dependencies: []
+    config:
+      use_spdlog: false
+      log_path: ''
+      log_format: ''
+      log_file: access.log
+      log_size_limit: 0
+      use_local_time: true
+      log_index: 0
+      # show_microseconds: true
+      # custom_time_format: ''
+      # use_real_ip: false
 # custom_config: custom configuration for users. This object can be get by the app().getCustomConfig() method. 
-custom_config:
-  realm: drogonRealm
-  opaque: drogonOpaque
-  credentials:
-    - user: drogon
-      password: dr0g0n
-
+custom_config: {}


### PR DESCRIPTION
There is an error in the `app.log.use_spdlog` item in the default
config file in the yaml format.
While fixing this error, other minor problems in the config files were
fixed.
For example, some spelling errors and missing items in yaml format.
At the same time, different config files are modified to store the same
content.