### PR TITLE
added -o|--output option to drogon_ctl create models

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- dg_ctl create models new command line option -o | --output
+
 ## [1.9.10] - 2025-02-20
 
 ### API changes list

--- a/drogon_ctl/create.cc
+++ b/drogon_ctl/create.cc
@@ -42,7 +42,8 @@ std::string create::detail()
            "create a plugin named class_name\n\n"
            "drogon_ctl create project <project_name> //"
            "create a project named project_name\n\n"
-           "drogon_ctl create model <model_path> [--table=<table_name>] [-f]//"
+           "drogon_ctl create model <model_path> [-o <output path>] "
+           "[--table=<table_name>] [-f]//"
            "create model classes in model_path\n";
 }
 

--- a/drogon_ctl/create_model.cc
+++ b/drogon_ctl/create_model.cc
@@ -826,6 +826,7 @@ void create_model::createModel(const std::string &path,
     auto restfulApiConfig = config["restful_api_controllers"];
     auto relationships = getRelationships(config["relationships"]);
     auto convertMethods = getConvertMethods(config["convert"]);
+    drogon::utils::createPath(path);
     if (dbType == "postgresql")
     {
 #if USE_POSTGRESQL
@@ -1173,7 +1174,9 @@ void create_model::createModel(const std::string &path,
         try
         {
             infile >> configJsonRoot;
-            createModel(path, configJsonRoot, singleModelName);
+            createModel(outputPath_.empty() ? path : outputPath_,
+                        configJsonRoot,
+                        singleModelName);
         }
         catch (const std::exception &exception)
         {
@@ -1211,6 +1214,21 @@ void create_model::handleCommand(std::vector<std::string> &parameters)
             break;
         }
     }
+    for (auto iter = parameters.begin(); iter != parameters.end(); ++iter)
+    {
+        auto &file = *iter;
+        if (file == "-o" || file == "--output")
+        {
+            iter = parameters.erase(iter);
+            if (iter != parameters.end())
+            {
+                outputPath_ = *iter;
+                iter = parameters.erase(iter);
+            }
+            continue;
+        }
+    }
+
     for (auto const &path : parameters)
     {
         createModel(path, singleModelName);

--- a/drogon_ctl/create_model.h
+++ b/drogon_ctl/create_model.h
@@ -429,5 +429,6 @@ class create_model : public DrObject<create_model>, public CommandHandler
                                     const Json::Value &restfulApiConfig);
     std::string dbname_;
     bool forceOverwrite_{false};
+    std::string outputPath_;
 };
 }  // namespace drogon_ctl


### PR DESCRIPTION
The goal of this pull request is to provide a way to install generated models in a different folder then the model path