### PR TITLE
fix: Fix a bug in isAutoCreationClass<T>.

### DIFF
--- a/lib/inc/drogon/DrObject.h
+++ b/lib/inc/drogon/DrObject.h
@@ -61,9 +61,9 @@ template <typename T>
 struct isAutoCreationClass
 {
     template <class C>
-    static constexpr auto check(C *)
-        -> std::enable_if_t<std::is_same_v<decltype(C::isAutoCreation), bool>,
-                            bool>
+    static constexpr auto check(C *) -> std::enable_if_t<
+        std::is_same_v<decltype(C::isAutoCreation), const bool>,
+        bool>
     {
         return C::isAutoCreation;
     }

--- a/lib/tests/unittests/DrObjectTest.cc
+++ b/lib/tests/unittests/DrObjectTest.cc
@@ -62,8 +62,8 @@ class TestE : public DrObject<TestE>
 
 DROGON_TEST(IsAutoCreationClassTest)
 {
-    CHECK(isAutoCreationClass<TestA>::value == false);
-    CHECK(isAutoCreationClass<TestC>::value == true);
-    CHECK(isAutoCreationClass<TestD>::value == false);
-    CHECK(isAutoCreationClass<TestE>::value == false);
+    STATIC_REQUIRE(isAutoCreationClass<TestA>::value == false);
+    STATIC_REQUIRE(isAutoCreationClass<TestC>::value == true);
+    STATIC_REQUIRE(isAutoCreationClass<TestD>::value == false);
+    STATIC_REQUIRE(isAutoCreationClass<TestE>::value == false);
 }

--- a/lib/tests/unittests/DrObjectTest.cc
+++ b/lib/tests/unittests/DrObjectTest.cc
@@ -41,3 +41,29 @@ DROGON_TEST(DrObjectNamespaceTest)
     CHECK(objPtr2.get() != nullptr);
     CHECK(objPtr == objPtr2);
 }
+
+class TestC : public DrObject<TestC>
+{
+  public:
+    static constexpr bool isAutoCreation = true;
+};
+
+class TestD : public DrObject<TestD>
+{
+  public:
+    static constexpr bool isAutoCreation = false;
+};
+
+class TestE : public DrObject<TestE>
+{
+  public:
+    static constexpr double isAutoCreation = 3.0;
+};
+
+DROGON_TEST(IsAutoCreationClassTest)
+{
+    CHECK(isAutoCreationClass<TestA>::value == false);
+    CHECK(isAutoCreationClass<TestC>::value == true);
+    CHECK(isAutoCreationClass<TestD>::value == false);
+    CHECK(isAutoCreationClass<TestE>::value == false);
+}

--- a/lib/tests/unittests/DrObjectTest.cc
+++ b/lib/tests/unittests/DrObjectTest.cc
@@ -1,5 +1,6 @@
 #include <drogon/DrObject.h>
 #include <drogon/drogon_test.h>
+#include <drogon/HttpController.h>
 
 using namespace drogon;
 
@@ -60,10 +61,26 @@ class TestE : public DrObject<TestE>
     static constexpr double isAutoCreation = 3.0;
 };
 
+class CtrlA : public HttpController<CtrlA>
+{
+  public:
+    METHOD_LIST_BEGIN
+    METHOD_LIST_END
+};
+
+class CtrlB : public HttpController<CtrlB, false>
+{
+  public:
+    METHOD_LIST_BEGIN
+    METHOD_LIST_END
+};
+
 DROGON_TEST(IsAutoCreationClassTest)
 {
     STATIC_REQUIRE(isAutoCreationClass<TestA>::value == false);
     STATIC_REQUIRE(isAutoCreationClass<TestC>::value == true);
     STATIC_REQUIRE(isAutoCreationClass<TestD>::value == false);
     STATIC_REQUIRE(isAutoCreationClass<TestE>::value == false);
+    STATIC_REQUIRE(isAutoCreationClass<CtrlA>::value == true);
+    STATIC_REQUIRE(isAutoCreationClass<CtrlB>::value == false);
 }


### PR DESCRIPTION
在 `DrObject::DrAllocator::registerClass()` 中的 `else if` 分支，`isAutoCreationClass<D>::value` 总会是 `false` ，因为其内部的偏特化始终没有被使用。
测试代码：
```cpp
#include <drogon/DrObject.h>
using namespace drogon;

class A
{
};

class B
{
  public:
    static constexpr bool isAutoCreation = true;
};

class C
{
  public:
    static constexpr bool isAutoCreation = false;
};

class D
{
  public:
    static constexpr double isAutoCreation = 3.0;
};

int main()
{
    if constexpr (isAutoCreationClass<A>::value)
    {
        std::cout << "A" << std::endl;
    }
    // only this case will be true
    if constexpr (isAutoCreationClass<B>::value)
    {
        std::cout << "B" << std::endl;
    }
    if constexpr (isAutoCreationClass<C>::value)
    {
        std::cout << "C" << std::endl;
    }
    if constexpr (isAutoCreationClass<D>::value)
    {
        std::cout << "D" << std::endl;
    }
    return 0;
}
```