### PR TITLE
Feature: TcpServer hot reload SSL file

### DIFF
--- a/lib/inc/drogon/HttpAppFramework.h
+++ b/lib/inc/drogon/HttpAppFramework.h
@@ -806,6 +806,15 @@ class DROGON_EXPORT HttpAppFramework : public trantor::NonCopyable
         const std::vector<std::pair<std::string, std::string>>
             &sslConfCmds) = 0;
 
+    /// Reload the global cert file and private key file for https server
+    /// Note: The goal of this method is not to make the framework
+    /// use the new SSL path, but rather to reload the new content
+    /// from the old path while the framework is still running.
+    /// Typically, when our SSL is about to expire,
+    /// we need to reload the SSL. The purpose of this function
+    /// is to use the new SSL certificate without stopping the framework.
+    virtual HttpAppFramework &reloadSSLFiles() = 0;
+
     /// Add plugins
     /**
      * @param configs The plugins array

--- a/lib/src/HttpAppFrameworkImpl.cc
+++ b/lib/src/HttpAppFrameworkImpl.cc
@@ -511,6 +511,12 @@ HttpAppFramework &HttpAppFrameworkImpl::setSSLFiles(const std::string &certPath,
     return *this;
 }
 
+HttpAppFramework &HttpAppFrameworkImpl::reloadSSLFiles()
+{
+    listenerManagerPtr_->reloadSSLFiles();
+    return *this;
+}
+
 void HttpAppFrameworkImpl::run()
 {
     if (!getLoop()->isInLoopThread())

--- a/lib/src/HttpAppFrameworkImpl.h
+++ b/lib/src/HttpAppFrameworkImpl.h
@@ -84,6 +84,9 @@ class HttpAppFrameworkImpl final : public HttpAppFramework
         override;
     HttpAppFramework &setSSLFiles(const std::string &certPath,
                                   const std::string &keyPath) override;
+
+    HttpAppFramework &reloadSSLFiles() override;
+
     void run() override;
     HttpAppFramework &registerWebSocketController(
         const std::string &pathName,

--- a/lib/src/HttpServer.h
+++ b/lib/src/HttpServer.h
@@ -49,6 +49,11 @@ class HttpServer : trantor::NonCopyable
         server_.enableSSL(std::move(policy));
     }
 
+    void reloadSSL()
+    {
+        server_.reloadSSL();
+    }
+
     const trantor::InetAddress &address() const
     {
         return server_.address();

--- a/lib/src/ListenerManager.cc
+++ b/lib/src/ListenerManager.cc
@@ -214,3 +214,11 @@ void ListenerManager::stopListening()
         listeningThread_->wait();
     }
 }
+
+void ListenerManager::reloadSSLFiles()
+{
+    for (auto &server : servers_)
+    {
+        server->reloadSSL();
+    }
+}

--- a/lib/src/ListenerManager.h
+++ b/lib/src/ListenerManager.h
@@ -61,6 +61,8 @@ class ListenerManager : public trantor::NonCopyable
         afterAcceptSetSockOptCallback_ = std::move(cb);
     }
 
+    void reloadSSLFiles();
+
   private:
     struct ListenerInfo
     {


### PR DESCRIPTION
Reload the global cert file and private key file for https server
Note: The goal of this method is not to make the framework use the new SSL path, but rather to reload the new content from the old path while the framework is still running.Typically, when our SSL is about to expire,
we need to reload the SSL. The purpose of this function is to use the new SSL certificate without stopping the framework.