### PR TITLE
Adding support for escaped identifiers in Postgresql

### DIFF
--- a/drogon_ctl/create_model.cc
+++ b/drogon_ctl/create_model.cc
@@ -66,6 +66,15 @@ static std::string escapeConnString(const std::string &str)
     return escaped;
 }
 
+std::string drogon_ctl::escapeIdentifier(const std::string &identifier, const std::string &rdbms)
+{
+    if (rdbms != "postgresql") {
+        return identifier;
+    }
+
+    return "\\\"" + identifier + "\\\"";
+}
+
 static std::map<std::string, std::vector<ConvertMethod>> getConvertMethods(
     const Json::Value &convertColumns)
 {
@@ -166,7 +175,7 @@ void create_model::createModelClassFromPG(
     auto className = nameTransform(tableName, true);
     HttpViewData data;
     data["className"] = className;
-    data["tableName"] = toLower(tableName);
+    data["tableName"] = tableName;
     data["hasPrimaryKey"] = (int)0;
     data["primaryKeyName"] = "";
     data["dbName"] = dbname_;

--- a/drogon_ctl/create_model.cc
+++ b/drogon_ctl/create_model.cc
@@ -66,9 +66,11 @@ static std::string escapeConnString(const std::string &str)
     return escaped;
 }
 
-std::string drogon_ctl::escapeIdentifier(const std::string &identifier, const std::string &rdbms)
+std::string drogon_ctl::escapeIdentifier(const std::string &identifier,
+                                         const std::string &rdbms)
 {
-    if (rdbms != "postgresql") {
+    if (rdbms != "postgresql")
+    {
         return identifier;
     }
 

--- a/drogon_ctl/create_model.h
+++ b/drogon_ctl/create_model.h
@@ -78,6 +78,8 @@ inline std::string nameTransform(const std::string &origName, bool isType)
     return ret;
 }
 
+std::string escapeIdentifier(const std::string &identifier, const std::string &rdbms);
+
 class PivotTable
 {
   public:

--- a/drogon_ctl/create_model.h
+++ b/drogon_ctl/create_model.h
@@ -78,7 +78,8 @@ inline std::string nameTransform(const std::string &origName, bool isType)
     return ret;
 }
 
-std::string escapeIdentifier(const std::string &identifier, const std::string &rdbms);
+std::string escapeIdentifier(const std::string &identifier,
+                             const std::string &rdbms);
 
 class PivotTable
 {

--- a/drogon_ctl/templates/model_cc.csp
+++ b/drogon_ctl/templates/model_cc.csp
@@ -76,7 +76,7 @@ else
 
 <%c++for(auto col:cols){
 %>
-const std::string [[className]]::Cols::_{%col.colName_%} = "{%col.colName_%}";
+const std::string [[className]]::Cols::_{%col.colName_%} = "{%escapeIdentifier(col.colName_, rdbms)%}";
 <%c++
 }%>
 <%c++if(@@.get<int>("hasPrimaryKey")<=1){%>
@@ -102,7 +102,7 @@ if(!schema.empty())
 {
     $$<<schema<<".";
 }
-%>[[tableName]]";
+%>{%escapeIdentifier(@@.get<std::string>("tableName"), rdbms)%}";
 
 const std::vector<typename [[className]]::MetaData> [[className]]::metaData_={
 <%c++for(size_t i=0;i<cols.size();i++){


### PR DESCRIPTION
This PR is for adding support for escaped identifiers in postgresql.

This should resolve: https://github.com/drogonframework/drogon/issues/1820

Example db table:
```pgsql
CREATE TABLE public."pageContent" (
    id bigint NOT NULL,
    "group" character varying(64) NOT NULL,
    "camelCaseName" character varying(64) NOT NULL
);
ALTER TABLE ONLY public."pageContent"
    ADD CONSTRAINT page_content_pkey PRIMARY KEY (id);

```