### PR TITLE
adding example 'webserver reverse proxy'

### DIFF
--- a/examples/webserver_reverse_proxy/.gitignore
+++ b/examples/webserver_reverse_proxy/.gitignore
@@ -1,0 +1,22 @@
+##
+## directory
+##
+/bin
+/build
+/logs
+/public
+
+
+##
+## extension
+##
+*.exe
+*.out
+*.app
+
+
+##
+## file
+##
+/.vscode/settings.json
+/.vscode/launch.json

--- a/examples/webserver_reverse_proxy/CMakeLists.txt
+++ b/examples/webserver_reverse_proxy/CMakeLists.txt
@@ -1,0 +1,36 @@
+cmake_minimum_required(VERSION 3.15)
+project(webserver_reverse_proxy_example)
+
+include(CheckIncludeFileCXX)
+
+check_include_file_cxx(any HAS_ANY)
+check_include_file_cxx(string_view HAS_STRING_VIEW)
+if(HAS_ANY AND HAS_STRING_VIEW)
+    set(CMAKE_CXX_STANDARD 17)
+else()
+    set(CMAKE_CXX_STANDARD 14)
+endif()
+
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+find_package(Drogon CONFIG REQUIRED)
+
+if(CMAKE_CXX_STANDARD LESS 17)
+#With C++14, use boost to support any and string_view
+    message(STATUS "use c++14")
+    find_package(Boost 1.61.0 REQUIRED)
+    target_include_directories(simple_reverse_proxy PRIVATE ${Boost_INCLUDE_DIRS})
+else()
+    message(STATUS "use c++17")
+endif()
+
+set(EXECUTABLE_OUTPUT_PATH          ${CMAKE_CURRENT_SOURCE_DIR}/bin)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY  ${CMAKE_CURRENT_SOURCE_DIR}/bin)
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY  ${CMAKE_CURRENT_SOURCE_DIR}/bin)
+set(CMAKE_PDB_OUTPUT_DIRECTORY      ${CMAKE_CURRENT_SOURCE_DIR}/bin)
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY  ${CMAKE_CURRENT_SOURCE_DIR}/bin)
+
+add_subdirectory(src/webserver/drogon_server)
+add_subdirectory(src/backend/backend_api)
+add_subdirectory(src/backend/backend_www)

--- a/examples/webserver_reverse_proxy/README.md
+++ b/examples/webserver_reverse_proxy/README.md
@@ -1,0 +1,71 @@
+# drogon framework example: webserver reverse proxy
+
+__NOTE:__
+
+```
+this example show how to use drogon as webserver and using reverse proxy
+```
+
+<br>
+
+## steps:
+
+- add these:
+    ```txt
+    127.0.0.1   localhost.com
+    127.0.0.1   api.localhost.com
+    127.0.0.1   admin.localhost.com
+    127.0.0.1   www.localhost.com
+    ```
+
+    to
+
+    - __linux debian__ base location:
+
+        - `/etc/hosts`:
+
+    - __windows__ base location:
+
+        - `C:\Windows\System32\drivers\etc\hosts`:
+
+    ---
+
+- make it sure drogon config is already installed on your machine environment
+
+- build this project, *you can use build-debug-linux.sh on linux environment*
+
+- launch:
+    - terminal:
+        - go to _*./bin*_ directory and run each of these:
+            - `./drogon_server`
+            - `./backend_api`
+            - `./backend_www`
+
+    - open your browser:
+        - go to:
+            - `http://www.localhost.com:9999`:
+                - this will redirect to `http://localhost.com:9999`
+
+            - `http://localhost.com:9999`:
+                - will show example message and which port is called
+
+            - `http://api.localhost.com:9999`:
+                - will show json message from which port
+
+            - `http://api.localhost.com:9999/test`:
+                - will show json message from `/test` endpoint/path and show which port is called
+
+<br>
+
+---
+
+## preview result example
+
+- [preview result example 1](https://raw.githubusercontent.com/prothegee/prothegee/main/previews/_preview-example-drogon_server-1.png)
+- [preview result example 2](https://raw.githubusercontent.com/prothegee/prothegee/main/previews/_preview-example-drogon_server-2.png)
+
+<br>
+
+---
+
+###### end of readme

--- a/examples/webserver_reverse_proxy/build-debug-linux.sh
+++ b/examples/webserver_reverse_proxy/build-debug-linux.sh
@@ -1,0 +1,10 @@
+mkdir -p bin;
+mkdir -p build;
+
+mkdir -p logs/access;
+mkdir -p logs/info;
+
+mkdir -p public;
+
+cmake -B build -DCMAKE_BUILD_TYPE=Debug;
+cmake --build build --config Debug;

--- a/examples/webserver_reverse_proxy/config.backend_api.json
+++ b/examples/webserver_reverse_proxy/config.backend_api.json
@@ -1,0 +1,130 @@
+{
+    "custom_config": {
+        "_": "don't use me"
+    },
+    "listeners": [
+        {
+            "address": "0.0.0.0",
+            "port": 9104,
+            "https": false
+        },
+        {
+            "address": "0.0.0.0",
+            "port": 9105,
+            "https": false
+        },
+        {
+            "address": "0.0.0.0",
+            "port": 9106,
+            "https": false
+        }
+    ],
+    "mime": {
+        "text/markdown": "md",
+        "text/gemini": [
+            "gmi", "gemini"
+        ],
+        "text/css": [
+            "css", "css.map"
+        ],
+        "text/javascript": [
+            "js", "mjs", "js.map", "framework.js", "loader.js",
+            "audio.worklet.js",
+            "data", "pck",
+            "wasm", "side.wasm",
+            "worker.js"
+        ]
+    },
+    "app": {
+        "number_of_threads": 2,
+        "document_root": "../public",
+        "enable_session": false,
+        "session_timeout": 604800,
+        "session_same_site" : "Strict",
+        "session_cookie_key": "_backend_api-session-id",
+        "max_connections": 262144,
+        "max_connections_per_ip": 0,
+        "client_max_body_size": "5M",
+        "client_max_memory_body_size": "5M",
+        "client_max_websocket_message_size": "5M",
+        "log": {
+            "use_spdlog": false,
+            "log_path": "../logs/info",
+            "logfile_base_name": "backend_api.info",
+            "log_size_limit": 100000000,
+            "max_files": 30,
+            "log_level": "INFO"
+        },
+        "run_as_daemon": false,
+        "relaunch_on_error": false,
+        "upload_path": "uploads",
+        "use_sendfile": true,
+        "use_gzip": true,
+        "use_brotli": true,
+        "static_files_cache_time": 480,
+        "idle_connection_timeout": 600,
+        "enable_server_header": true,
+        "server_header_field": "Drogon Framework",
+        "enable_date_header": false,
+        "keepalive_requests": 0,
+        "br_static": true,
+        "reuse_port": false,
+        "file_types": [
+            "gif",
+            "png",
+            "jpg",
+            "map",
+            "js",
+            "framework.js",
+            "loader.js",
+            "bundle.js",
+            "min.js",
+            "js.map",
+            "js.flow",
+            "module.js",
+            "cjs",
+            "mjs",
+            "css",
+            "css.map",
+            "min.css",
+            "min.css.map",
+            "rtl.css.map",
+            "rtl.min.css.map",
+            "scss",
+            "html",
+            "ico",
+            "swf",
+            "svg",
+            "xap",
+            "apk",
+            "cur",
+            "xml",
+            "ttf",
+            "woff",
+            "woff2",
+            "text",
+            "txt",
+            "json",
+            "audio.worklet.js",
+            "data",
+            "pck",
+            "wasm",
+            "side.wasm",
+            "worker.js"
+        ]
+    },
+    "plugins": [
+        {
+            "name": "drogon::plugin::AccessLogger",
+            "dependencies": [],
+            "config": {
+                "log_path": "../logs/access",
+                "log_format": "$request_date $method $url [$body_bytes_received] ($remote_addr - $local_addr) $status $body_bytes_sent $processing_time",
+                "log_file": "backend_api.access.log",
+                "log_size_limit": 100000000,
+                "use_local_time": true,
+                "log_index": 0
+            }
+        }
+    ]
+}

--- a/examples/webserver_reverse_proxy/config.backend_www.json
+++ b/examples/webserver_reverse_proxy/config.backend_www.json
@@ -1,0 +1,130 @@
+{
+    "custom_config": {
+        "_": "don't use me"
+    },
+    "listeners": [
+        {
+            "address": "0.0.0.0",
+            "port": 9101,
+            "https": false
+        },
+        {
+            "address": "0.0.0.0",
+            "port": 9102,
+            "https": false
+        },
+        {
+            "address": "0.0.0.0",
+            "port": 9103,
+            "https": false
+        }
+    ],
+    "mime": {
+        "text/markdown": "md",
+        "text/gemini": [
+            "gmi", "gemini"
+        ],
+        "text/css": [
+            "css", "css.map"
+        ],
+        "text/javascript": [
+            "js", "mjs", "js.map", "framework.js", "loader.js",
+            "audio.worklet.js",
+            "data", "pck",
+            "wasm", "side.wasm",
+            "worker.js"
+        ]
+    },
+    "app": {
+        "number_of_threads": 2,
+        "document_root": "../public",
+        "enable_session": false,
+        "session_timeout": 604800,
+        "session_same_site" : "Strict",
+        "session_cookie_key": "_backend_www-session-id",
+        "max_connections": 262144,
+        "max_connections_per_ip": 0,
+        "client_max_body_size": "5M",
+        "client_max_memory_body_size": "5M",
+        "client_max_websocket_message_size": "5M",
+        "log": {
+            "use_spdlog": false,
+            "log_path": "../logs/info",
+            "logfile_base_name": "backend_www.info",
+            "log_size_limit": 100000000,
+            "max_files": 30,
+            "log_level": "INFO"
+        },
+        "run_as_daemon": false,
+        "relaunch_on_error": false,
+        "upload_path": "uploads",
+        "use_sendfile": true,
+        "use_gzip": true,
+        "use_brotli": true,
+        "static_files_cache_time": 480,
+        "idle_connection_timeout": 600,
+        "enable_server_header": true,
+        "server_header_field": "Drogon Framework",
+        "enable_date_header": false,
+        "keepalive_requests": 0,
+        "br_static": true,
+        "reuse_port": false,
+        "file_types": [
+            "gif",
+            "png",
+            "jpg",
+            "map",
+            "js",
+            "framework.js",
+            "loader.js",
+            "bundle.js",
+            "min.js",
+            "js.map",
+            "js.flow",
+            "module.js",
+            "cjs",
+            "mjs",
+            "css",
+            "css.map",
+            "min.css",
+            "min.css.map",
+            "rtl.css.map",
+            "rtl.min.css.map",
+            "scss",
+            "html",
+            "ico",
+            "swf",
+            "svg",
+            "xap",
+            "apk",
+            "cur",
+            "xml",
+            "ttf",
+            "woff",
+            "woff2",
+            "text",
+            "txt",
+            "json",
+            "audio.worklet.js",
+            "data",
+            "pck",
+            "wasm",
+            "side.wasm",
+            "worker.js"
+        ]
+    },
+    "plugins": [
+        {
+            "name": "drogon::plugin::AccessLogger",
+            "dependencies": [],
+            "config": {
+                "log_path": "../logs/access",
+                "log_format": "$request_date $method $url [$body_bytes_received] ($remote_addr - $local_addr) $status $body_bytes_sent $processing_time",
+                "log_file": "backend_www.access.log",
+                "log_size_limit": 100000000,
+                "use_local_time": true,
+                "log_index": 0
+            }
+        }
+    ]
+}

--- a/examples/webserver_reverse_proxy/config.drogon_server.json
+++ b/examples/webserver_reverse_proxy/config.drogon_server.json
@@ -1,0 +1,204 @@
+{
+    "custom_config": {
+        "name": "drogon_server"
+    },
+    "listeners": [
+        {
+            "address": "0.0.0.0",
+            "port": 9999,
+            "https": false
+        }
+    ],
+    "mime": {
+        "text/markdown": "md",
+        "text/gemini": [
+            "gmi", "gemini"
+        ],
+        "text/css": [
+            "css", "css.map"
+        ],
+        "text/javascript": [
+            "js", "mjs", "js.map", "framework.js", "loader.js",
+            "audio.worklet.js",
+            "data", "pck",
+            "wasm", "side.wasm",
+            "worker.js"
+        ]
+    },
+    "app": {
+        "number_of_threads": 2,
+        "document_root": "../public",
+        "enable_session": false,
+        "session_timeout": 604800,
+        "session_same_site" : "Strict",
+        "session_cookie_key": "_drogon_server-session-id",
+        "max_connections": 262144,
+        "max_connections_per_ip": 0,
+        "client_max_body_size": "5M",
+        "client_max_memory_body_size": "5M",
+        "client_max_websocket_message_size": "5M",
+        "log": {
+            "use_spdlog": false,
+            "log_path": "../logs/info",
+            "logfile_base_name": "drogon_server.info",
+            "log_size_limit": 100000000,
+            "max_files": 30,
+            "log_level": "INFO"
+        },
+        "run_as_daemon": false,
+        "relaunch_on_error": false,
+        "upload_path": "m",
+        "use_sendfile": true,
+        "use_gzip": true,
+        "use_brotli": true,
+        "static_files_cache_time": -1,
+        "idle_connection_timeout": 600,
+        "enable_server_header": true,
+        "server_header_field": "Drogon Framework",
+        "enable_date_header": false,
+        "keepalive_requests": 0,
+        "br_static": true,
+        "reuse_port": false,
+        "file_types": [
+            "gif",
+            "png",
+            "jpg",
+            "map",
+            "js",
+            "framework.js",
+            "loader.js",
+            "bundle.js",
+            "min.js",
+            "js.map",
+            "js.flow",
+            "module.js",
+            "cjs",
+            "mjs",
+            "css",
+            "css.map",
+            "min.css",
+            "min.css.map",
+            "rtl.css.map",
+            "rtl.min.css.map",
+            "scss",
+            "html",
+            "ico",
+            "swf",
+            "svg",
+            "xap",
+            "apk",
+            "cur",
+            "xml",
+            "ttf",
+            "woff",
+            "woff2",
+            "text",
+            "txt",
+            "json",
+            "audio.worklet.js",
+            "data",
+            "pck",
+            "wasm",
+            "side.wasm",
+            "worker.js"
+        ]
+    },
+    "plugins": [
+        {
+            "name": "drogon::plugin::AccessLogger",
+            "dependencies": [],
+            "config": {
+                "log_path": "../logs/access",
+                "log_format": "$request_date $method $url [$body_bytes_received] ($remote_addr - $local_addr) $status $body_bytes_sent $processing_time",
+                "log_file": "drogon_server.access.log",
+                "log_size_limit": 100000000,
+                "use_local_time": true,
+                "log_index": 0
+            }
+        },
+        {
+            "name": "ReverseProxy",
+            "dependencies": [],
+            "config": {
+                "backends": [
+                    {
+                        "host": "localhost.com:9999",
+                        "redirect": false,
+                        "redirect_to": "",
+                        "header_add": false,
+                        "header_add_list": [
+                            ["x-frame-options", "sameorigin"]
+                        ],
+                        "document_root": "../public",
+                        "check_origin_whitelist": false,
+                        "check_origin_whitelist_data": "http://localhost.com:9999 http://api.localhost.com:9999 http://www.localhost.com:9999",
+                        "internal_proxies": [
+                            "http://127.0.0.1:9101",
+                            "http://127.0.0.1:9102",
+                            "http://127.0.0.1:9103"
+                        ],
+                        "ssl": false,
+                        "ssl_conf": {
+                            "cert": "",
+                            "key": "",
+                            "use_old_tls": false,
+                            "configurations": []
+                        }
+                    },
+                    {
+                        "host": "www.localhost.com:9999",
+                        "redirect": true,
+                        "redirect_to": "http://localhost.com:9999",
+                        "header_add": false,
+                        "header_add_list": [
+                            ["x-frame-options", "sameorigin"]
+                        ],
+                        "document_root": "../public",
+                        "check_origin_whitelist": false,
+                        "check_origin_whitelist_data": "http://localhost.com:9999 http://api.localhost.com:9999 http://www.localhost.com:9999",
+                        "internal_proxies": [
+                            "http://127.0.0.1:9101",
+                            "http://127.0.0.1:9102",
+                            "http://127.0.0.1:9103"
+                        ],
+                        "ssl": false,
+                        "ssl_conf": {
+                            "cert": "",
+                            "key": "",
+                            "use_old_tls": false,
+                            "configurations": []
+                        }
+                    },
+                    {
+                        "host": "api.localhost.com:9999",
+                        "redirect": false,
+                        "redirect_to": "",
+                        "header_add": false,
+                        "header_add_list": [
+                            ["x-frame-options", "sameorigin"]
+                        ],
+                        "document_root": "../public",
+                        "check_origin_whitelist": false,
+                        "check_origin_whitelist_data": "http://localhost.com:9999 http://api.localhost.com:9999 http://www.localhost.com:9999",
+                        "internal_proxies": [
+                            "http://127.0.0.1:9104",
+                            "http://127.0.0.1:9105",
+                            "http://127.0.0.1:9106"
+                        ],
+                        "ssl": false,
+                        "ssl_conf": {
+                            "cert": "",
+                            "key": "",
+                            "use_old_tls": false,
+                            "configurations": []
+                        }
+                    }
+                ],
+                "pipelining": 16,
+                "connection_factor": 1,
+                "default_document_root": "../public",
+                "same_client_to_same_backend": false
+            }
+        }
+    ]
+}

--- a/examples/webserver_reverse_proxy/src/backend/backend_api/CMakeLists.txt
+++ b/examples/webserver_reverse_proxy/src/backend/backend_api/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.15)
+project(backend_api)
+
+set(BACKEND_API_ROOT_HEADERS
+)
+set(BACKEND_API_ROOT_FILES
+    main.cc
+)
+
+add_executable(${PROJECT_NAME}
+    ${BACKEND_API_ROOT_HEADERS} ${BACKEND_API_ROOT_FILES}
+)
+
+target_link_libraries(${PROJECT_NAME} PRIVATE Drogon::Drogon)

--- a/examples/webserver_reverse_proxy/src/backend/backend_api/main.cc
+++ b/examples/webserver_reverse_proxy/src/backend/backend_api/main.cc
@@ -1,0 +1,42 @@
+#include <drogon/drogon.h>
+
+using namespace drogon;
+
+int main(int argc, char* argv[])
+{
+    app().loadConfigFile("../config.backend_api.json");
+
+    app().registerHandler("/",
+                         [](const HttpRequestPtr &pReq, std::function<void(const HttpResponsePtr &)> &&callback)
+                         {
+                            Json::Value body;
+
+                            body.clear();
+
+                            body["port"] = pReq->getLocalAddr().toPort();
+
+                            body["message"] = "a simple message from api.localhost.com '/' path";
+
+                            auto pResp = HttpResponse::newHttpJsonResponse(body);
+
+                            callback(pResp);
+                         });
+
+    app().registerHandler("/test",
+                         [](const HttpRequestPtr &pReq, std::function<void(const HttpResponsePtr &)> &&callback)
+                         {
+                            Json::Value body;
+
+                            body.clear();
+
+                            body["port"] = pReq->getLocalAddr().toPort();
+
+                            body["message"] = "another test message from api.localhost.com '/test' path";
+                            
+                            auto pResp = HttpResponse::newHttpJsonResponse(body);
+
+                            callback(pResp);
+                         });
+
+    app().run();
+}

--- a/examples/webserver_reverse_proxy/src/backend/backend_www/CMakeLists.txt
+++ b/examples/webserver_reverse_proxy/src/backend/backend_www/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.15)
+project(backend_www)
+
+set(BACKEND_WWW_ROOT_HEADERS
+)
+set(BACKEND_WWW_ROOT_FILES
+    main.cc
+)
+
+add_executable(${PROJECT_NAME}
+    ${BACKEND_WWW_ROOT_HEADERS} ${BACKEND_WWW_ROOT_FILES}
+)
+
+target_link_libraries(${PROJECT_NAME} PRIVATE Drogon::Drogon)

--- a/examples/webserver_reverse_proxy/src/backend/backend_www/main.cc
+++ b/examples/webserver_reverse_proxy/src/backend/backend_www/main.cc
@@ -1,0 +1,22 @@
+#include <drogon/drogon.h>
+
+using namespace drogon;
+
+int main(int argc, char* argv[])
+{
+    app().loadConfigFile("../config.backend_www.json");
+
+    app().registerHandler("/",
+                         [](const HttpRequestPtr &pReq, std::function<void(const HttpResponsePtr &)> &&callback)
+                         {
+                            auto pResp = HttpResponse::newHttpResponse();
+
+                            std::string body = std::string("welcome to localhost.com port " + std::to_string(pReq->getLocalAddr().toPort()));
+
+                            pResp->setBody(body);
+
+                            callback(pResp);
+                         });
+
+    app().run();
+}

--- a/examples/webserver_reverse_proxy/src/webserver/drogon_server/CMakeLists.txt
+++ b/examples/webserver_reverse_proxy/src/webserver/drogon_server/CMakeLists.txt
@@ -1,0 +1,22 @@
+cmake_minimum_required(VERSION 3.15)
+project(drogon_server)
+
+set(DROGON_SERVER_ROOT_HEADERS
+)
+set(DROGON_SERVER_ROOT_FILES
+    main.cc
+)
+
+set(DROGON_SERVER_PLUGINS_HEADERS
+    plugins/ReverseProxy.h
+)
+set(DROGON_SERVER_PLUGINS_FILES
+    plugins/ReverseProxy.cc
+)
+
+add_executable(${PROJECT_NAME}
+    ${DROGON_SERVER_ROOT_HEADERS} ${DROGON_SERVER_ROOT_FILES}
+    ${DROGON_SERVER_PLUGINS_HEADERS} ${DROGON_SERVER_PLUGINS_FILES}
+)
+
+target_link_libraries(${PROJECT_NAME} PRIVATE Drogon::Drogon)

--- a/examples/webserver_reverse_proxy/src/webserver/drogon_server/main.cc
+++ b/examples/webserver_reverse_proxy/src/webserver/drogon_server/main.cc
@@ -1,0 +1,10 @@
+#include <drogon/drogon.h>
+
+using namespace drogon;
+
+int main(int argc, char* argv[])
+{
+    app().loadConfigFile("../config.drogon_server.json");
+
+    app().run();
+}

--- a/examples/webserver_reverse_proxy/src/webserver/drogon_server/plugins/ReverseProxy.cc
+++ b/examples/webserver_reverse_proxy/src/webserver/drogon_server/plugins/ReverseProxy.cc
@@ -1,0 +1,374 @@
+#include "ReverseProxy.h"
+
+void ReverseProxy::PreRouting(const HttpRequestPtr &pReq, AdviceCallback &&aCallback, AdviceChainCallback &&acCallback)
+{
+    size_t index = 0, index_be = 0;
+    size_t count = -1;
+    auto host = pReq->getHeader("host");
+
+    auto &clientsVector = *m_clients;
+
+    bool redirect = false;
+    std::string redirectUrl = "";
+
+    bool requestFound = false;
+
+    // check for correct request
+    for (const auto &backend : m_backends)
+    {
+        count++;
+
+        if (backend.host.rfind(host, 0) == 0)
+        {
+            index_be = count;
+            requestFound = true;
+            break;
+        }
+    }
+
+    // ssl assignment config
+    if (requestFound && m_backends[index_be].ssl)
+    {
+        const auto &sslConf = m_backends[index_be].ssl_conf;
+        app().setSSLFiles(sslConf.cert, sslConf.key);
+        app().setSSLConfigCommands(sslConf.configurations);
+    }
+
+    // same client same backend
+    if (requestFound && m_sameClientToSameBackend)
+    {
+        auto ipHash = std::hash<uint32_t>{}(pReq->getPeerAddr().ipNetEndian()) % clientsVector.size();
+        index = (ipHash + (++(*m_clientIndex))) % clientsVector.size();
+    }
+    else if (requestFound && !m_sameClientToSameBackend)
+    {
+        index = ++(*m_clientIndex) % clientsVector.size();
+    }
+
+    // set another document root
+    if (requestFound)
+    {
+        app().setDocumentRoot(m_backends[index_be].document_root);
+    }
+
+    // http client pointer
+    auto &pClient = clientsVector[index];
+
+    if (!pClient && requestFound)
+    {
+        const auto &backend = m_backends[index_be];
+        const auto &address = backend.internal_proxies[index % backend.internal_proxies.size()];
+
+        pClient = HttpClient::newHttpClient(
+            address,
+            trantor::EventLoop::getEventLoopOfCurrentThread(),
+            backend.ssl_conf.use_old_tls,
+            backend.ssl
+        );
+    }
+    else
+    {
+        // NOTE:
+        // this section is to
+        // expecting something not right
+        // to prevent subdomain and same path conflict
+        // if this else section remove, there's something wrong with the request
+
+        const auto &backend = m_backends[index_be];
+        const auto &address = backend.internal_proxies[index % backend.internal_proxies.size()];
+
+        pClient = HttpClient::newHttpClient(
+            address,
+            trantor::EventLoop::getEventLoopOfCurrentThread(),
+            backend.ssl_conf.use_old_tls,
+            backend.ssl
+        );
+    }
+
+    pReq->setPassThrough(true);
+
+    if (requestFound)
+    {
+        pClient->setPipeliningDepth(m_pipelining);
+
+        redirect = m_backends[index_be].redirect;
+        redirectUrl = m_backends[index_be].redirect_to;
+
+        if (redirect)
+        {
+            auto pRequestRedirect = HttpResponse::newHttpResponse();
+
+            aCallback(pRequestRedirect->newRedirectionResponse(redirectUrl, k307TemporaryRedirect));
+            return;
+        }
+
+        // valid backend object helper for response
+        auto validBackend = m_backends[index_be];
+
+        pClient->sendRequest(pReq, [aCallback = std::move(aCallback), validBackend = std::move(validBackend)](ReqResult result, const HttpResponsePtr &pResp)
+        {
+            pResp->setPassThrough(true);
+
+            switch (result)
+            {
+                case ReqResult::Ok:
+                {
+                    // add header if supplied
+                    if (validBackend.header_add && validBackend.header_add_list_pair.size() >= 1)
+                    {
+                        for (auto &pair : validBackend.header_add_list_pair)
+                        {
+                            pResp->addHeader(pair.first, pair.second);
+                        }
+                    }
+                    // give warn or error?
+
+                    // add server check origin if supplied
+                    // can be add manually from each backend before their response callback
+                    if (validBackend.check_origin_whitelist)
+                    {
+                        pResp->addHeader("access-control-allow-origin", validBackend.check_origin_whitelist_data);
+                    }
+
+                    aCallback(pResp);
+                }
+                break;
+
+                default:
+                {
+                    // just to make it sure and show the message when happen
+                    pResp->setBody("Internal Server Error By Default");
+                    pResp->setStatusCode(k500InternalServerError);
+
+                    aCallback(pResp);
+                }
+                break;
+            }
+        });
+    }
+    else
+    {
+        app().setDocumentRoot(m_defaultDocumentRoot);
+
+        auto errorResp = HttpResponse::newHttpResponse();
+
+        errorResp->setBody("Internal Server Error");
+        errorResp->setStatusCode(k500InternalServerError);
+
+        aCallback(errorResp);
+    }
+}
+
+ReverseProxy::ReverseProxy()
+{
+}
+
+ReverseProxy::~ReverseProxy()
+{
+}
+
+void ReverseProxy::initAndStart(const Json::Value &config)
+{
+    if (m_ready) { return; }
+
+#pragma region configuration
+    // backends storage
+    if (config.isMember("backends") && config["backends"].isArray())
+    {
+        for (auto &backends : config["backends"])
+        {
+            TBackendStorage backend;
+
+            backend.host = backends["host"].asString();
+
+            backend.redirect = backends["redirect"].asBool();
+
+            backend.redirect_to = backends["redirect_to"].asString();
+
+            backend.check_origin_whitelist = backends["check_origin_whitelist"].asBool();
+
+            backend.check_origin_whitelist_data = backends["check_origin_whitelist_data"].asString();
+
+            backend.header_add = backends["header_add"].asBool();
+
+            if (backend.header_add)
+            {
+                if (backends["header_add_list"].isArray() && backends["header_add_list"].size() <= 0)
+                {
+                    app().getLoop()->runAfter(0, [&]()
+                    {
+                        std::cerr << "ERROR: you are trying to add more header response, but header add list is not supplied or 0\n";
+                        app().quit();
+                    });
+                }
+
+                for (auto &header : backends["header_add_list"])
+                {
+                    if (header.isArray() && header.size() == 2 && header[0].isString() && header[1].isString())
+                    {
+                        std::string key = header[0].asString();
+                        std::string value = header[1].asString();
+
+                        backend.header_add_list_pair.emplace_back(key, value);
+                    }
+                    else
+                    {
+                        app().getLoop()->runAfter(0, [&]()
+                        {
+                            std::cerr << "ERROR: can't use header list, these array can't assign as pair 2 string\n";
+                            app().quit();
+                        });
+                    }
+                }
+            }
+
+            backend.document_root = backends["document_root"].asString();
+
+            // check backend proxies
+            if (backends["internal_proxies"].size() <= 0)
+            {
+                app().getLoop()->runAfter(0, [&]()
+                {
+                    std::cerr << "ERROR: internal backend proxies should be provide at least one\n";
+                    app().quit();
+                });
+            }
+
+            for (auto &proxy : backends["internal_proxies"])
+            {
+                backend.internal_proxies.emplace_back(proxy.asString());
+            }
+
+            backend.ssl = backends["ssl"].asBool();
+
+            if (backend.ssl)
+            {
+                TBackendSSL backendSSL;
+
+                backendSSL.key = backends["ssl_conf"]["key"].asString();
+                backendSSL.cert = backends["ssl_conf"]["cert"].asString();
+                backendSSL.use_old_tls = backends["ssl_conf"]["use_old_tls"].asBool();
+
+                if (backendSSL.key.length() <= 0)
+                {
+                    app().getLoop()->runAfter(0, [&]()
+                    {
+                        std::cerr << "ERROR: you're configuring using ssl, but key is not supplied\n";
+                        app().quit();
+                    });
+                }
+
+                if (backendSSL.cert.length() <= 0)
+                {
+                    app().getLoop()->runAfter(0, [&]()
+                    {
+                        std::cerr << "ERROR: you're configuring using ssl, but cert is not supplied\n";
+                        app().quit();
+                    });
+                }
+
+                const auto SSL_CONF_CONFIG = backends["ssl_conf"]["configurations"];
+
+                if (SSL_CONF_CONFIG.isArray() && SSL_CONF_CONFIG.size() >= 1)
+                {
+                    for (auto &ssl_cfg : SSL_CONF_CONFIG)
+                    {
+                        if (ssl_cfg.isArray() && ssl_cfg.size() == 2 && ssl_cfg[0].isString() && ssl_cfg[1].isString())
+                        {
+                            std::string key = ssl_cfg[0].asString();
+                            std::string value = ssl_cfg[1].asString();
+
+                            backendSSL.configurations.emplace_back(key, value);
+                        }
+                        else
+                        {
+                            app().getLoop()->runAfter(0, [&]()
+                            {
+                                std::cerr << "ERROR: can't use config, these array can't assign as pair 2 string\n";
+                                app().quit();
+                            });
+                        }
+                    }
+
+                    backend.ssl_conf = backendSSL;
+                }
+                else
+                {
+                    app().getLoop()->runAfter(0, [&]()
+                    {
+                        std::cerr << "ERROR: ssl_conf configurations is not an array or empty\nREADMORE: https://www.openssl.org/docs/manmaster/man3/SSL_CONF_cmd.html\n";
+                        app().quit();
+                    });
+                }
+            }
+
+            m_backends.emplace_back(backend);
+        }
+
+        // final check
+        if (m_backends.empty())
+        {
+            app().getLoop()->runAfter(0, [&]()
+            {
+                std::cerr << "ERROR: backends configuration is empty\n";
+                app().quit();
+            });
+        }
+    }
+    else
+    {
+        std::cerr << "ERROR: configuration\n";
+        abort();
+    }
+
+    // pipelining
+    m_pipelining = config.get("pipelining", 0).asInt();
+
+    // connection factor
+    m_connectionFactor = config.get("connection_factor", 0).asInt();
+
+    if (m_connectionFactor == 0 || m_connectionFactor > 100)
+    {
+        app().getLoop()->runAfter(0, [&]()
+        {
+            std::cerr << "ERROR: invalid number of connection factor\n";
+            app().quit();
+        });
+    }
+
+    // same client to same backend
+    m_sameClientToSameBackend = config.get("same_client_to_same_backend", false).asBool();
+
+    // default document root
+    m_defaultDocumentRoot = config["default_document_root"].asString();
+
+    // clients config
+    m_clients.init([this](std::vector<HttpClientPtr> &clients, size_t ioLoopIndex)
+    {
+        clients.resize(m_backends.size() * m_connectionFactor);
+    });
+
+    // client index config
+    m_clientIndex.init([this](size_t &index, size_t ioLoopIndex)
+    {
+        index = ioLoopIndex;
+    });
+
+    // pre routing register
+    app().registerPreRoutingAdvice([this](const HttpRequestPtr &pReq, AdviceCallback &&aCallback, AdviceChainCallback &&acCallback)
+    {
+        PreRouting(pReq, std::move(aCallback), std::move(acCallback));
+    });
+#pragma endregion
+
+    #if !NDEBUG
+    std::cout << "drogon_server ReverseProxy plugin started\n";
+    #endif
+}
+
+void ReverseProxy::shutdown()
+{
+    #if !NDEBUG
+    std::cout << "drogon_server ReverseProxy plugin shutdown\n";
+    #endif
+}

--- a/examples/webserver_reverse_proxy/src/webserver/drogon_server/plugins/ReverseProxy.h
+++ b/examples/webserver_reverse_proxy/src/webserver/drogon_server/plugins/ReverseProxy.h
@@ -1,0 +1,79 @@
+#ifndef DROGON_SERVER_REVERSE_PROXY_H
+#define DROGON_SERVER_REVERSE_PROXY_H
+#include <drogon/drogon.h>
+
+using namespace drogon;
+
+/**
+ * @brief type for backend ssl storage
+ * 
+ */
+struct TBackendSSL
+{
+    std::string key;
+    std::string cert;
+    bool use_old_tls;
+    std::vector<std::pair<std::string, std::string>> configurations;
+};
+
+
+/**
+ * @brief type for backend storage
+ * 
+ */
+struct TBackendStorage
+{
+    bool ssl;
+    bool redirect;
+    bool header_add;
+    bool check_origin_whitelist;
+    std::string host;
+    TBackendSSL ssl_conf;
+    std::string redirect_to;
+    std::string document_root;
+    std::string check_origin_whitelist_data;
+    std::vector<std::string> internal_proxies;
+    std::vector<std::pair<std::string, std::string>> header_add_list_pair;
+};
+
+
+/**
+ * @brief reverse proxy plugin for drogon_server project
+ * 
+ */
+class ReverseProxy final : public Plugin<ReverseProxy>
+{
+private:
+    bool m_ready = false;
+    bool m_useSSL = false;
+    bool m_sameClientToSameBackend = false;
+
+    size_t m_pipelining = 16;
+    size_t m_connectionFactor = 1;
+
+    std::vector<TBackendStorage> m_backends;
+
+    std::string m_defaultDocumentRoot = "";
+
+    IOThreadStorage<size_t> m_clientIndex = 0;
+    IOThreadStorage<std::vector<HttpClientPtr>> m_clients;
+
+protected:
+    /**
+     * @brief pre routing request to array backend
+     * 
+     * @param pReq 
+     * @param aCallback 
+     * @param acCallback 
+     */
+    void PreRouting(const HttpRequestPtr &pReq, AdviceCallback &&aCallback, AdviceChainCallback &&acCallback);
+
+public:
+    ReverseProxy(/* args */);
+    ~ReverseProxy();
+
+    void initAndStart(const Json::Value &config) override;
+    void shutdown() override;
+};
+
+#endif // DROGON_SERVER_REVERSE_PROXY_H


### PR DESCRIPTION
# drogon framework example: webserver reverse proxy

__NOTE:__

```
this example show how to use drogon as webserver and using reverse proxy
```

<br>

## steps:

- add these:
    ```txt
    127.0.0.1   localhost.com
    127.0.0.1   api.localhost.com
    127.0.0.1   admin.localhost.com
    127.0.0.1   www.localhost.com
    ```

    to

    - __linux debian__ base location:

        - `/etc/hosts`:

    - __windows__ base location:

        - `C:\Windows\System32\drivers\etc\hosts`:

    ---

- make it sure drogon config is already installed on your machine environment

- build this project, *you can use build-debug-linux.sh on linux environment*

- launch:
    - terminal:
        - go to _*./bin*_ directory and run each of these:
            - `./drogon_server`
            - `./backend_api`
            - `./backend_www`

    - open your browser:
        - go to:
            - `http://www.localhost.com:9999`:
                - this will redirect to `http://localhost.com:9999`

            - `http://localhost.com:9999`:
                - will show example message and which port is called

            - `http://api.localhost.com:9999`:
                - will show json message from which port

            - `http://api.localhost.com:9999/test`:
                - will show json message from `/test` endpoint/path and show which port is called

<br>

---

## preview result example

- [preview result example 1](https://raw.githubusercontent.com/prothegee/prothegee/main/previews/_preview-example-drogon_server-1.png)
- [preview result example 2](https://raw.githubusercontent.com/prothegee/prothegee/main/previews/_preview-example-drogon_server-2.png)

<br>

---

###### end of readme
