### PR TITLE
Improved Postgres connection stability

### DIFF
--- a/orm_lib/src/DbClientImpl.cc
+++ b/orm_lib/src/DbClientImpl.cc
@@ -429,7 +429,7 @@ DbConnectionPtr DbClientImpl::newConnection(trantor::EventLoop *loop)
         }
         // Reconnect after 1 second
         auto loop = closeConnPtr->loop();
-        // Old connection is not valid. Close the connection file descriptor.
+        // closeConnPtr may be not valid. Close the connection file descriptor.
         closeConnPtr->disconnect();
         loop->runAfter(1, [weakPtr, loop, closeConnPtr] {
             auto thisPtr = weakPtr.lock();

--- a/orm_lib/src/DbClientImpl.cc
+++ b/orm_lib/src/DbClientImpl.cc
@@ -429,6 +429,8 @@ DbConnectionPtr DbClientImpl::newConnection(trantor::EventLoop *loop)
         }
         // Reconnect after 1 second
         auto loop = closeConnPtr->loop();
+        // Old connection is closed. Close the connection file descriptor now.
+        closeConnPtr->disconnect();
         loop->runAfter(1, [weakPtr, loop, closeConnPtr] {
             auto thisPtr = weakPtr.lock();
             if (!thisPtr)

--- a/orm_lib/src/DbClientImpl.cc
+++ b/orm_lib/src/DbClientImpl.cc
@@ -429,7 +429,7 @@ DbConnectionPtr DbClientImpl::newConnection(trantor::EventLoop *loop)
         }
         // Reconnect after 1 second
         auto loop = closeConnPtr->loop();
-        // Old connection is closed. Close the connection file descriptor now.
+        // Old connection is not valid. Close the connection file descriptor.
         closeConnPtr->disconnect();
         loop->runAfter(1, [weakPtr, loop, closeConnPtr] {
             auto thisPtr = weakPtr.lock();


### PR DESCRIPTION
This PR improves connection with PostgreSQL server stability. 

1) handleFatalException can be called several times in this code during the loop:
https://github.com/drogonframework/drogon/blob/1fb67d68be0d4426359e1c385cd6c2e67e7fd2bd/orm_lib/src/postgresql_impl/PgConnection.cc#L319-L331

So I added nullptr check before calling `exceptionCallback_ `

2) Added explicit `closeConnPtr->disconnect()` before the creation of a new connection. `PQsocket`  function may return the same file descriptor ID as for a previously created connection.
In this scenario:
*) Postgres server is not running.
*) Drogon application runs and tries to connect with Postgres.
*) File descriptor is still placed in the channels_ map in `channels_`  in class `EpollPoller`.  But it is invalid.
*) Drogon fails to connect to the postgres and adds a timer event that creates a new postgres connection. PQsocket returns the same file descriptor ID for this connection.
*) Assertion happens here:
https://github.com/an-tao/trantor/blob/14471b5dfc208b6b454f824cbd760f971739da97/trantor/net/inner/poller/EpollPoller.cc#L147-L152


This fix removes the file descriptor from `channels_` map by explicitly calling  
```cpp
closeConnPtr->disconnect();
```

3) Added  better protection from invalid file descriptors: ` PQsocket` also may return -1.  to avoid executing assertion like that:
```cpp
    assert(channel->fd() >= 0);
```
 

