### PR TITLE
Adding unix timestamp to executable name on projects with name that conflicts with items on project root

### DIFF
--- a/drogon_ctl/templates/cmake.csp
+++ b/drogon_ctl/templates/cmake.csp
@@ -1,6 +1,16 @@
 cmake_minimum_required(VERSION 3.5)
 project([[ProjectName]] CXX)
 
+set(EXECUTABLE_NAME ${PROJECT_NAME})
+
+# Check if a file or directory exists in the current source dir with the same name
+set(CONFLICT_PATH "${CMAKE_CURRENT_SOURCE_DIR}/${PROJECT_NAME}")
+if (EXISTS "${CONFLICT_PATH}")
+    string(TIMESTAMP BUILD_TIMESTAMP "%s" UTC)
+    set(EXECUTABLE_NAME "${PROJECT_NAME}_${BUILD_TIMESTAMP}")
+    message(WARNING "A file or directory named '${PROJECT_NAME}' exists. Renaming executable to: ${EXECUTABLE_NAME}")
+endif ()
+
 include(CheckIncludeFileCXX)
 
 check_include_file_cxx(any HAS_ANY)
@@ -19,17 +29,17 @@ endif ()
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-add_executable(${PROJECT_NAME} main.cc)
+add_executable(${EXECUTABLE_NAME} main.cc)
 
 # ##############################################################################
 # If you include the drogon source code locally in your project, use this method
 # to add drogon 
 # add_subdirectory(drogon) 
-# target_link_libraries(${PROJECT_NAME} PRIVATE drogon)
+# target_link_libraries(${EXECUTABLE_NAME} PRIVATE drogon)
 #
 # and comment out the following lines
 find_package(Drogon CONFIG REQUIRED)
-target_link_libraries(${PROJECT_NAME} PRIVATE Drogon::Drogon)
+target_link_libraries(${EXECUTABLE_NAME} PRIVATE Drogon::Drogon)
 
 # ##############################################################################
 
@@ -46,20 +56,20 @@ aux_source_directory(filters FILTER_SRC)
 aux_source_directory(plugins PLUGIN_SRC)
 aux_source_directory(models MODEL_SRC)
 
-drogon_create_views(${PROJECT_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/views
+drogon_create_views(${EXECUTABLE_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/views
                     ${CMAKE_CURRENT_BINARY_DIR})
 # use the following line to create views with namespaces.
-# drogon_create_views(${PROJECT_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/views
+# drogon_create_views(${EXECUTABLE_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/views
 #                     ${CMAKE_CURRENT_BINARY_DIR} TRUE)
 # use the following line to create views with namespace CHANGE_ME prefixed
 # and path namespaces.
-# drogon_create_views(${PROJECT_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/views
+# drogon_create_views(${EXECUTABLE_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/views
 #                     ${CMAKE_CURRENT_BINARY_DIR} TRUE CHANGE_ME)
 
-target_include_directories(${PROJECT_NAME}
+target_include_directories(${EXECUTABLE_NAME}
                            PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
                                    ${CMAKE_CURRENT_SOURCE_DIR}/models)
-target_sources(${PROJECT_NAME}
+target_sources(${EXECUTABLE_NAME}
                PRIVATE
                ${SRC_DIR}
                ${CTL_SRC}
@@ -68,7 +78,7 @@ target_sources(${PROJECT_NAME}
                ${MODEL_SRC})
 # ##############################################################################
 # uncomment the following line for dynamically loading views 
-# set_property(TARGET ${PROJECT_NAME} PROPERTY ENABLE_EXPORTS ON)
+# set_property(TARGET ${EXECUTABLE_NAME} PROPERTY ENABLE_EXPORTS ON)
 
 # ##############################################################################
 


### PR DESCRIPTION
Good evening. This PR concerns this issue: https://github.com/drogonframework/drogon/issues/2370

The solution I found to avoid conflict between the generated executable file and the various folders and files on the drogon_ctl generated project root folder was to add a `_<unix_timestamp>` to it.