### PR TITLE
chore(workflow/cmake.yml): upgrade macos runner

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -73,7 +73,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        osver: [12, 13]
+        osver: [13, 14, 15]
     steps:
       - name: Checkout Drogon source code
         uses: actions/checkout@v4


### PR DESCRIPTION
As https://github.com/actions/runner-images/issues/10721 shown, `macos-12` is deprecated. Now GHA supports macOS 13, 14, 15 runners.

Need to be discussed:
- `macos-13` is based on x86, but `macos-14` and `macos-15` are based on arm64. Should we ~~add arm support or~~ just using x86 version?

Also it's a carry for #1933 