### PR TITLE
Update FindFilesystem.cmake to check for GNU instead of GCC for CMAKE…

### DIFF
--- a/cmake_modules/FindFilesystem.cmake
+++ b/cmake_modules/FindFilesystem.cmake
@@ -212,7 +212,7 @@ if(CXX_FILESYSTEM_HAVE_FS)
     ]] code @ONLY)
 
     # HACK: Needed to compile correctly on Yocto Linux
-    if(CMAKE_CXX_COMPILER_ID STREQUAL "GCC" OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang"
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang"
         OR CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
         set(CMAKE_REQUIRED_FLAGS ${prev_req_flags} -std=c++17)
     endif ()


### PR DESCRIPTION
…_CXX_COMPILER_ID

This patch fixes a build issue encountered in our Amazon Linux 2 environment when integrating Drogon alongside other dependencies. The issue occurred because the filesystem check failed to compile when the compiler ID was set to "GNU", due to missing -std=c++17 flag. The existing CXX_FILESYSTEM_HAVE_FS check was looking for "GCC" instead of "GNU". "GNU" is the correct identifier for gcc according to CMake documentation (see https://cmake.org/cmake/help/latest/variable/CMAKE_LANG_COMPILER_ID.html).

Interestingly, this issue only manifested when Drogon was integrated alongside other dependencies. When Drogon was the sole project added to our build, compilation proceeded without error.