### PR TITLE
Add quotes to DESC MySQL query to avoid error when table name is keyword

### DIFF
--- a/drogon_ctl/create_model.cc
+++ b/drogon_ctl/create_model.cc
@@ -460,7 +460,7 @@ void create_model::createModelClassFromMysql(
     data["convertMethods"] = convertMethods;
     std::vector<ColumnInfo> cols;
     int i = 0;
-    *client << "desc " + tableName << Mode::Blocking >>
+    *client << "desc `" + tableName + "`" << Mode::Blocking >>
         [&i, &cols](bool isNull,
                     const std::string &field,
                     const std::string &type,


### PR DESCRIPTION
When there are tables that have name same as some keyword (for example groups) "desc TableName" query get an error. We have to add quotes to avoid MySQL think table name is keyword.

desc groups - Error Code: 1064. You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'groups' at line 1

desc \`groups\` - valid sql