### PR TITLE
Replace rejection sampling and remove use of rand()

### DIFF
--- a/lib/src/Utilities.cc
+++ b/lib/src/Utilities.cc
@@ -33,6 +33,7 @@
 #include <sstream>
 #include <string>
 #include <mutex>
+#include <random>
 #include <algorithm>
 #include <array>
 #include <locale>
@@ -162,28 +163,16 @@ bool isBase64(std::string_view str)
 
 std::string genRandomString(int length)
 {
-    static const char char_space[] =
+    static const std::string_view char_space[] =
         "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
-    static std::once_flag once;
-    static const size_t len = strlen(char_space);
-    static const int randMax = RAND_MAX - (RAND_MAX % len);
-    std::call_once(once, []() {
-        std::srand(static_cast<unsigned int>(time(nullptr)));
-    });
+    std::uniform_int_distribution<size_t> dist(0, char_space.size()-1);
+    thread_local std::mt19937 rng(std::random_device{}());
 
-    int i;
     std::string str;
     str.resize(length);
-
-    for (i = 0; i < length; ++i)
+    for(char& ch : str)
     {
-        int x = std::rand();
-        while (x >= randMax)
-        {
-            x = std::rand();
-        }
-        x = (x % len);
-        str[i] = char_space[x];
+        ch = char_space[dist(rng)];
     }
 
     return str;

--- a/lib/src/Utilities.cc
+++ b/lib/src/Utilities.cc
@@ -163,7 +163,7 @@ bool isBase64(std::string_view str)
 
 std::string genRandomString(int length)
 {
-    static const std::string_view char_space[] =
+    static const std::string_view char_space =
         "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
     std::uniform_int_distribution<size_t> dist(0, char_space.size() - 1);
     thread_local std::mt19937 rng(std::random_device{}());

--- a/lib/src/Utilities.cc
+++ b/lib/src/Utilities.cc
@@ -170,7 +170,7 @@ std::string genRandomString(int length)
 
     std::string str;
     str.resize(length);
-    for (char& ch : str)
+    for (char &ch : str)
     {
         ch = char_space[dist(rng)];
     }

--- a/lib/src/Utilities.cc
+++ b/lib/src/Utilities.cc
@@ -165,12 +165,12 @@ std::string genRandomString(int length)
 {
     static const std::string_view char_space[] =
         "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
-    std::uniform_int_distribution<size_t> dist(0, char_space.size()-1);
+    std::uniform_int_distribution<size_t> dist(0, char_space.size() - 1);
     thread_local std::mt19937 rng(std::random_device{}());
 
     std::string str;
     str.resize(length);
-    for(char& ch : str)
+    for (char& ch : str)
     {
         ch = char_space[dist(rng)];
     }


### PR DESCRIPTION
The old code uses rejection sampling. Trying to get number between 0~61 from 0~RAND_MAX (on Windows this is 15bits and on Linux 32bits) is extremely slow. This patch fixes that by using C++'s distribution class.

Also replaces rand() with C++ random engines since OpenBSD is complaining about it.

```
ld: warning: Utilities.cc(Utilities.cc.o:(drogon::utils::genRandomString(int)) in archive ../libdrogon.a): warning: rand() may return deterministic values, is that what you want?
```