### PR TITLE
changing std::string to a more multibyte-friendly format

### DIFF
--- a/drogon_ctl/templates/model_cc.csp
+++ b/drogon_ctl/templates/model_cc.csp
@@ -1539,14 +1539,14 @@ if(!col.notNull_){%>
                 if(col.colType_ == "std::string" && col.colLength_>0)
                 {
 %>
-            if(pJson.isString() && std::strlen(pJson.asCString()) > {%col.colLength_%})
+            if(pJson.isString() && std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>, wchar_t>{}
+                .from_bytes(pJson.asCString()).size() > {%col.colLength_%})
             {
                 err="String length exceeds limit for the " +
                     fieldName +
                     " field (the maximum value is {%col.colLength_%})";
                 return false;
             }
-
 <%c++
                 }
             }


### PR DESCRIPTION
Good evening. This PR concerns the following issue: https://github.com/drogonframework/drogon/issues/2371

I tried doing with the `size()` function as a regular std::string, like the OP in the issue said, but it still showed the wrong string length. After converting it, though, the correct size was shown.