### PR TITLE
Fix compile warning

### DIFF
--- a/lib/inc/drogon/HttpAppFramework.h
+++ b/lib/inc/drogon/HttpAppFramework.h
@@ -43,14 +43,14 @@
 #include <vector>
 #include <chrono>
 
-#if defined(__APPLE__) && defined(__MACH__)
-#if defined(__ENVIRONMENT_IPHONE_OS__) || \
-    defined(__IPHONE_OS_VERSION_MIN_REQUIRED)
+#if defined(__APPLE__) && defined(__MACH__) && \
+    (defined(__ENVIRONMENT_IPHONE_OS__) || \
+     defined(__IPHONE_OS_VERSION_MIN_REQUIRED))
 // iOS
 #define TARGET_OS_IOS 1
-#elif defined(__MAC_OS_X_VERSION_MIN_REQUIRED)
-// macOS
-#endif
+#else
+// not iOS
+#define TARGET_OS_IOS 0
 #endif
 
 namespace drogon

--- a/lib/src/StaticFileRouter.cc
+++ b/lib/src/StaticFileRouter.cc
@@ -44,7 +44,7 @@ void StaticFileRouter::init(const std::vector<trantor::EventLoop *> &ioLoops)
                    size_t i) {
             assert(i == ioLoops[i]->index());
             mapPtr = std::make_unique<CacheMap<std::string, char>>(ioLoops[i],
-                                                                   1.0,
+                                                                   1.0f,
                                                                    4,
                                                                    50);
         });


### PR DESCRIPTION
#2307 introduces a macro that indicates whether the environment is iOS. However, under macOS, the macro is not defined, and the compiler will warn.

```text
/Users/runner/work/drogon/drogon/lib/inc/drogon/HttpAppFramework.h:1011:26: warning: 'TARGET_OS_IOS' is not defined, evaluates to 0 [-Wundef-prefix=TARGET_OS_]
#if !defined(_WIN32) && !TARGET_OS_IOS
                         ^
In file included from /Users/runner/work/drogon/drogon/lib/src/ConfigLoader.cc:16:
/Users/runner/work/drogon/drogon/lib/src/HttpAppFrameworkImpl.h:270:26: warning: 'TARGET_OS_IOS' is not defined, evaluates to 0 [-Wundef-prefix=TARGET_OS_]
#if !defined(_WIN32) && !TARGET_OS_IOS
                         ^
/Users/runner/work/drogon/drogon/lib/src/HttpAppFrameworkImpl.h:712:26: warning: 'TARGET_OS_IOS' is not defined, evaluates to 0 [-Wundef-prefix=TARGET_OS_]
#if !defined(_WIN32) && !TARGET_OS_IOS
                         ^
/Users/runner/work/drogon/drogon/lib/src/ConfigLoader.cc:386:26: warning: 'TARGET_OS_IOS' is not defined, evaluates to 0 [-Wundef-prefix=TARGET_OS_]
#if !defined(_WIN32) && !TARGET_OS_IOS
                         ^
4 warnings generated.
```

The first commit makes the `TARGET_OS_IOS` macro available on all the OS.

When compiling on Windows, the compiler warns that.

```text
C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.43.34808\include\memory(3594,56): warning C4244: 'argument': conversion from '_Ty' to 'float', possible loss of data [D:\a\drogon\drogon\build\drogon.vcxproj]
C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.43.34808\include\memory(3594,56): warning C4244:         with [D:\a\drogon\drogon\build\drogon.vcxproj]
C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.43.34808\include\memory(3594,56): warning C4244:         [ [D:\a\drogon\drogon\build\drogon.vcxproj]
C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.43.34808\include\memory(3594,56): warning C4244:             _Ty=double [D:\a\drogon\drogon\build\drogon.vcxproj]
C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.43.34808\include\memory(3594,56): warning C4244:         ] [D:\a\drogon\drogon\build\drogon.vcxproj]
  (compiling source file '../../../../lib/src/StaticFileRouter.cc')
      C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.43.34808\include\memory(3594,56):
      the template instantiation context (the oldest one first) is
          D:\a\drogon\drogon\lib\src\StaticFileRouter.cc(46,27):
          see reference to function template instantiation 'std::unique_ptr<drogon::CacheMap<std::string,char>,std::default_delete<drogon::CacheMap<std::string,char>>> std::make_unique<drogon::CacheMap<std::string,char>,const _Ty&,double,int,int,0>(const _Ty &,double &&,int &&,int &&)' being compiled
          with
          [
              _Ty=trantor::EventLoop *
          ]
```

The second commit changes `1.0` to `float` for avoiding the warning.