### PR TITLE
Fix coroutine continuation handle

### DIFF
--- a/lib/inc/drogon/utils/coroutine.h
+++ b/lib/inc/drogon/utils/coroutine.h
@@ -245,7 +245,7 @@ struct [[nodiscard]] Task
 
         std::optional<T> value;
         std::exception_ptr exception_;
-        std::coroutine_handle<> continuation_;
+        std::coroutine_handle<> continuation_{std::noop_coroutine()};
     };
 
     auto operator co_await() const noexcept
@@ -332,7 +332,7 @@ struct [[nodiscard]] Task<void>
         }
 
         std::exception_ptr exception_;
-        std::coroutine_handle<> continuation_;
+        std::coroutine_handle<> continuation_{std::noop_coroutine()};
     };
 
     auto operator co_await() const noexcept


### PR DESCRIPTION
Using coroutines directly by the user e.g. declaring a function with drogon::Task<> return type, will have it's continuation set to nullptr.

Returning nullptr causes a segfault and it must be checked before returning e.g. the snippet form https://en.cppreference.com/w/cpp/coroutine/noop_coroutine

```cpp
struct final_awaiter
{
    std::coroutine_handle<>
        await_suspend(std::coroutine_handle<promise_type> h) noexcept
    {
        // final_awaiter::await_suspend is called when the execution of the
        // current coroutine (referred to by 'h') is about to finish.
        // If the current coroutine was resumed by another coroutine via
        // co_await get_task(), a handle to that coroutine has been stored
        // as h.promise().previous. In that case, return the handle to resume
        // the previous coroutine.
        // Otherwise, return noop_coroutine(), whose resumption does nothing.

        if (auto previous = h.promise().previous; previous)
            return previous;
        else
            return std::noop_coroutine();
    }
};
```

This commit default initializes the continuation handle to no op coroutine and avoids the check.