### PR TITLE
bugfix/fix-missing-include

### DIFF
--- a/drogon_ctl/create_view.cc
+++ b/drogon_ctl/create_view.cc
@@ -411,6 +411,7 @@ void create_view::newViewSourceFile(std::ofstream &file,
             "automatically,don't modify it!\n";
     file << "#include \"" << namespacePrefix << className << ".h\"\n";
     file << "#include <drogon/utils/OStringStream.h>\n";
+    file << "#include <drogon/utils/Utilities.h>\n";
     file << "#include <string>\n";
     file << "#include <map>\n";
     file << "#include <vector>\n";


### PR DESCRIPTION
Fixes a missing include in drogon_ctl generated view code.