### PR TITLE
Add in-place base64 encode and decode

### DIFF
--- a/lib/inc/drogon/utils/Utilities.h
+++ b/lib/inc/drogon/utils/Utilities.h
@@ -134,86 +134,85 @@ constexpr size_t base64EncodedLength(size_t in_len, bool padded = true)
 }
 
 /// Encode the string to base64 format.
-DROGON_EXPORT void base64Encode(const unsigned char *bytes_to_encode,
-                                size_t in_len,
-                                unsigned char *output_buffer,
-                                bool url_safe = false,
+DROGON_EXPORT void base64Encode(const unsigned char *bytesToEncode,
+                                size_t inLen,
+                                unsigned char *outputBuffer,
+                                bool urlSafe = false,
                                 bool padded = true);
 
 /// Encode the string to base64 format.
-inline std::string base64Encode(const unsigned char *bytes_to_encode,
-                                size_t in_len,
-                                bool url_safe = false,
+inline std::string base64Encode(const unsigned char *bytesToEncode,
+                                size_t inLen,
+                                bool urlSafe = false,
                                 bool padded = true)
 {
     std::string ret;
-    ret.resize(base64EncodedLength(in_len, padded));
+    ret.resize(base64EncodedLength(inLen, padded));
     base64Encode(
-        bytes_to_encode, in_len, (unsigned char *)ret.data(), url_safe, padded);
+        bytesToEncode, inLen, (unsigned char *)ret.data(), urlSafe, padded);
     return ret;
 }
 
 /// Encode the string to base64 format.
 inline std::string base64Encode(std::string_view data,
-                                bool url_safe = false,
+                                bool urlSafe = false,
                                 bool padded = true)
 {
     return base64Encode((unsigned char *)data.data(),
                         data.size(),
-                        url_safe,
+                        urlSafe,
                         padded);
 }
 
 /// Encode the string to base64 format with no padding.
-inline void base64EncodeUnpadded(const unsigned char *bytes_to_encode,
-                                 size_t in_len,
-                                 unsigned char *output_buffer,
-                                 bool url_safe = false)
+inline void base64EncodeUnpadded(const unsigned char *bytesToEncode,
+                                 size_t inLen,
+                                 unsigned char *outputBuffer,
+                                 bool urlSafe = false)
 {
-    base64Encode(bytes_to_encode, in_len, output_buffer, url_safe, false);
+    base64Encode(bytesToEncode, inLen, outputBuffer, urlSafe, false);
 }
 
 /// Encode the string to base64 format with no padding.
-inline std::string base64EncodeUnpadded(const unsigned char *bytes_to_encode,
-                                        size_t in_len,
-                                        bool url_safe = false)
+inline std::string base64EncodeUnpadded(const unsigned char *bytesToEncode,
+                                        size_t inLen,
+                                        bool urlSafe = false)
 {
-    return base64Encode(bytes_to_encode, in_len, url_safe, false);
+    return base64Encode(bytesToEncode, inLen, urlSafe, false);
 }
 
 /// Encode the string to base64 format with no padding.
 inline std::string base64EncodeUnpadded(std::string_view data,
-                                        bool url_safe = false)
+                                        bool urlSafe = false)
 {
-    return base64Encode(data, url_safe, false);
+    return base64Encode(data, urlSafe, false);
 }
 
 /// Get the decoded length of base64.
-constexpr size_t base64DecodedLength(size_t in_len)
+constexpr size_t base64DecodedLength(size_t inLen)
 {
-    return (in_len * 3) / 4;
+    return (inLen * 3) / 4;
 }
 
 /// Decode the base64 format string.
 /// Return the number of bytes written.
-DROGON_EXPORT size_t base64Decode(const char *encoded_string,
-                                  size_t in_len,
-                                  unsigned char *output_buffer);
+DROGON_EXPORT size_t base64Decode(const char *encodedString,
+                                  size_t inLen,
+                                  unsigned char *outputBuffer);
 
 /// Decode the base64 format string.
-inline std::string base64Decode(std::string_view encoded_string)
+inline std::string base64Decode(std::string_view encodedString)
 {
-    auto in_len = encoded_string.size();
+    auto inLen = encodedString.size();
     std::string ret;
-    ret.resize(base64DecodedLength(in_len));
-    ret.resize(base64Decode(encoded_string.data(),
-                            in_len,
-                            (unsigned char *)ret.data()));
+    ret.resize(base64DecodedLength(inLen));
+    ret.resize(
+        base64Decode(encodedString.data(), inLen, (unsigned char *)ret.data()));
     return ret;
 }
 
 DROGON_EXPORT std::vector<char> base64DecodeToVector(
-    std::string_view encoded_string);
+    std::string_view encodedString);
 
 /// Check if the string need decoding
 DROGON_EXPORT bool needUrlDecoding(const char *begin, const char *end);

--- a/lib/inc/drogon/utils/Utilities.h
+++ b/lib/inc/drogon/utils/Utilities.h
@@ -134,10 +134,24 @@ constexpr size_t base64EncodedLength(size_t in_len, bool padded = true)
 }
 
 /// Encode the string to base64 format.
-DROGON_EXPORT std::string base64Encode(const unsigned char *bytes_to_encode,
-                                       size_t in_len,
-                                       bool url_safe = false,
-                                       bool padded = true);
+DROGON_EXPORT void base64Encode(const unsigned char *bytes_to_encode,
+                                size_t in_len,
+                                unsigned char *output_buffer,
+                                bool url_safe = false,
+                                bool padded = true);
+
+/// Encode the string to base64 format.
+inline std::string base64Encode(const unsigned char *bytes_to_encode,
+                                size_t in_len,
+                                bool url_safe = false,
+                                bool padded = true)
+{
+    std::string ret;
+    ret.resize(base64EncodedLength(in_len, padded));
+    base64Encode(
+        bytes_to_encode, in_len, (unsigned char *)ret.data(), url_safe, padded);
+    return ret;
+}
 
 /// Encode the string to base64 format.
 inline std::string base64Encode(std::string_view data,
@@ -148,6 +162,15 @@ inline std::string base64Encode(std::string_view data,
                         data.size(),
                         url_safe,
                         padded);
+}
+
+/// Encode the string to base64 format with no padding.
+inline void base64EncodeUnpadded(const unsigned char *bytes_to_encode,
+                                 size_t in_len,
+                                 unsigned char *output_buffer,
+                                 bool url_safe = false)
+{
+    base64Encode(bytes_to_encode, in_len, output_buffer, url_safe, false);
 }
 
 /// Encode the string to base64 format with no padding.
@@ -172,7 +195,23 @@ constexpr size_t base64DecodedLength(size_t in_len)
 }
 
 /// Decode the base64 format string.
-DROGON_EXPORT std::string base64Decode(std::string_view encoded_string);
+/// Return the number of bytes written.
+DROGON_EXPORT size_t base64Decode(const char *encoded_string,
+                                  size_t in_len,
+                                  unsigned char *output_buffer);
+
+/// Decode the base64 format string.
+inline std::string base64Decode(std::string_view encoded_string)
+{
+    auto in_len = encoded_string.size();
+    std::string ret;
+    ret.resize(base64DecodedLength(in_len));
+    ret.resize(base64Decode(encoded_string.data(),
+                            in_len,
+                            (unsigned char *)ret.data()));
+    return ret;
+}
+
 DROGON_EXPORT std::vector<char> base64DecodeToVector(
     std::string_view encoded_string);
 

--- a/lib/src/Utilities.cc
+++ b/lib/src/Utilities.cc
@@ -612,7 +612,7 @@ size_t base64Decode(const char *encoded_string,
 
         --i;
         for (int j = 0; (j < i); ++j, ++a)
-            output_buffer[a] += char_array_3[j];
+            output_buffer[a] = char_array_3[j];
     }
 
     return a;

--- a/lib/src/Utilities.cc
+++ b/lib/src/Utilities.cc
@@ -83,12 +83,12 @@ namespace drogon
 {
 namespace utils
 {
-static const std::string base64Chars =
+static constexpr std::string_view base64Chars =
     "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
     "abcdefghijklmnopqrstuvwxyz"
     "0123456789+/";
 
-static const std::string urlBase64Chars =
+static constexpr std::string_view urlBase64Chars =
     "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
     "abcdefghijklmnopqrstuvwxyz"
     "0123456789-_";
@@ -440,33 +440,33 @@ std::string getUuid(bool lowercase)
 #endif
 }
 
-void base64Encode(const unsigned char *bytes_to_encode,
-                  size_t in_len,
-                  unsigned char *output_buffer,
-                  bool url_safe,
+void base64Encode(const unsigned char *bytesToEncode,
+                  size_t inLen,
+                  unsigned char *outputBuffer,
+                  bool urlSafe,
                   bool padded)
 {
     int i = 0;
-    unsigned char char_array_3[3];
-    unsigned char char_array_4[4];
+    unsigned char charArray3[3];
+    unsigned char charArray4[4];
 
-    const std::string &charSet = url_safe ? urlBase64Chars : base64Chars;
+    const std::string_view charSet = urlSafe ? urlBase64Chars : base64Chars;
 
     size_t a = 0;
-    while (in_len--)
+    while (inLen--)
     {
-        char_array_3[i++] = *(bytes_to_encode++);
+        charArray3[i++] = *(bytesToEncode++);
         if (i == 3)
         {
-            char_array_4[0] = (char_array_3[0] & 0xfc) >> 2;
-            char_array_4[1] = ((char_array_3[0] & 0x03) << 4) +
-                              ((char_array_3[1] & 0xf0) >> 4);
-            char_array_4[2] = ((char_array_3[1] & 0x0f) << 2) +
-                              ((char_array_3[2] & 0xc0) >> 6);
-            char_array_4[3] = char_array_3[2] & 0x3f;
+            charArray4[0] = (charArray3[0] & 0xfc) >> 2;
+            charArray4[1] =
+                ((charArray3[0] & 0x03) << 4) + ((charArray3[1] & 0xf0) >> 4);
+            charArray4[2] =
+                ((charArray3[1] & 0x0f) << 2) + ((charArray3[2] & 0xc0) >> 6);
+            charArray4[3] = charArray3[2] & 0x3f;
 
             for (i = 0; (i < 4); ++i, ++a)
-                output_buffer[a] = charSet[char_array_4[i]];
+                outputBuffer[a] = charSet[charArray4[i]];
             i = 0;
         }
     }
@@ -474,61 +474,61 @@ void base64Encode(const unsigned char *bytes_to_encode,
     if (i)
     {
         for (int j = i; j < 3; ++j)
-            char_array_3[j] = '\0';
+            charArray3[j] = '\0';
 
-        char_array_4[0] = (char_array_3[0] & 0xfc) >> 2;
-        char_array_4[1] =
-            ((char_array_3[0] & 0x03) << 4) + ((char_array_3[1] & 0xf0) >> 4);
-        char_array_4[2] =
-            ((char_array_3[1] & 0x0f) << 2) + ((char_array_3[2] & 0xc0) >> 6);
-        char_array_4[3] = char_array_3[2] & 0x3f;
+        charArray4[0] = (charArray3[0] & 0xfc) >> 2;
+        charArray4[1] =
+            ((charArray3[0] & 0x03) << 4) + ((charArray3[1] & 0xf0) >> 4);
+        charArray4[2] =
+            ((charArray3[1] & 0x0f) << 2) + ((charArray3[2] & 0xc0) >> 6);
+        charArray4[3] = charArray3[2] & 0x3f;
 
         for (int j = 0; (j <= i); ++j, ++a)
-            output_buffer[a] = charSet[char_array_4[j]];
+            outputBuffer[a] = charSet[charArray4[j]];
 
         if (padded)
             while ((++i < 4))
             {
-                output_buffer[a] = '=';
+                outputBuffer[a] = '=';
                 ++a;
             }
     }
 }
 
-std::vector<char> base64DecodeToVector(std::string_view encoded_string)
+std::vector<char> base64DecodeToVector(std::string_view encodedString)
 {
-    auto in_len = encoded_string.size();
+    auto inLen = encodedString.size();
     int i = 0;
     int in_{0};
-    char char_array_4[4], char_array_3[3];
+    char charArray4[4], charArray3[3];
     std::vector<char> ret;
-    ret.reserve(base64DecodedLength(in_len));
+    ret.reserve(base64DecodedLength(inLen));
 
-    while (in_len-- && (encoded_string[in_] != '='))
+    while (inLen-- && (encodedString[in_] != '='))
     {
-        if (!isBase64(encoded_string[in_]))
+        if (!isBase64(encodedString[in_]))
         {
             ++in_;
             continue;
         }
 
-        char_array_4[i++] = encoded_string[in_];
+        charArray4[i++] = encodedString[in_];
         ++in_;
         if (i == 4)
         {
             for (i = 0; i < 4; ++i)
             {
-                char_array_4[i] = base64CharMap.getIndex(char_array_4[i]);
+                charArray4[i] = base64CharMap.getIndex(charArray4[i]);
             }
 
-            char_array_3[0] =
-                (char_array_4[0] << 2) + ((char_array_4[1] & 0x30) >> 4);
-            char_array_3[1] = ((char_array_4[1] & 0xf) << 4) +
-                              ((char_array_4[2] & 0x3c) >> 2);
-            char_array_3[2] = ((char_array_4[2] & 0x3) << 6) + char_array_4[3];
+            charArray3[0] =
+                (charArray4[0] << 2) + ((charArray4[1] & 0x30) >> 4);
+            charArray3[1] =
+                ((charArray4[1] & 0xf) << 4) + ((charArray4[2] & 0x3c) >> 2);
+            charArray3[2] = ((charArray4[2] & 0x3) << 6) + charArray4[3];
 
             for (i = 0; (i < 3); ++i)
-                ret.push_back(char_array_3[i]);
+                ret.push_back(charArray3[i]);
             i = 0;
         }
     }
@@ -536,60 +536,59 @@ std::vector<char> base64DecodeToVector(std::string_view encoded_string)
     if (i)
     {
         for (int j = i; j < 4; ++j)
-            char_array_4[j] = 0;
+            charArray4[j] = 0;
 
         for (int j = 0; j < 4; ++j)
         {
-            char_array_4[j] = base64CharMap.getIndex(char_array_4[j]);
+            charArray4[j] = base64CharMap.getIndex(charArray4[j]);
         }
 
-        char_array_3[0] =
-            (char_array_4[0] << 2) + ((char_array_4[1] & 0x30) >> 4);
-        char_array_3[1] =
-            ((char_array_4[1] & 0xf) << 4) + ((char_array_4[2] & 0x3c) >> 2);
-        char_array_3[2] = ((char_array_4[2] & 0x3) << 6) + char_array_4[3];
+        charArray3[0] = (charArray4[0] << 2) + ((charArray4[1] & 0x30) >> 4);
+        charArray3[1] =
+            ((charArray4[1] & 0xf) << 4) + ((charArray4[2] & 0x3c) >> 2);
+        charArray3[2] = ((charArray4[2] & 0x3) << 6) + charArray4[3];
 
         --i;
         for (int j = 0; (j < i); ++j)
-            ret.push_back(char_array_3[j]);
+            ret.push_back(charArray3[j]);
     }
 
     return ret;
 }
 
-size_t base64Decode(const char *encoded_string,
-                    size_t in_len,
-                    unsigned char *output_buffer)
+size_t base64Decode(const char *encodedString,
+                    size_t inLen,
+                    unsigned char *outputBuffer)
 {
     int i = 0;
     int in_{0};
-    unsigned char char_array_4[4], char_array_3[3];
+    unsigned char charArray4[4], charArray3[3];
 
     size_t a = 0;
-    while (in_len-- && (encoded_string[in_] != '='))
+    while (inLen-- && (encodedString[in_] != '='))
     {
-        if (!isBase64(encoded_string[in_]))
+        if (!isBase64(encodedString[in_]))
         {
             ++in_;
             continue;
         }
 
-        char_array_4[i++] = encoded_string[in_];
+        charArray4[i++] = encodedString[in_];
         ++in_;
         if (i == 4)
         {
             for (i = 0; i < 4; ++i)
             {
-                char_array_4[i] = base64CharMap.getIndex(char_array_4[i]);
+                charArray4[i] = base64CharMap.getIndex(charArray4[i]);
             }
-            char_array_3[0] =
-                (char_array_4[0] << 2) + ((char_array_4[1] & 0x30) >> 4);
-            char_array_3[1] = ((char_array_4[1] & 0xf) << 4) +
-                              ((char_array_4[2] & 0x3c) >> 2);
-            char_array_3[2] = ((char_array_4[2] & 0x3) << 6) + char_array_4[3];
+            charArray3[0] =
+                (charArray4[0] << 2) + ((charArray4[1] & 0x30) >> 4);
+            charArray3[1] =
+                ((charArray4[1] & 0xf) << 4) + ((charArray4[2] & 0x3c) >> 2);
+            charArray3[2] = ((charArray4[2] & 0x3) << 6) + charArray4[3];
 
             for (i = 0; (i < 3); ++i, ++a)
-                output_buffer[a] = char_array_3[i];
+                outputBuffer[a] = charArray3[i];
             i = 0;
         }
     }
@@ -597,22 +596,21 @@ size_t base64Decode(const char *encoded_string,
     if (i)
     {
         for (int j = i; j < 4; ++j)
-            char_array_4[j] = 0;
+            charArray4[j] = 0;
 
         for (int j = 0; j < 4; ++j)
         {
-            char_array_4[j] = base64CharMap.getIndex(char_array_4[j]);
+            charArray4[j] = base64CharMap.getIndex(charArray4[j]);
         }
 
-        char_array_3[0] =
-            (char_array_4[0] << 2) + ((char_array_4[1] & 0x30) >> 4);
-        char_array_3[1] =
-            ((char_array_4[1] & 0xf) << 4) + ((char_array_4[2] & 0x3c) >> 2);
-        char_array_3[2] = ((char_array_4[2] & 0x3) << 6) + char_array_4[3];
+        charArray3[0] = (charArray4[0] << 2) + ((charArray4[1] & 0x30) >> 4);
+        charArray3[1] =
+            ((charArray4[1] & 0xf) << 4) + ((charArray4[2] & 0x3c) >> 2);
+        charArray3[2] = ((charArray4[2] & 0x3) << 6) + charArray4[3];
 
         --i;
         for (int j = 0; (j < i); ++j, ++a)
-            output_buffer[a] = char_array_3[j];
+            outputBuffer[a] = charArray3[j];
     }
 
     return a;


### PR DESCRIPTION
There are cases one wants to encode or decode into a much bigger buffer.

Eliminates the need to encode into a string, to then be copied over to the bigger buffer.

Allows for the possibility of decoding in-place, so that no extra string or buffer is needed.