### PR TITLE
Fixed issues created by the date string being localized

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -170,9 +170,16 @@ jobs:
           # Installing packages might fail as the github image becomes outdated
           sudo apt update
           # These aren't available or don't work well in vcpkg
-          sudo apt-get install -y libjsoncpp-dev uuid-dev libssl-dev zlib1g-dev libsqlite3-dev
+          sudo apt-get install -y libjsoncpp-dev uuid-dev libssl-dev zlib1g-dev libsqlite3-dev locales
           sudo apt-get install -y ninja-build libbrotli-dev
           sudo apt-get install -y libspdlog-dev
+    
+      - name: Install locales
+        run: |
+          sudo apt-get install -y locales
+          sudo locale-gen en_US
+          sudo locale-gen en_US.UTF-8
+          sudo locale-gen en_US.UTF-8
 
       - name: Install postgresql
         run: |

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -170,16 +170,15 @@ jobs:
           # Installing packages might fail as the github image becomes outdated
           sudo apt update
           # These aren't available or don't work well in vcpkg
-          sudo apt-get install -y libjsoncpp-dev uuid-dev libssl-dev zlib1g-dev libsqlite3-dev locales
+          sudo apt-get install -y libjsoncpp-dev uuid-dev libssl-dev zlib1g-dev libsqlite3-dev
           sudo apt-get install -y ninja-build libbrotli-dev
           sudo apt-get install -y libspdlog-dev
     
-      - name: Install locales
+      - name: Install and update locales
         run: |
           sudo apt-get install -y locales
-          sudo locale-gen en_US
-          sudo locale-gen en_US.UTF-8
-          sudo locale-gen en_US.UTF-8
+          sudo locale-gen en_US && sudo locale-gen en_US.UTF-8
+          sudo update-locale LC_ALL=en_US.UTF-8
 
       - name: Install postgresql
         run: |

--- a/lib/inc/drogon/utils/Utilities.h
+++ b/lib/inc/drogon/utils/Utilities.h
@@ -302,11 +302,11 @@ DROGON_EXPORT char *getHttpFullDate(
     const trantor::Date &date = trantor::Date::now());
 
 DROGON_EXPORT std::string getHttpFullDateStr(
-		const trantor::Date &date = trantor::Date::now());
+    const trantor::Date &date = trantor::Date::now());
 
 DROGON_EXPORT void datetoCustomFormattedString(const std::string &fmtStr,
-																							 std::string &str,
-																							 const trantor::Date &date);
+                                               std::string &str,
+                                               const trantor::Date &date);
 /// Get the trantor::Date object according to the http full date string
 /**
  * Returns trantor::Date(std::numeric_limits<int64_t>::max()) upon failure.

--- a/lib/inc/drogon/utils/Utilities.h
+++ b/lib/inc/drogon/utils/Utilities.h
@@ -301,7 +301,7 @@ DROGON_EXPORT std::string brotliDecompress(const char *data,
 DROGON_EXPORT char *getHttpFullDate(
     const trantor::Date &date = trantor::Date::now());
 
-DROGON_EXPORT const std::string getHttpFullDateStr(
+DROGON_EXPORT const std::string &getHttpFullDateStr(
     const trantor::Date &date = trantor::Date::now());
 
 DROGON_EXPORT void dateToCustomFormattedString(const std::string &fmtStr,

--- a/lib/inc/drogon/utils/Utilities.h
+++ b/lib/inc/drogon/utils/Utilities.h
@@ -301,6 +301,12 @@ DROGON_EXPORT std::string brotliDecompress(const char *data,
 DROGON_EXPORT char *getHttpFullDate(
     const trantor::Date &date = trantor::Date::now());
 
+DROGON_EXPORT std::string getHttpFullDateStr(
+		const trantor::Date &date = trantor::Date::now());
+
+DROGON_EXPORT void datetoCustomFormattedString(const std::string &fmtStr,
+																							 std::string &str,
+																							 const trantor::Date &date);
 /// Get the trantor::Date object according to the http full date string
 /**
  * Returns trantor::Date(std::numeric_limits<int64_t>::max()) upon failure.

--- a/lib/inc/drogon/utils/Utilities.h
+++ b/lib/inc/drogon/utils/Utilities.h
@@ -301,10 +301,10 @@ DROGON_EXPORT std::string brotliDecompress(const char *data,
 DROGON_EXPORT char *getHttpFullDate(
     const trantor::Date &date = trantor::Date::now());
 
-DROGON_EXPORT std::string getHttpFullDateStr(
+DROGON_EXPORT const std::string getHttpFullDateStr(
     const trantor::Date &date = trantor::Date::now());
 
-DROGON_EXPORT void datetoCustomFormattedString(const std::string &fmtStr,
+DROGON_EXPORT void dateToCustomFormattedString(const std::string &fmtStr,
                                                std::string &str,
                                                const trantor::Date &date);
 /// Get the trantor::Date object according to the http full date string

--- a/lib/src/Cookie.cc
+++ b/lib/src/Cookie.cc
@@ -30,7 +30,7 @@ std::string Cookie::cookieString() const
         expiresDate_.microSecondsSinceEpoch() >= 0)
     {
         ret.append("Expires=")
-            .append(utils::getHttpFullDate(expiresDate_))
+            .append(utils::getHttpFullDateStr(expiresDate_))
             .append("; ");
     }
     if (maxAge_.has_value())

--- a/lib/src/HttpResponseImpl.cc
+++ b/lib/src/HttpResponseImpl.cc
@@ -632,8 +632,7 @@ void HttpResponseImpl::renderToBuffer(trantor::MsgBuffer &buffer)
         drogon::HttpAppFrameworkImpl::instance().sendDateHeader())
     {
         buffer.append("date: ");
-        buffer.append(utils::getHttpFullDate(trantor::Date::date()),
-                      httpFullDateStringLength);
+        buffer.append(utils::getHttpFullDateStr(trantor::Date::date()));
         buffer.append("\r\n\r\n");
     }
     else
@@ -706,8 +705,7 @@ std::shared_ptr<trantor::MsgBuffer> HttpResponseImpl::renderToBuffer()
     {
         httpString->append("date: ");
         auto datePos = httpString->readableBytes();
-        httpString->append(utils::getHttpFullDate(trantor::Date::date()),
-                           httpFullDateStringLength);
+        httpString->append(utils::getHttpFullDateStr(trantor::Date::date()));
         httpString->append("\r\n\r\n");
         datePos_ = datePos;
     }

--- a/lib/src/Utilities.cc
+++ b/lib/src/Utilities.cc
@@ -1034,7 +1034,7 @@ char *getHttpFullDate(const trantor::Date &date)
     return lastTimeString;
 }
 
-void datetoCustomFormattedString(const std::string &fmtStr,
+void dateToCustomFormattedString(const std::string &fmtStr,
                                  std::string &str,
                                  const trantor::Date &date)
 {
@@ -1047,7 +1047,7 @@ void datetoCustomFormattedString(const std::string &fmtStr,
     str = Out.str();
 }
 
-std::string getHttpFullDateStr(const trantor::Date &date)
+const std::string getHttpFullDateStr(const trantor::Date &date)
 {
     static thread_local int64_t lastSecond = 0;
     static thread_local std::string lastTimeString(128, 0);
@@ -1057,7 +1057,7 @@ std::string getHttpFullDateStr(const trantor::Date &date)
         return lastTimeString;
     }
     lastSecond = nowSecond;
-    datetoCustomFormattedString("%a, %d %b %Y %H:%M:%S GMT",
+    dateToCustomFormattedString("%a, %d %b %Y %H:%M:%S GMT",
                                 lastTimeString,
                                 date);
     return lastTimeString;

--- a/lib/src/Utilities.cc
+++ b/lib/src/Utilities.cc
@@ -1034,6 +1034,33 @@ char *getHttpFullDate(const trantor::Date &date)
     return lastTimeString;
 }
 
+void datetoCustomFormattedString(const std::string &fmtStr,
+                                 std::string &str,
+                                 const trantor::Date &date)
+{
+    auto nowSecond = date.microSecondsSinceEpoch() / MICRO_SECONDS_PRE_SEC;
+    time_t seconds = static_cast<time_t>(nowSecond);
+    struct tm tm_LValue = date.tmStruct();
+    std::stringstream Out;
+    Out.imbue(std::locale{"en_US"});
+    Out << std::put_time(&tm_LValue, fmtStr.c_str());
+    str = Out.str();
+}
+
+std::string getHttpFullDateStr(const trantor::Date &date)
+{
+    static thread_local int64_t lastSecond = 0;
+    static thread_local std::string lastTimeString(128, 0);
+    auto nowSecond = date.microSecondsSinceEpoch() / MICRO_SECONDS_PRE_SEC;
+    if (nowSecond == lastSecond)
+    {
+        return lastTimeString;
+    }
+    lastSecond = nowSecond;
+    datetoCustomFormattedString("%a, %d %b %Y %H:%M:%S GMT", lastTimeString, date);
+    return lastTimeString;
+}
+
 trantor::Date getHttpDate(const std::string &httpFullDateString)
 {
     static const std::array<const char *, 4> formats = {

--- a/lib/src/Utilities.cc
+++ b/lib/src/Utilities.cc
@@ -1057,7 +1057,9 @@ std::string getHttpFullDateStr(const trantor::Date &date)
         return lastTimeString;
     }
     lastSecond = nowSecond;
-    datetoCustomFormattedString("%a, %d %b %Y %H:%M:%S GMT", lastTimeString, date);
+    datetoCustomFormattedString("%a, %d %b %Y %H:%M:%S GMT",
+                                lastTimeString,
+                                date);
     return lastTimeString;
 }
 

--- a/lib/src/Utilities.cc
+++ b/lib/src/Utilities.cc
@@ -1047,7 +1047,7 @@ void dateToCustomFormattedString(const std::string &fmtStr,
     str = Out.str();
 }
 
-const std::string getHttpFullDateStr(const trantor::Date &date)
+const std::string &getHttpFullDateStr(const trantor::Date &date)
 {
     static thread_local int64_t lastSecond = 0;
     static thread_local std::string lastTimeString(128, 0);

--- a/lib/tests/integration_test/server/main.cc
+++ b/lib/tests/integration_test/server/main.cc
@@ -408,8 +408,7 @@ int main()
     app().registerCustomExtensionMime("md", "text/markdown");
     app().setFileTypes({"md", "html", "jpg", "cc", "txt"});
     std::cout << "Date: "
-              << std::string{drogon::utils::getHttpFullDate(
-                     trantor::Date::now())}
+              << drogon::utils::getHttpFullDateStr(trantor::Date::now())
               << std::endl;
 
     app().registerBeginningAdvice(

--- a/lib/tests/unittests/HttpFullDateTest.cc
+++ b/lib/tests/unittests/HttpFullDateTest.cc
@@ -7,7 +7,7 @@ using namespace drogon;
 
 DROGON_TEST(HttpFullDateTest)
 {
-    auto str = utils::getHttpFullDate();
+    auto str = utils::getHttpFullDateStr();
     auto date = utils::getHttpDate(str);
     CHECK(utils::getHttpFullDate(date) == str);
 }


### PR DESCRIPTION
Fixes #2215.

Since this implementation also involves stream locales, I thought it would be a good idea to replace char arrays with strings, as these arrays would be casted to strings anyway and require size managment that in current implementation is prone to fail (see the issue).

I've added an overload for string to function `datetoCustomFormattedString` and added `getHttpFullDateStr` function, that does exactly the same as `getHttpFullDate`, but returns the string type.

I've left old functions just-in-case, and adjusted github workflow as containers were missing en_US locale. Seems to be working fine.

Here is a minimal working example:
```CPP
#include <iostream>
#include <string>
#include <functional>
#include <locale>
#include <drogon/drogon.h>
#include <codecvt>

typedef std::function<void(const drogon::HttpResponsePtr&)> Callback;

void nodeInfo(const drogon::HttpRequestPtr& request, Callback&& callback)
{
  drogon::HttpResponsePtr response = drogon::HttpResponse::newHttpResponse(
    drogon::k200OK,
    drogon::ContentType::CT_TEXT_PLAIN);  //?newCustomHttpResponse
  response->setVersion(drogon::Version::kHttp11);
  response->addHeader("ServerTest", "Drogon");
  response->setBody("Hello\r");
  std::cout << response->getCreationDate().toFormattedString(false);
  callback(response);
}

void InitWebServer()
{
  // Locks caller thread
  trantor::Logger::setLogLevel(trantor::Logger::kTrace);
  drogon::app()
    .setLogLevel(trantor::Logger::kTrace)
    .enableDateHeader(true)
    .enableServerHeader(false)
    .enableSendfile(false)
    .addListener("0.0.0.0", 1781)
    .setThreadNum(1)
    .registerHandler("/metrics", &nodeInfo, { drogon::Get })
    .run();
  return;
}

int main()
{
  std::setlocale(LC_ALL, "ru-RU");
#ifdef _WIN32
  std::locale::global(std::locale(std::locale::empty(), new std::codecvt_utf8<wchar_t>));
#endif _WIN32
  std::cout << "Привет мир!" << std::endl;
  InitWebServer();
}
```

This is the program output:
```
Привет мир!
20241128 18:52:50.872000 UTC 29240 TRACE [registerHandler] pathPattern:/metrics - drogon/HttpAppFramework.h:531
20241128 18:52:50.875000 UTC 29240 TRACE [run] Start to run... - HttpAppFrameworkImpl.cc:526
20241128 18:52:50.896000 UTC 29240 TRACE [createListeners] thread num=1 - ListenerManager.cc:84
20241128 18:52:50.900000 UTC 29240 TRACE [createNonblockingSocketOrDie] sock=412 - Socket.h:46
20241128 18:52:50.901000 UTC 29240 TRACE [start] HttpServer[drogon] starts listening on 0.0.0.0:1781 - HttpServer.cc:96
20241128 18:52:50.903000 UTC 38136 TRACE [operator ()] map size=1 - TcpServer.cc:131
20241128 18:53:14.780000 UTC 38136 TRACE [newConnection] new connection:fd=180 address=127.0.0.1:6493 - TcpServer.cc:62
20241128 18:53:14.782000 UTC 38136 TRACE [TcpConnectionImpl] new connection:127.0.0.1:6493->127.0.0.1:1781 - TcpConnectionImpl.cc:78
20241128 18:53:14.784000 UTC 36840 TRACE [operator ()] connectEstablished - TcpConnectionImpl.cc:262
20241128 18:53:14.785000 UTC 36840 TRACE [onHttpRequest] new request:127.0.0.1:6493->127.0.0.1:1781 - HttpServer.cc:409
20241128 18:53:14.786000 UTC 36840 TRACE [onHttpRequest] Headers GET /metrics - HttpServer.cc:411
20241128 18:53:14.787000 UTC 36840 TRACE [onHttpRequest] http path=/metrics - HttpServer.cc:412
20241128 18:53:1420241128 18:53:14.790000 UTC 36840 TRACE [renderToBuffer] response(no body):HTTP/1.1 200 OK
content-length: 6
content-type: text/plain; charset=utf-8
servertest: Drogon
date: Thu, 28 Nov 2024 18:53:14 GMT

 - HttpResponseImpl.cc:717
```

and this is the request result from Postman:
```
GET /metrics HTTP/1.1
User-Agent: PostmanRuntime/7.42.0
Accept: */*
Host: 127.0.0.1:1781
Accept-Encoding: gzip, deflate, br
Connection: keep-alive
 
HTTP/1.1 200 OK
content-length: 6
content-type: text/plain; charset=utf-8
servertest: Drogon
date: Thu, 28 Nov 2024 18:53:14 GMT
 
Hello
```