### PR TITLE
Added emptiness check to the LogStream &operator<< with std::string_view

### DIFF
--- a/lib/inc/drogon/utils/Utilities.h
+++ b/lib/inc/drogon/utils/Utilities.h
@@ -584,7 +584,8 @@ namespace trantor
 {
 inline LogStream &operator<<(LogStream &ls, const std::string_view &v)
 {
-    ls.append(v.data(), v.length());
+    if (!v.empty())
+        ls.append(v.data(), v.length());
     return ls;
 }
 


### PR DESCRIPTION
Empty (non-initialized) `std::string_view` has 0 length and nullptr data inside.
Putting such a string into the trantor logger leads to an UBSAN warning:

```
/builds/ZWJbGeiL/0/arenadata/development/adqmc/services/contrib/drogon/trantor/trantor/utils/LogStream.h:50:26: runtime error: null pointer passed as argument 2, which is declared to never be null
/usr/include/string.h:44:28: note: nonnull attribute specified here
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /builds/ZWJbGeiL/0/arenadata/development/adqmc/services/contrib/drogon/trantor/trantor/utils/LogStream.h:50:26 
```

This PR adds a `empty()` check before appending a string to the stream.

Previous PR tro Trantor was here:
https://github.com/an-tao/trantor/pull/363
