### PR TITLE
Make HttpAppFrameworkImpl::quit() safe

### DIFF
--- a/lib/src/HttpAppFrameworkImpl.cc
+++ b/lib/src/HttpAppFrameworkImpl.cc
@@ -1033,7 +1033,7 @@ HttpAppFramework &HttpAppFrameworkImpl::createRedisClient(
 
 void HttpAppFrameworkImpl::quit()
 {
-    if (getLoop()->isRunning())
+    if (getLoop()->isRunning() && running_.exchange(false))
     {
         getLoop()->queueInLoop([this]() {
             // Release members in the reverse order of initialization
@@ -1044,7 +1044,6 @@ void HttpAppFrameworkImpl::quit()
             pluginsManagerPtr_.reset();
             redisClientManagerPtr_.reset();
             dbClientManagerPtr_.reset();
-            running_ = false;
             getLoop()->quit();
             for (trantor::EventLoop *loop : ioLoopThreadPool_->getLoops())
             {


### PR DESCRIPTION
### Description:
It is possible to call `HttpAppFrameworkImpl::quit()` 2 times in a row directly or in the default signal handler.

Calling such code:
```cpp
       app().quit();
       app().quit();
```

Execues double calling of such code in internal lambda:
```cpp
    listenerManagerPtr_->stopListening();
    listenerManagerPtr_.reset();
```

And it leads to undefined behavior.

### Fix:
Atomically check and set `running_` flag earlier before queuing the lambda that resets pointers.
