### PR TITLE
Remove content-length header from 101 Switching Protocols response

### DIFF
--- a/lib/src/HttpControllerBinder.cc
+++ b/lib/src/HttpControllerBinder.cc
@@ -64,15 +64,10 @@ void WebsocketControllerBinder::handleRequest(
     memcpy(accKey, &sha1, sizeof(sha1));
     auto base64Key = utils::base64Encode(accKey, sizeof(accKey));
     auto resp = HttpResponse::newHttpResponse();
-    resp->setPassThrough(true);
     resp->setStatusCode(k101SwitchingProtocols);
     resp->addHeader("Upgrade", "websocket");
     resp->addHeader("Connection", "Upgrade");
     resp->addHeader("Sec-WebSocket-Accept", base64Key);
-
-    std::string versionStr = "drogon/" + drogon::getVersion();
-    resp->addHeader("Server", versionStr);
-
     callback(resp);
 }
 

--- a/lib/src/HttpControllerBinder.cc
+++ b/lib/src/HttpControllerBinder.cc
@@ -64,10 +64,15 @@ void WebsocketControllerBinder::handleRequest(
     memcpy(accKey, &sha1, sizeof(sha1));
     auto base64Key = utils::base64Encode(accKey, sizeof(accKey));
     auto resp = HttpResponse::newHttpResponse();
+    resp->setPassThrough(true);
     resp->setStatusCode(k101SwitchingProtocols);
     resp->addHeader("Upgrade", "websocket");
     resp->addHeader("Connection", "Upgrade");
     resp->addHeader("Sec-WebSocket-Accept", base64Key);
+
+    std::string versionStr = "drogon/" + drogon::getVersion();
+    resp->addHeader("Server", versionStr);
+
     callback(resp);
 }
 

--- a/lib/src/HttpResponseImpl.cc
+++ b/lib/src/HttpResponseImpl.cc
@@ -516,6 +516,7 @@ void HttpResponseImpl::makeHeaderString(trantor::MsgBuffer &buffer)
                            statusCode_);
         }
     }
+
     buffer.hasWritten(len);
 
     if (!statusMessage_.empty())
@@ -537,7 +538,7 @@ void HttpResponseImpl::makeHeaderString(trantor::MsgBuffer &buffer)
             }
             len = 0;
         }
-        else if (sendfileName_.empty())
+        else if (sendfileName_.empty() && contentLengthIsAllowed())
         {
             auto bodyLength = bodyPtr_ ? bodyPtr_->length() : 0;
             len = snprintf(buffer.beginWrite(),
@@ -545,7 +546,7 @@ void HttpResponseImpl::makeHeaderString(trantor::MsgBuffer &buffer)
                            contentLengthFormatString<decltype(bodyLength)>(),
                            bodyLength);
         }
-        else
+        else if (contentLengthIsAllowed())
         {
             auto bodyLength = sendfileRange_.second;
             len = snprintf(buffer.beginWrite(),

--- a/lib/src/HttpResponseImpl.h
+++ b/lib/src/HttpResponseImpl.h
@@ -537,6 +537,16 @@ class DROGON_EXPORT HttpResponseImpl : public HttpResponse
     {
         statusMessage_ = message;
     }
+
+    bool contentLengthIsAllowed()
+    {
+        int statusCode =
+            customStatusCode_ >= 0 ? customStatusCode_ : statusCode_;
+
+        // return false if status code is 1xx or 204
+        return (statusCode >= k200OK || statusCode < k100Continue) &&
+               statusCode != k204NoContent;
+    }
 };
 
 using HttpResponseImplPtr = std::shared_ptr<HttpResponseImpl>;

--- a/lib/tests/CMakeLists.txt
+++ b/lib/tests/CMakeLists.txt
@@ -28,6 +28,7 @@ set(UNITTEST_SOURCES
     unittests/SlashRemoverTest.cc
     unittests/UtilitiesTest.cc
     unittests/UuidUnittest.cc
+    unittests/WebsocketResponseTest.cc
 )
 
 if(DROGON_CXX_STANDARD GREATER_EQUAL 20 AND HAS_COROUTINE)

--- a/lib/tests/unittests/WebsocketResponseTest.cc
+++ b/lib/tests/unittests/WebsocketResponseTest.cc
@@ -17,10 +17,9 @@ DROGON_TEST(WebsocketReponseTest)
 
     binder.handleRequest(reqPtr, [&](const HttpResponsePtr &resp) {
         CHECK(resp->statusCode() == k101SwitchingProtocols);
-        CHECK(resp->headers().size() == 4);
+        CHECK(resp->headers().size() == 3);
         CHECK(resp->getHeader("Upgrade") == "websocket");
         CHECK(resp->getHeader("Connection") == "Upgrade");
-        CHECK(resp->getHeader("Server") == "drogon/" + drogon::getVersion());
 
         // Value from rfc6455-1.3
         CHECK(resp->getHeader("Sec-WebSocket-Accept") ==

--- a/lib/tests/unittests/WebsocketResponseTest.cc
+++ b/lib/tests/unittests/WebsocketResponseTest.cc
@@ -1,0 +1,41 @@
+#include <drogon/drogon_test.h>
+
+#include "../../lib/src/HttpRequestImpl.h"
+#include "../../lib/src/HttpResponseImpl.h"
+#include "../../lib/src/HttpControllerBinder.h"
+
+using namespace drogon;
+
+DROGON_TEST(WebsocketReponseTest)
+{
+    WebsocketControllerBinder binder;
+
+    auto reqPtr = std::make_shared<HttpRequestImpl>(nullptr);
+
+    // Value from rfc6455-1.3
+    reqPtr->addHeader("sec-websocket-key", "dGhlIHNhbXBsZSBub25jZQ==");
+
+    binder.handleRequest(reqPtr, [&](const HttpResponsePtr &resp) {
+        CHECK(resp->statusCode() == k101SwitchingProtocols);
+        CHECK(resp->headers().size() == 4);
+        CHECK(resp->getHeader("Upgrade") == "websocket");
+        CHECK(resp->getHeader("Connection") == "Upgrade");
+        CHECK(resp->getHeader("Server") == "drogon/" + drogon::getVersion());
+
+        // Value from rfc6455-1.3
+        CHECK(resp->getHeader("Sec-WebSocket-Accept") ==
+              "s3pPLMBiTxaQ9kYGzzhZRbK+xOo=");
+
+        auto implPtr = std::dynamic_pointer_cast<HttpResponseImpl>(resp);
+
+        implPtr->makeHeaderString();
+        auto buffer = implPtr->renderToBuffer();
+        auto str = std::string{buffer->peek(), buffer->readableBytes()};
+
+        CHECK(str.find("upgrade: websocket") != std::string::npos);
+        CHECK(str.find("connection: Upgrade") != std::string::npos);
+        CHECK(str.find("sec-websocket-accept: s3pPLMBiTxaQ9kYGzzhZRbK+xOo=") !=
+              std::string::npos);
+        CHECK(str.find("content-length:") == std::string::npos);
+    });
+}


### PR DESCRIPTION

RFC 9110-8.6 (and RFC 7230 before it) states:

```
A server MUST NOT send a Content-Length header field in any response with a status code of 1xx
(Informational) or 204 (No Content).
```
The websocket connect response is 101 (Switching Protocols) and should not contain `Content-Length` as specified above. Drogon's response incorrectly included the `Content-Length` header.

This causes an issue with the .NET websockets client implementation as described in [this Stack Overflow question](https://stackoverflow.com/questions/40502921/net-websockets-forcibly-closed-despite-keep-alive-and-activity-on-the-connectio).

Using `setPassthrough` on Switching Protocols response suppresses the `Content-Length` header as well as `Content-Type`, `Date`, and `Server`. I added explicit code to add back the `Server` header. I'm not sure how desirable that actually is.

And there is a test added that fails without the code changes.