### PR TITLE
Improve the zh-TW README translation

### DIFF
--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -19,8 +19,8 @@ Drogon 是一個跨平台框架，支援 Linux、macOS、FreeBSD/OpenBSD、Haiku
 * 支援 HTTP 1.0/1.1（伺服器端和用戶端）；
 * 基於樣板（template）實作的簡單反射機制，使主程式框架、控制器（controller）和視圖（view）完全解耦；
 * 支援 cookies 和內建的 session；
-* 支援後端算繪，將控制器產生的資料交給檢視產生 HTML 頁面，檢視由 CSP 樣板檔案描述，透過 CSP 標籤將 C++ 程式碼嵌入 HTML 頁面，由 drogon 的命令列工具在編譯階段自動產生 C++ 程式碼並編譯；
-* 支援執行期的檢視頁面動態載入（動態編譯和載入 so 檔案）；
+* 支援後端算繪，將控制器產生的資料交給視圖產生 HTML 頁面，視圖由 CSP 樣板檔案描述，透過 CSP 標籤將 C++ 程式碼嵌入 HTML 頁面，由 drogon 的命令列工具在編譯階段自動產生 C++ 程式碼並編譯；
+* 支援執行期的視圖頁面動態載入（動態編譯和載入 so 檔案）；
 * 非常方便靈活的路徑（path）到控制器處理函式（handler）的對應方案；
 * 支援過濾器（filter）鏈，方便在控制器之前執行統一的邏輯（如登入驗證、HTTP Method 限制驗證等）；
 * 支援 HTTPS（基於 OpenSSL）；
@@ -29,7 +29,7 @@ Drogon 是一個跨平台框架，支援 Linux、macOS、FreeBSD/OpenBSD、Haiku
 * 支援檔案下載和上傳，支援 `sendfile` 系統呼叫；
 * 支援 Gzip/Brotli 壓縮傳輸；
 * 支援 pipelining；
-* 提供輕量的命令列工具 `drogon_ctl`，幫助簡化各種類的建立和檢視程式碼的產生過程；
+* 提供輕量的命令列工具 `drogon_ctl`，幫助簡化各種類別的建立和視圖程式碼的產生過程；
 * 非同步的讀寫資料庫，目前支援 PostgreSQL 和 MySQL（MariaDB）資料庫；
 * 支援非同步讀寫 Redis；
 * 基於執行緒池實作 sqlite3 資料庫的非同步讀寫，提供與上述資料庫相同的介面；

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -8,41 +8,42 @@
 
 [English](./README.md) | [简体中文](./README.zh-CN.md) | 繁體中文
 
-**Drogon**是一個基於C++17/20的Http應用框架，使用Drogon可以方便的使用C++構建各種類型的Web App伺服器程式。
-本版本庫是github上[Drogon](https://github.com/an-tao/drogon)的鏡像庫。 **Drogon**是作者非常喜歡的美劇《冰與火之歌：權力遊戲》中的一條龍的名字(漢譯作卓耿)，和龍有關但並不是dragon的誤寫，為了不至於引起不必要的誤會這裡說明一下。
+**Drogon** 是一個基於 C++17/20 的 HTTP 應用程式框架，使用 Drogon 可以方便地用 C++ 建立各種類型的 Web App 伺服器端程式。
 
-Drogon是一個跨平台框架，它支援Linux，也支援macOS、FreeBSD/OpenBSD、HaikuOS和Windows。它的主要特點如下：
+這個版本庫是 GitHub 上 [Drogon](https://github.com/an-tao/drogon) 的鏡像庫。**Drogon** 是作者非常喜歡的美劇《冰與火之歌：權力遊戲》中的一條龍的名字（中文譯作卓耿），和龍有關但並不是 dragon 的誤寫，為了避免不必要的誤會在此說明。
 
-* 網路層使用基於epoll(macOS/FreeBSD下是kqueue)的非阻塞IO框架，提供高並發、高性能的網路IO。詳細請見[TFB Tests Results](https://www.techempower.com/benchmarks/#section=data-r19&hw=ph&test=composite)；
-* 全異步程式設計；
-* 支援Http1.0/1.1(server端和client端)；
-* 基於模板(template)實現了簡單的反射機制，使主程式框架、控制器(controller)和視圖(view)完全去耦；
-* 支援cookies和內建的session；
-* 支援後端渲染，把控制器生成的數據交給視圖生成Html頁面，視圖由CSP模板文件描述，通過CSP標籤把C++程式碼嵌入到Html頁面，由drogon的指令列工具在編譯階段自動生成C++程式碼並編譯；
-* 支援運行期的視圖頁面動態加載(動態編譯和載入so文件)；
-* 非常方便靈活的路徑(path)到控制器處理函數(handler)的映射方案；
-* 支援過濾器(filter)鏈，方便在控制器之前執行統一的邏輯(如登錄驗證、Http Method約束驗證等)；
-* 支援https(基於OpenSSL);
-* 支援websocket(server端和client端);
-* 支援Json格式的請求和回應, 方便開發Restful API;
-* 支援文件下載和上傳,支援sendfile系統呼叫；
-* 支援gzip/brotli壓縮傳輸；
-* 支援pipelining；
-* 提供一個輕量的指令列工具drogon_ctl，幫助簡化各種類的創造和視圖程式碼的生成過程；
-* 非同步的讀寫資料庫，目前支援PostgreSQL和MySQL(MariaDB)資料庫；
-* 支援異步讀寫Redis;
-* 基於執行序池實現sqlite3資料庫的異步讀寫，提供與上文資料庫相同的接口；
-* 支援ARM架構；
-* 方便的輕量級ORM實現，一般物件到資料庫的雙向映射；
-* 支援外掛，可通過設定文件在載入時動態載入；
-* 支援內建插入點的AOP
-* 支援C++ coroutine
+Drogon 是一個跨平台框架，支援 Linux、macOS、FreeBSD/OpenBSD、HaikuOS 和 Windows。主要特點如下：
+
+* 網路層使用基於 epoll（macOS/FreeBSD 下是 kqueue）的非阻塞 IO 框架，提供高並行、高效能的網路 IO。詳細請見 [TFB Tests Results](https://www.techempower.com/benchmarks/#section=data-r19&hw=ph&test=composite)；
+* 完全非同步的程式撰寫邏輯；
+* 支援 HTTP 1.0/1.1（伺服器端和用戶端）；
+* 基於樣板（template）實作的簡單反射機制，使主程式框架、控制器（controller）和視圖（view）完全解耦；
+* 支援 cookies 和內建的 session；
+* 支援後端算繪，將控制器產生的資料交給檢視產生 HTML 頁面，檢視由 CSP 樣板檔案描述，透過 CSP 標籤將 C++ 程式碼嵌入 HTML 頁面，由 drogon 的命令列工具在編譯階段自動產生 C++ 程式碼並編譯；
+* 支援執行期的檢視頁面動態載入（動態編譯和載入 so 檔案）；
+* 非常方便靈活的路徑（path）到控制器處理函式（handler）的對應方案；
+* 支援過濾器（filter）鏈，方便在控制器之前執行統一的邏輯（如登入驗證、HTTP Method 限制驗證等）；
+* 支援 HTTPS（基於 OpenSSL）；
+* 支援 WebSocket（伺服器端和用戶端）；
+* 支援 JSON 格式的請求和回應，方便開發 RESTful API；
+* 支援檔案下載和上傳，支援 `sendfile` 系統呼叫；
+* 支援 Gzip/Brotli 壓縮傳輸；
+* 支援 pipelining；
+* 提供輕量的命令列工具 `drogon_ctl`，幫助簡化各種類的建立和檢視程式碼的產生過程；
+* 非同步的讀寫資料庫，目前支援 PostgreSQL 和 MySQL（MariaDB）資料庫；
+* 支援非同步讀寫 Redis；
+* 基於執行緒池實作 sqlite3 資料庫的非同步讀寫，提供與上述資料庫相同的介面；
+* 支援 ARM 架構；
+* 方便的輕量級 ORM 實現，一般物件到資料庫的雙向對應；
+* 支援外掛，可透過設定檔案在載入時動態載入；
+* 支援內建插入點的 AOP；
+* 支援 C++ coroutine。
 
 ## 一個非常簡單的例子
 
-不像大多數C++框架那樣，drogon的主程式可以非常簡單。 Drogon使用了一些小技巧使主程式和控制器去耦. 控制器的路由設定可以在控制器類別中定義或者設定文件中完成.
+不像大多數 C++ 框架，drogon 的主程式可以非常簡單。Drogon 使用了一些小技巧使主程式和控制器解耦。控制器的路由設定可以在控制器類別中定義或在設定檔案中完成。
 
-下面是一個典型的主程式的樣子:
+下面是一個典型主程式的樣子：
 
 ```c++
 #include <drogon/drogon.h>
@@ -58,7 +59,7 @@ int main()
 }
 ```
 
-如果使用設定文件，可以進一步簡化成這樣:
+如果使用設定檔案，可以進一步簡化成：
 
 ```c++
 #include <drogon/drogon.h>
@@ -69,7 +70,7 @@ int main()
 }
 ```
 
-當然，Drogon也提供了一些函數，使使用者可以在main()函數中直接添​​加控制器邏輯，比如，使用者可以註冊一個lambda處理器到drogon框架中，如下所示：
+當然，Drogon 也提供了一些函式，讓使用者可以在 `main()` 函式中直接加入控制器邏輯，例如，使用者可以註冊一個 lambda 處理常式到 drogon 框架中，如下所示：
 
 ```c++
 app().registerHandler("/test?username={name}",
@@ -86,9 +87,7 @@ app().registerHandler("/test?username={name}",
                     {Get,"LoginFilter"});
 ```
 
-
-這看起來是很方便，但是這並不適用於復雜的場景，試想假如有數十個或者數百個處理函數要註冊進框架，main()函數將膨脹到不可讀的程度。顯然，讓每個包含處理函數的類在自己的定義中完成註冊是更好的選擇。所以，除非你的應用邏輯非常簡單，我們不推薦使用上述接口，更好的實踐是，我們可以創造一個HttpSimpleController類別，如下：
-
+這看起來很方便，但不適用於複雜的場景，試想如果有數十個或數百個處理函式要註冊進框架，`main()` 函式將變得難以閱讀。顯然，讓每個包含處理函式的類別在自己的定義中完成註冊是更好的選擇。所以，除非你的應用邏輯非常簡單，我們不建議使用上述介面，更好的做法是建立一個 HttpSimpleController 類別，如下：
 
 ```c++
 /// The TestCtrl.h file
@@ -117,9 +116,9 @@ void TestCtrl::asyncHandleHttpRequest(const HttpRequestPtr& req,
 }
 ```
 
-**上面程式的大部分程式碼都可以由`drogon_ctl`指令創造**（這個指令是`drogon_ctl create controller TestCtr`）。使用者所需做的就是添加自己的業務邏輯。在這個例子中，當客戶端訪問URL`http://ip/test`時，控制器簡單的回傳了一個`Hello, world!`頁面。
+**上述程式的大部分程式碼都可以由 `drogon_ctl` 指令產生**（使用指令 `drogon_ctl create controller TestCtr`）。使用者只需要加入自己的業務邏輯。在這個範例中，當用戶端存取 URL `http://ip/test` 時，控制器簡單地回傳一個 `Hello, world!` 頁面。
 
-對於JSON格式的回應，我們可以像下面這樣創造控制器：
+對於 JSON 格式的回應，我們可以這樣建立控制器：
 
 ```c++
 /// The header file
@@ -148,7 +147,7 @@ void JsonCtrl::asyncHandleHttpRequest(const HttpRequestPtr &req,
 }
 ```
 
-讓我們更進一步，通過HttpController類別創造一個RESTful API的例子，如下所示（忽略了實做文件）：
+讓我們更進一步，透過 HttpController 類別建立一個 RESTful API 的範例，如下所示（省略實作檔案）：
 
 ```c++
 /// The header file
@@ -182,18 +181,18 @@ class User : public drogon::HttpController<User>
 } // namespace api
 ```
 
-如你所見，通過`HttpController`類別，使用者可以同時映射路徑和路徑參數，這對RESTful API應用來說非常方便。
+如你所見，透過 `HttpController` 類別，使用者可以同時對應路徑和路徑參數，這對 RESTful API 應用來說非常方便。
 
-另外，你可以發現前面所有的處理函數接口都是異步的，處理器的回應是通過回調對象回傳的。這種設計是出於對高性能的考慮，因為在異步模式下，可以使用少量的執行序（比如和處理器核心數相等的執行序）處理大量的並發請求。
+另外，你可以發現前面所有的處理函式介面都是非同步的，處理器的回應是透過回呼物件回傳的。這種設計是考慮到效能，因為在非同步模式下，可以使用少量的執行緒（例如和處理器核心數相等的執行緒）處理大量的並行請求。
 
-編譯上述的所有源文件後，我們得到了一個非常簡單的web應用程式，這是一個不錯的開始。 **請瀏覽GitHub上的[文檔](https://drogonframework.github.io/drogon-docs/#/CHN/CHN-01-%E6%A6%82%E8%BF%B0)**
+編譯上述所有原始檔案後，我們得到了一個非常簡單的網頁應用程式，這是一個不錯的開始。**請瀏覽 GitHub 上的[文件](https://drogonframework.github.io/drogon-docs/#/CHN/CHN-01-%E6%A6%82%E8%BF%B0)**
 
 ## 貢獻方式
 
-歡迎您的貢獻。請閱讀[貢獻指南](CONTRIBUTING.md)以獲取更多的信息。
+歡迎您的貢獻。請閱讀[貢獻指南](CONTRIBUTING.md)以取得更多資訊。
 
 <a href="https://github.com/drogonframework/drogon/graphs/contributors"><img src="https://contributors-svg.opencollective.com/drogon/contributors.svg?width=890&button=false" alt="Code contributors" /></a>
 
-## QQ交流群：1137909452
+## QQ 交流群：1137909452
 
-歡迎交流探討。
+歡迎交流討論。


### PR DESCRIPTION
Add spacing and correct some term usage in Taiwan.

-  The dictionary was referenced from <https://zhconvert.org/>.
-  The [spacing](https://github.com/sparanoid/chinese-copywriting-guidelines) and some rewrites were done by [Claude](https://claude.ai).
-  I have reviewed and corrected (rollbacked) changes made by AI.

It is recommended to have other native Chinese (Taiwan) speakers review it.