### PR TITLE
For Jsoncpp support, make sure include directories are present

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -188,7 +188,7 @@ endif()
 
 # jsoncpp
 find_package(Jsoncpp REQUIRED)
-target_link_libraries(${PROJECT_NAME} PUBLIC Jsoncpp_lib)
+target_link_libraries(${PROJECT_NAME} PUBLIC JsonCpp::JsonCpp)
 list(APPEND INCLUDE_DIRS_FOR_DYNAMIC_VIEW ${JSONCPP_INCLUDE_DIRS})
 
 # yamlcpp


### PR DESCRIPTION
link the cmake target instead of just the libs so we get the include path as well.