### PR TITLE
A way to use pJson.asCString() in template model

### DIFF
--- a/drogon_ctl/templates/model_cc.csp
+++ b/drogon_ctl/templates/model_cc.csp
@@ -1534,8 +1534,7 @@ if(!col.notNull_){%>
                 if(col.colType_ == "std::string" && col.colLength_>0)
                 {
 %>
-            // asString().length() creates a string object, is there any better way to validate the length?
-            if(pJson.isString() && pJson.asString().length() > {%col.colLength_%})
+            if(pJson.isString() && std::strlen(pJson.asCString()) > {%col.colLength_%})
             {
                 err="String length exceeds limit for the " +
                     fieldName +

--- a/orm_lib/tests/mysql/Blog.cc
+++ b/orm_lib/tests/mysql/Blog.cc
@@ -673,9 +673,7 @@ bool Blog::validJsonOfField(size_t index,
                 err = "Type error in the " + fieldName + " field";
                 return false;
             }
-            // asString().length() creates a string object, is there any better
-            // way to validate the length?
-            if (pJson.isString() && pJson.asString().length() > 30)
+            if (pJson.isString() && std::strlen(pJson.asCString()) > 30)
             {
                 err = "String length exceeds limit for the " + fieldName +
                       " field (the maximum value is 30)";

--- a/orm_lib/tests/mysql/Category.cc
+++ b/orm_lib/tests/mysql/Category.cc
@@ -510,9 +510,7 @@ bool Category::validJsonOfField(size_t index,
                 err = "Type error in the " + fieldName + " field";
                 return false;
             }
-            // asString().length() creates a string object, is there any better
-            // way to validate the length?
-            if (pJson.isString() && pJson.asString().length() > 30)
+            if (pJson.isString() && std::strlen(pJson.asCString()) > 30)
             {
                 err = "String length exceeds limit for the " + fieldName +
                       " field (the maximum value is 30)";

--- a/orm_lib/tests/mysql/Tag.cc
+++ b/orm_lib/tests/mysql/Tag.cc
@@ -509,9 +509,7 @@ bool Tag::validJsonOfField(size_t index,
                 err = "Type error in the " + fieldName + " field";
                 return false;
             }
-            // asString().length() creates a string object, is there any better
-            // way to validate the length?
-            if (pJson.isString() && pJson.asString().length() > 30)
+            if (pJson.isString() && std::strlen(pJson.asCString()) > 30)
             {
                 err = "String length exceeds limit for the " + fieldName +
                       " field (the maximum value is 30)";

--- a/orm_lib/tests/mysql/Users.cc
+++ b/orm_lib/tests/mysql/Users.cc
@@ -1674,9 +1674,7 @@ bool Users::validJsonOfField(size_t index,
                 err = "Type error in the " + fieldName + " field";
                 return false;
             }
-            // asString().length() creates a string object, is there any better
-            // way to validate the length?
-            if (pJson.isString() && pJson.asString().length() > 32)
+            if (pJson.isString() && std::strlen(pJson.asCString()) > 32)
             {
                 err = "String length exceeds limit for the " + fieldName +
                       " field (the maximum value is 32)";
@@ -1694,9 +1692,7 @@ bool Users::validJsonOfField(size_t index,
                 err = "Type error in the " + fieldName + " field";
                 return false;
             }
-            // asString().length() creates a string object, is there any better
-            // way to validate the length?
-            if (pJson.isString() && pJson.asString().length() > 64)
+            if (pJson.isString() && std::strlen(pJson.asCString()) > 64)
             {
                 err = "String length exceeds limit for the " + fieldName +
                       " field (the maximum value is 64)";
@@ -1714,9 +1710,7 @@ bool Users::validJsonOfField(size_t index,
                 err = "Type error in the " + fieldName + " field";
                 return false;
             }
-            // asString().length() creates a string object, is there any better
-            // way to validate the length?
-            if (pJson.isString() && pJson.asString().length() > 64)
+            if (pJson.isString() && std::strlen(pJson.asCString()) > 64)
             {
                 err = "String length exceeds limit for the " + fieldName +
                       " field (the maximum value is 64)";
@@ -1734,9 +1728,7 @@ bool Users::validJsonOfField(size_t index,
                 err = "Type error in the " + fieldName + " field";
                 return false;
             }
-            // asString().length() creates a string object, is there any better
-            // way to validate the length?
-            if (pJson.isString() && pJson.asString().length() > 20)
+            if (pJson.isString() && std::strlen(pJson.asCString()) > 20)
             {
                 err = "String length exceeds limit for the " + fieldName +
                       " field (the maximum value is 20)";
@@ -1754,9 +1746,7 @@ bool Users::validJsonOfField(size_t index,
                 err = "Type error in the " + fieldName + " field";
                 return false;
             }
-            // asString().length() creates a string object, is there any better
-            // way to validate the length?
-            if (pJson.isString() && pJson.asString().length() > 50)
+            if (pJson.isString() && std::strlen(pJson.asCString()) > 50)
             {
                 err = "String length exceeds limit for the " + fieldName +
                       " field (the maximum value is 50)";
@@ -1774,9 +1764,7 @@ bool Users::validJsonOfField(size_t index,
                 err = "Type error in the " + fieldName + " field";
                 return false;
             }
-            // asString().length() creates a string object, is there any better
-            // way to validate the length?
-            if (pJson.isString() && pJson.asString().length() > 32)
+            if (pJson.isString() && std::strlen(pJson.asCString()) > 32)
             {
                 err = "String length exceeds limit for the " + fieldName +
                       " field (the maximum value is 32)";
@@ -1794,9 +1782,7 @@ bool Users::validJsonOfField(size_t index,
                 err = "Type error in the " + fieldName + " field";
                 return false;
             }
-            // asString().length() creates a string object, is there any better
-            // way to validate the length?
-            if (pJson.isString() && pJson.asString().length() > 20)
+            if (pJson.isString() && std::strlen(pJson.asCString()) > 20)
             {
                 err = "String length exceeds limit for the " + fieldName +
                       " field (the maximum value is 20)";

--- a/orm_lib/tests/mysql/Wallets.cc
+++ b/orm_lib/tests/mysql/Wallets.cc
@@ -677,9 +677,7 @@ bool Wallets::validJsonOfField(size_t index,
                 err = "Type error in the " + fieldName + " field";
                 return false;
             }
-            // asString().length() creates a string object, is there any better
-            // way to validate the length?
-            if (pJson.isString() && pJson.asString().length() > 32)
+            if (pJson.isString() && std::strlen(pJson.asCString()) > 32)
             {
                 err = "String length exceeds limit for the " + fieldName +
                       " field (the maximum value is 32)";

--- a/orm_lib/tests/postgresql/Blog.cc
+++ b/orm_lib/tests/postgresql/Blog.cc
@@ -672,9 +672,7 @@ bool Blog::validJsonOfField(size_t index,
                 err = "Type error in the " + fieldName + " field";
                 return false;
             }
-            // asString().length() creates a string object, is there any better
-            // way to validate the length?
-            if (pJson.isString() && pJson.asString().length() > 30)
+            if (pJson.isString() && std::strlen(pJson.asCString()) > 30)
             {
                 err = "String length exceeds limit for the " + fieldName +
                       " field (the maximum value is 30)";

--- a/orm_lib/tests/postgresql/Category.cc
+++ b/orm_lib/tests/postgresql/Category.cc
@@ -509,9 +509,7 @@ bool Category::validJsonOfField(size_t index,
                 err = "Type error in the " + fieldName + " field";
                 return false;
             }
-            // asString().length() creates a string object, is there any better
-            // way to validate the length?
-            if (pJson.isString() && pJson.asString().length() > 30)
+            if (pJson.isString() && std::strlen(pJson.asCString()) > 30)
             {
                 err = "String length exceeds limit for the " + fieldName +
                       " field (the maximum value is 30)";

--- a/orm_lib/tests/postgresql/Tag.cc
+++ b/orm_lib/tests/postgresql/Tag.cc
@@ -508,9 +508,7 @@ bool Tag::validJsonOfField(size_t index,
                 err = "Type error in the " + fieldName + " field";
                 return false;
             }
-            // asString().length() creates a string object, is there any better
-            // way to validate the length?
-            if (pJson.isString() && pJson.asString().length() > 30)
+            if (pJson.isString() && std::strlen(pJson.asCString()) > 30)
             {
                 err = "String length exceeds limit for the " + fieldName +
                       " field (the maximum value is 30)";

--- a/orm_lib/tests/postgresql/Users.cc
+++ b/orm_lib/tests/postgresql/Users.cc
@@ -1656,9 +1656,7 @@ bool Users::validJsonOfField(size_t index,
                 err = "Type error in the " + fieldName + " field";
                 return false;
             }
-            // asString().length() creates a string object, is there any better
-            // way to validate the length?
-            if (pJson.isString() && pJson.asString().length() > 32)
+            if (pJson.isString() && std::strlen(pJson.asCString()) > 32)
             {
                 err = "String length exceeds limit for the " + fieldName +
                       " field (the maximum value is 32)";
@@ -1676,9 +1674,7 @@ bool Users::validJsonOfField(size_t index,
                 err = "Type error in the " + fieldName + " field";
                 return false;
             }
-            // asString().length() creates a string object, is there any better
-            // way to validate the length?
-            if (pJson.isString() && pJson.asString().length() > 64)
+            if (pJson.isString() && std::strlen(pJson.asCString()) > 64)
             {
                 err = "String length exceeds limit for the " + fieldName +
                       " field (the maximum value is 64)";
@@ -1696,9 +1692,7 @@ bool Users::validJsonOfField(size_t index,
                 err = "Type error in the " + fieldName + " field";
                 return false;
             }
-            // asString().length() creates a string object, is there any better
-            // way to validate the length?
-            if (pJson.isString() && pJson.asString().length() > 64)
+            if (pJson.isString() && std::strlen(pJson.asCString()) > 64)
             {
                 err = "String length exceeds limit for the " + fieldName +
                       " field (the maximum value is 64)";
@@ -1716,9 +1710,7 @@ bool Users::validJsonOfField(size_t index,
                 err = "Type error in the " + fieldName + " field";
                 return false;
             }
-            // asString().length() creates a string object, is there any better
-            // way to validate the length?
-            if (pJson.isString() && pJson.asString().length() > 20)
+            if (pJson.isString() && std::strlen(pJson.asCString()) > 20)
             {
                 err = "String length exceeds limit for the " + fieldName +
                       " field (the maximum value is 20)";
@@ -1736,9 +1728,7 @@ bool Users::validJsonOfField(size_t index,
                 err = "Type error in the " + fieldName + " field";
                 return false;
             }
-            // asString().length() creates a string object, is there any better
-            // way to validate the length?
-            if (pJson.isString() && pJson.asString().length() > 50)
+            if (pJson.isString() && std::strlen(pJson.asCString()) > 50)
             {
                 err = "String length exceeds limit for the " + fieldName +
                       " field (the maximum value is 50)";
@@ -1756,9 +1746,7 @@ bool Users::validJsonOfField(size_t index,
                 err = "Type error in the " + fieldName + " field";
                 return false;
             }
-            // asString().length() creates a string object, is there any better
-            // way to validate the length?
-            if (pJson.isString() && pJson.asString().length() > 32)
+            if (pJson.isString() && std::strlen(pJson.asCString()) > 32)
             {
                 err = "String length exceeds limit for the " + fieldName +
                       " field (the maximum value is 32)";
@@ -1793,9 +1781,7 @@ bool Users::validJsonOfField(size_t index,
                 err = "Type error in the " + fieldName + " field";
                 return false;
             }
-            // asString().length() creates a string object, is there any better
-            // way to validate the length?
-            if (pJson.isString() && pJson.asString().length() > 20)
+            if (pJson.isString() && std::strlen(pJson.asCString()) > 20)
             {
                 err = "String length exceeds limit for the " + fieldName +
                       " field (the maximum value is 20)";

--- a/orm_lib/tests/postgresql/Wallets.cc
+++ b/orm_lib/tests/postgresql/Wallets.cc
@@ -676,9 +676,7 @@ bool Wallets::validJsonOfField(size_t index,
                 err = "Type error in the " + fieldName + " field";
                 return false;
             }
-            // asString().length() creates a string object, is there any better
-            // way to validate the length?
-            if (pJson.isString() && pJson.asString().length() > 32)
+            if (pJson.isString() && std::strlen(pJson.asCString()) > 32)
             {
                 err = "String length exceeds limit for the " + fieldName +
                       " field (the maximum value is 32)";


### PR DESCRIPTION
In this version, pJson.asCString() returns a pointer to the string data, and strlen is used to measure the length of the string without creating a temporary std::string object. It could be an alternative to improve how it was working previously. I hope it is useful.