### PR TITLE
Fix: Removed dependency on locales being installed

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -173,12 +173,6 @@ jobs:
           sudo apt-get install -y libjsoncpp-dev uuid-dev libssl-dev zlib1g-dev libsqlite3-dev
           sudo apt-get install -y ninja-build libbrotli-dev
           sudo apt-get install -y libspdlog-dev
-    
-      - name: Install and update locales
-        run: |
-          sudo apt-get install -y locales
-          sudo locale-gen en_US && sudo locale-gen en_US.UTF-8
-          sudo update-locale LC_ALL=en_US.UTF-8
 
       - name: Install postgresql
         run: |

--- a/lib/src/Utilities.cc
+++ b/lib/src/Utilities.cc
@@ -1042,7 +1042,7 @@ void dateToCustomFormattedString(const std::string &fmtStr,
     time_t seconds = static_cast<time_t>(nowSecond);
     struct tm tm_LValue = date.tmStruct();
     std::stringstream Out;
-    Out.imbue(std::locale{"en_US"});
+    Out.imbue(std::locale{"C"});
     Out << std::put_time(&tm_LValue, fmtStr.c_str());
     str = Out.str();
 }


### PR DESCRIPTION
Replaced imbue locale with posix-compliant "C" locale to support systems without en_US locales, and removed locales installation steps on github workflow as they are not required anymore.

Fixes: #2225