### PR TITLE
Use "/" as default path in HTTP/2 client when req has no path set

### DIFF
--- a/lib/src/Http2Transport.cc
+++ b/lib/src/Http2Transport.cc
@@ -692,7 +692,7 @@ void Http2Transport::sendRequestInLoop(const HttpRequestPtr &req,
     vec.emplace_back(":method", req->methodString());
     const auto &params = req->parameters();
     if (params.empty())
-        vec.emplace_back(":path", req->path());
+        vec.emplace_back(":path", req->path().empty() ? "/" : req->path());
     else
     {
         std::string path = req->path() + "?";
@@ -705,7 +705,7 @@ void Http2Transport::sendRequestInLoop(const HttpRequestPtr &req,
         vec.emplace_back(":path", path);
     }
     std::string scheme = connPtr->isSSLConnection() ? "https" : "http";
-    if (!static_cast<drogon::HttpRequestImpl *>(req.get())->passThrough())
+    if (static_cast<drogon::HttpRequestImpl *>(req.get())->passThrough())
         scheme = (req->isOnSecureConnection()) ? "https" : "http";
     vec.emplace_back(":scheme", scheme);
     if (auto host = req->getHeader("host"); !host.empty())

--- a/lib/src/Http2Transport.cc
+++ b/lib/src/Http2Transport.cc
@@ -695,7 +695,7 @@ void Http2Transport::sendRequestInLoop(const HttpRequestPtr &req,
         vec.emplace_back(":path", req->path().empty() ? "/" : req->path());
     else
     {
-        std::string path = req->path() + "?";
+        std::string path = (req->path().empty() ? "/" : req->path()) + "?";
         for (auto const &[key, value] : params)
         {
             path += utils::urlEncodeComponent(key) + "=" +


### PR DESCRIPTION
Fix for failed request when sending requests to google.