### PR TITLE
fix a bug in plugin Redirector.

### DIFF
--- a/lib/src/Redirector.cc
+++ b/lib/src/Redirector.cc
@@ -30,16 +30,16 @@ void Redirector::initAndStart(const Json::Value &config)
             }
             std::string protocol, host;
             bool pathChanged{false};
+            for (auto &handler : thisPtr->pathRewriteHandlers_)
+            {
+                pathChanged |= handler(req);
+            }
             for (auto &handler : thisPtr->handlers_)
             {
                 if (!handler(req, protocol, host, pathChanged))
                 {
                     return HttpResponse::newNotFoundResponse(req);
                 }
-            }
-            for (auto &handler : thisPtr->pathRewriteHandlers_)
-            {
-                pathChanged |= handler(req);
             }
             if (!protocol.empty() || !host.empty() || pathChanged)
             {


### PR DESCRIPTION
```cpp
#include <drogon/drogon.h>
#include <drogon/plugins/Redirector.h>

int main()
{
    drogon::app().addListener("0.0.0.0", 8000);
    // {"plugins": [{"name": "drogon::plugin::Redirector"}]}
    drogon::app().loadConfigFile("../config.json");
    drogon::app().registerBeginningAdvice([] {
        drogon::plugin::Redirector *redirector =
            drogon::app().getPlugin<drogon::plugin::Redirector>();

        redirector->registerRedirectHandler(
            [](const drogon::HttpRequestPtr &req,
               std::string &protocol,
               std::string &host,
               bool &pathChanged) -> bool {
                if (req->path() == "/")
                {
                    protocol = "https://";
                    host = "github.com";
                    req->setPath("/drogonframework/drogon");
                    pathChanged = true;
                }
                return true;
            });

        redirector->registerPathRewriteHandler(
            [](const drogon::HttpRequestPtr &req) -> bool {
                if (!req->path().starts_with("/api") && req->path() != "/")
                {
                    req->setPath("/");
                    return true;
                }
                return false;
            });
    });
    drogon::app().run();
    return 0;
}
```

For the above code, the expected goal is: access `localhost:8000`, redirect to `https://github.com/drogonframework/drogon`.
The old version of the `Redirector` plugin redirects to the `github.com` homepage, because the loop of `pathRewriteHandlers_` modifies the `path`. This is not as expected.