### PR TITLE
Added handleFatalError in handleClosed

### DIFF
--- a/orm_lib/src/DbConnection.h
+++ b/orm_lib/src/DbConnection.h
@@ -118,7 +118,7 @@ class DbConnection : public trantor::NonCopyable
 
     virtual ~DbConnection()
     {
-        LOG_TRACE << "Destruct DbConn" << this;
+        LOG_TRACE << "Destruct DbConn " << this;
     }
 
     ConnectStatus status() const

--- a/orm_lib/src/postgresql_impl/PgConnection.cc
+++ b/orm_lib/src/postgresql_impl/PgConnection.cc
@@ -136,7 +136,7 @@ void PgConnection::handleClosed()
 
     if (isWorking_)
     {
-        // Connection was closed unexpectedly while isWorking_ were true.
+        // Connection was closed unexpectedly while isWorking_ was true.
         isWorking_ = false;
         handleFatalError();
         callback_ = nullptr;

--- a/orm_lib/src/postgresql_impl/PgConnection.cc
+++ b/orm_lib/src/postgresql_impl/PgConnection.cc
@@ -136,7 +136,7 @@ void PgConnection::handleClosed()
 
     if (isWorking_)
     {
-        // Connection was closed unexpectedly during isWorking_ while were true.
+        // Connection was closed unexpectedly while isWorking_ were true.
         isWorking_ = false;
         handleFatalError();
         callback_ = nullptr;

--- a/orm_lib/src/postgresql_impl/PgConnection.cc
+++ b/orm_lib/src/postgresql_impl/PgConnection.cc
@@ -133,6 +133,15 @@ void PgConnection::handleClosed()
     if (status_ == ConnectStatus::Bad)
         return;
     status_ = ConnectStatus::Bad;
+
+    if (isWorking_)
+    {
+        // Connection was closed unexpectedly during isWorking_ while were true.
+        isWorking_ = false;
+        handleFatalError();
+        callback_ = nullptr;
+    }
+
     channel_.disableAll();
     channel_.remove();
     assert(closeCallback_);
@@ -406,10 +415,13 @@ void PgConnection::doAfterPreparing()
 
 void PgConnection::handleFatalError()
 {
-    auto exceptPtr =
-        std::make_exception_ptr(Failure(PQerrorMessage(connectionPtr_.get())));
     if (exceptionCallback_)
+    {
+        auto exceptPtr = std::make_exception_ptr(
+            Failure(PQerrorMessage(connectionPtr_.get())));
         exceptionCallback_(exceptPtr);
+    }
+
     exceptionCallback_ = nullptr;
 }
 


### PR DESCRIPTION
##Problem
`exceptionCallback_` was not called after the connection was closed

Steps to reproduce:
1) Execute some query like `SELECT 1`.
2) Right after the query was sent but the result was not received, stop the PostgreSQL server. Actually, I had this in Postgres logs:
```
2025-04-14 12:41:49.350 UTC [1] LOG:  server process (PID 33426) was terminated by signal 1: Hangup
2025-04-14 12:41:49.350 UTC [1] LOG:  terminating any other active server processes
2025-04-14 12:41:49.834 UTC [1] LOG:  all server processes terminated; reinitializing
2025-04-14 12:41:51.849 UTC [33518] LOG:  database system was interrupted; last known up at 2025-04-14 12:37:58 UTC
2025-04-14 12:41:51.851 UTC [33524] LOG:  connection received: <hidden>
2025-04-14 12:41:51.851 UTC [33526] LOG:  connection received: <hidden>
2025-04-14 12:41:51.851 UTC [33527] LOG:  connection received: <hidden>
2025-04-14 12:41:51.851 UTC [33521] LOG:  connection received: <hidden>
2025-04-14 12:41:51.851 UTC [33522] LOG:  connection received: <hidden>
2025-04-14 12:41:51.851 UTC [33523] LOG:  connection received: <hidden>
2025-04-14 12:41:51.851 UTC [33528] LOG:  connection received: <hidden>
2025-04-14 12:41:51.851 UTC [33525] LOG:  connection received: <hidden>
2025-04-14 12:41:51.852 UTC [33529] LOG:  connection received: <hidden>
2025-04-14 12:41:51.852 UTC [33527] FATAL:  the database system is in recovery mode
```
3) I got `exceptionCallback_`  not called, but `handleClosed()` was (then connection object is destroyed and `drogon::TaskTimeoutFlag` in DBClient is also destroyed)
4) Client hung forever.

I'm not sure that this fix is absolutely correct. The problem is very hard to reproduce, it's very infrequent.

OS:
```
$ lsb_release -a
No LSB modules are available.
Distributor ID: Ubuntu
Description:    Ubuntu 22.04.5 LTS
Release:        22.04
Codename:       jammy
```
