### PR TITLE
dg_ctl: fix segfault when using --output option

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+
+### Fixed
+
+- dg_ctl fix segfault when create models is called with --output
+
 ### Added
 
 - dg_ctl create models new command line option -o | --output

--- a/drogon_ctl/create_model.cc
+++ b/drogon_ctl/create_model.cc
@@ -1214,7 +1214,7 @@ void create_model::handleCommand(std::vector<std::string> &parameters)
             break;
         }
     }
-    for (auto iter = parameters.begin(); iter != parameters.end(); ++iter)
+    for (auto iter = parameters.begin(); iter != parameters.end();)
     {
         auto &file = *iter;
         if (file == "-o" || file == "--output")
@@ -1227,6 +1227,7 @@ void create_model::handleCommand(std::vector<std::string> &parameters)
             }
             continue;
         }
+        ++iter;
     }
 
     for (auto const &path : parameters)


### PR DESCRIPTION
dg_ctl segfault if  if models.json path is set before --output (ie drogon_ctl  create model PATH_TO_JSON --output OUTPUT_FOLDER)
iterator was past parameters.end() but we still performed iter++