### PR TITLE
Add partial base64 in-place encoding support

### DIFF
--- a/lib/inc/drogon/utils/Utilities.h
+++ b/lib/inc/drogon/utils/Utilities.h
@@ -128,12 +128,14 @@ DROGON_EXPORT std::set<std::string> splitStringToSet(
 DROGON_EXPORT std::string getUuid(bool lowercase = true);
 
 /// Get the encoded length of base64.
-constexpr size_t base64EncodedLength(size_t in_len, bool padded = true)
+constexpr size_t base64EncodedLength(size_t inLen, bool padded = true)
 {
-    return padded ? ((in_len + 3 - 1) / 3) * 4 : (in_len * 8 + 6 - 1) / 6;
+    return padded ? ((inLen + 3 - 1) / 3) * 4 : (inLen * 8 + 6 - 1) / 6;
 }
 
 /// Encode the string to base64 format.
+/// Supports in-place encoding up to 12 input bytes.
+/// To encode more than 12 input bytes, use the `base64EncodeInPlace` overload.
 DROGON_EXPORT void base64Encode(const unsigned char *bytesToEncode,
                                 size_t inLen,
                                 unsigned char *outputBuffer,
@@ -141,13 +143,21 @@ DROGON_EXPORT void base64Encode(const unsigned char *bytesToEncode,
                                 bool padded = true);
 
 /// Encode the string to base64 format.
+/// Uses minimal dynamic allocation for encoding.
+/// TODO: To be implemented
+/*DROGON_EXPORT void base64EncodeInPlace(const unsigned char *bytesToEncode,
+                                size_t inLen,
+                                unsigned char *outputBuffer,
+                                bool urlSafe = false,
+                                bool padded = true);*/
+
+/// Encode the string to base64 format.
 inline std::string base64Encode(const unsigned char *bytesToEncode,
                                 size_t inLen,
                                 bool urlSafe = false,
                                 bool padded = true)
 {
-    std::string ret;
-    ret.resize(base64EncodedLength(inLen, padded));
+    std::string ret(base64EncodedLength(inLen, padded), uint8_t(0));
     base64Encode(
         bytesToEncode, inLen, (unsigned char *)ret.data(), urlSafe, padded);
     return ret;
@@ -204,8 +214,7 @@ DROGON_EXPORT size_t base64Decode(const char *encodedString,
 inline std::string base64Decode(std::string_view encodedString)
 {
     auto inLen = encodedString.size();
-    std::string ret;
-    ret.resize(base64DecodedLength(inLen));
+    std::string ret(base64DecodedLength(inLen), uint8_t(0));
     ret.resize(
         base64Decode(encodedString.data(), inLen, (unsigned char *)ret.data()));
     return ret;

--- a/lib/tests/unittests/Base64Test.cc
+++ b/lib/tests/unittests/Base64Test.cc
@@ -1,10 +1,11 @@
 #include <drogon/utils/Utilities.h>
 #include <drogon/drogon_test.h>
 #include <string>
+#include <string_view>
 
 DROGON_TEST(Base64)
 {
-    std::string in{"drogon framework"};
+    constexpr std::string_view in = "drogon framework";
     auto encoded = drogon::utils::base64Encode(in);
     auto decoded = drogon::utils::base64Decode(encoded);
     CHECK(encoded == "ZHJvZ29uIGZyYW1ld29yaw==");
@@ -26,11 +27,29 @@ DROGON_TEST(Base64)
 
     SUBSECTION(Unpadded)
     {
-        std::string in{"drogon framework"};
         auto encoded = drogon::utils::base64EncodeUnpadded(in);
         auto decoded = drogon::utils::base64Decode(encoded);
         CHECK(encoded == "ZHJvZ29uIGZyYW1ld29yaw");
         CHECK(decoded == in);
+    }
+
+    SUBSECTION(InPlace12)
+    {
+        constexpr std::string_view in = "base64encode";
+        std::string encoded(drogon::utils::base64EncodedLength(in.size()),
+                            '\0');
+        std::memcpy(encoded.data(), in.data(), in.size());
+        drogon::utils::base64Encode((const unsigned char *)encoded.data(),
+                                    in.size(),
+                                    (unsigned char *)encoded.data());
+        auto decoded = drogon::utils::base64Decode(encoded);
+        CHECK(encoded == "YmFzZTY0ZW5jb2Rl");
+        CHECK(decoded == in);
+
+        // In-place decoding
+        encoded.resize(drogon::utils::base64Decode(
+            encoded.data(), encoded.size(), (unsigned char *)encoded.data()));
+        CHECK(encoded == in);
     }
 
     SUBSECTION(LongString)
@@ -50,7 +69,6 @@ DROGON_TEST(Base64)
 
     SUBSECTION(URLSafe)
     {
-        std::string in{"drogon framework"};
         auto encoded = drogon::utils::base64Encode(in, true);
         auto decoded = drogon::utils::base64Decode(encoded);
         CHECK(encoded == "ZHJvZ29uIGZyYW1ld29yaw==");
@@ -59,7 +77,6 @@ DROGON_TEST(Base64)
 
     SUBSECTION(UnpaddedURLSafe)
     {
-        std::string in{"drogon framework"};
         auto encoded = drogon::utils::base64EncodeUnpadded(in, true);
         auto decoded = drogon::utils::base64Decode(encoded);
         CHECK(encoded == "ZHJvZ29uIGZyYW1ld29yaw");


### PR DESCRIPTION
This PR allows for encoding a sequence of bytes, which does not exceed 12 bytes, in-place.
Added the declaration of another base64 encoding function that will do in-place encoding but with dynamic allocation.
Tried as much as I could to stick to the old implementation, had to make some structured changes to make it work for in-place encoding.

Replaced `.resize()` calls as they were allocating more than they needed in terms of capacity. Use this sample code to check out this change:
```c++
int main()
{
    constexpr auto len = 20;
    string s1(len, '0');
    string s2;
    s2.resize(len, '0');
    cout << "S1: " << s1 << " | Len: " << s1.size() << " | Cap: " << s1.capacity() << '\n'; // Cap: 20
    cout << "S2: " << s2 << " | Len: " << s2.size() << " | Cap: " << s2.capacity() << '\n'; // Cap: 30
}
```