### PR TITLE
fix some bugs in plugin PromExporter.

### DIFF
--- a/lib/inc/drogon/utils/monitoring/Gauge.h
+++ b/lib/inc/drogon/utils/monitoring/Gauge.h
@@ -91,7 +91,7 @@ class Gauge : public Metric
 
     static std::string_view type()
     {
-        return "counter";
+        return "gauge";
     }
 
     void setToCurrentTime()

--- a/lib/src/PromExporter.cc
+++ b/lib/src/PromExporter.cc
@@ -28,6 +28,7 @@ void PromExporter::initAndStart(const Json::Value &config)
             }
             auto resp = HttpResponse::newHttpResponse();
             resp->setBody(thisPtr->exportMetrics());
+            resp->setContentTypeCode(CT_TEXT_PLAIN);
             resp->setExpiredTime(5);
             callback(resp);
         },
@@ -118,12 +119,12 @@ static std::string exportCollector(
         .append(collector->name())
         .append(" ")
         .append(collector->help())
-        .append("\r\n");
+        .append("\n");
     res.append("# TYPE ")
         .append(collector->name())
         .append(" ")
         .append(collector->type())
-        .append("\r\n");
+        .append("\n");
     for (auto const &sampleGroup : sampleGroups)
     {
         auto const &metricPtr = sampleGroup.metric;
@@ -157,11 +158,11 @@ static std::string exportCollector(
                 res.append(" ")
                     .append(std::to_string(
                         sample.timestamp.microSecondsSinceEpoch() / 1000))
-                    .append("\r\n");
+                    .append("\n");
             }
             else
             {
-                res.append("\r\n");
+                res.append("\n");
             }
         }
     }


### PR DESCRIPTION
1. `Gauge`类的 `type()` 函数
2. 应该使用 `"\n"` 来换行而不是 `"\r\n"` ，后者会导致 `Prometheus` 错误的识别 `Collector` 的类型，比如：`"counter\r"`
3. 设置了响应头的 `Content-Type`为 `text/plain`