### PR TITLE
Optimize query params and allow for empty values

### DIFF
--- a/lib/src/HttpRequestImpl.cc
+++ b/lib/src/HttpRequestImpl.cc
@@ -96,13 +96,15 @@ void HttpRequestImpl::parseParameters() const
                 while (cpos < key.length() &&
                        isspace(static_cast<unsigned char>(key[cpos])))
                     ++cpos;
-                key = key.substr(cpos);
+                key.remove_prefix(cpos);
                 auto pvalue = coo.substr(epos + 1);
-                std::string pdecode = utils::urlDecode(pvalue);
-                std::string keydecode = utils::urlDecode(key);
-                parameters_[keydecode] = pdecode;
+                parameters_[utils::urlDecode(key)] = utils::urlDecode(pvalue);
             }
-            value = value.substr(pos + 1);
+            else
+            {
+                parameters_[utils::urlDecode(coo)];
+            }
+            value.remove_prefix(pos + 1);
         }
         if (value.length() > 0)
         {
@@ -115,11 +117,13 @@ void HttpRequestImpl::parseParameters() const
                 while (cpos < key.length() &&
                        isspace(static_cast<unsigned char>(key[cpos])))
                     ++cpos;
-                key = key.substr(cpos);
+                key.remove_prefix(cpos);
                 auto pvalue = coo.substr(epos + 1);
-                std::string pdecode = utils::urlDecode(pvalue);
-                std::string keydecode = utils::urlDecode(key);
-                parameters_[keydecode] = pdecode;
+                parameters_[utils::urlDecode(key)] = utils::urlDecode(pvalue);
+            }
+            else
+            {
+                parameters_[utils::urlDecode(coo)];
             }
         }
     }
@@ -153,13 +157,15 @@ void HttpRequestImpl::parseParameters() const
                 while (cpos < key.length() &&
                        isspace(static_cast<unsigned char>(key[cpos])))
                     ++cpos;
-                key = key.substr(cpos);
+                key.remove_prefix(cpos);
                 auto pvalue = coo.substr(epos + 1);
-                std::string pdecode = utils::urlDecode(pvalue);
-                std::string keydecode = utils::urlDecode(key);
-                parameters_[keydecode] = pdecode;
+                parameters_[utils::urlDecode(key)] = utils::urlDecode(pvalue);
             }
-            value = value.substr(pos + 1);
+            else
+            {
+                parameters_[utils::urlDecode(coo)];
+            }
+            value.remove_prefix(pos + 1);
         }
         if (value.length() > 0)
         {
@@ -172,11 +178,13 @@ void HttpRequestImpl::parseParameters() const
                 while (cpos < key.length() &&
                        isspace(static_cast<unsigned char>(key[cpos])))
                     ++cpos;
-                key = key.substr(cpos);
+                key.remove_prefix(cpos);
                 auto pvalue = coo.substr(epos + 1);
-                std::string pdecode = utils::urlDecode(pvalue);
-                std::string keydecode = utils::urlDecode(key);
-                parameters_[keydecode] = pdecode;
+                parameters_[utils::urlDecode(key)] = utils::urlDecode(pvalue);
+            }
+            else
+            {
+                parameters_[utils::urlDecode(coo)];
             }
         }
     }


### PR DESCRIPTION
1. By moving the string decodes directly into map arguments, it inserts both keys and values as rvalues (`std::string&&`).
2. Allows for empty values in query parameters: `/api/something?confirm`
3. Use `std::string_view::remove_prefix(...)` instead of reassigning self to a substring of self, removing the need for reconstructing string_views repeatedly.