### PR TITLE
Fix warnings - for range loop no copies, unsigned int always >= 0

### DIFF
--- a/lib/src/AccessLogger.cc
+++ b/lib/src/AccessLogger.cc
@@ -260,10 +260,7 @@ void AccessLogger::initAndStart(const Json::Value &config)
             asyncFileLogger_.setFileSizeLimit(sizeLimit);
         }
         auto maxFiles = config.get("max_files", 0).asUInt();
-        if (maxFiles >= 0)
-        {
-            asyncFileLogger_.setMaxFiles(maxFiles);
-        }
+        asyncFileLogger_.setMaxFiles(maxFiles);
     }
     drogon::app().registerPreSendingAdvice(
         [this](const drogon::HttpRequestPtr &req,

--- a/lib/src/HttpAppFrameworkImpl.cc
+++ b/lib/src/HttpAppFrameworkImpl.cc
@@ -376,7 +376,7 @@ void HttpAppFrameworkImpl::addPlugin(
     Json::Value pluginConfig;
     pluginConfig["name"] = name;
     Json::Value deps(Json::arrayValue);
-    for (const auto dep : dependencies)
+    for (const auto &dep : dependencies)
     {
         deps.append(dep);
     }
@@ -391,7 +391,7 @@ void HttpAppFrameworkImpl::addPlugins(const Json::Value &configs)
     assert(!isRunning());
     assert(configs.isArray());
     auto &plugins = jsonRuntimeConfig_["plugins"];
-    for (const auto config : configs)
+    for (const auto &config : configs)
     {
         plugins.append(config);
     }


### PR DESCRIPTION
Fix the following warnings:

```
[build] drogon-src/lib/src/AccessLogger.cc: In member function ‘virtual void drogon::plugin::AccessLogger::initAndStart(const Json::Value&)’:
[build] drogon-src/lib/src/AccessLogger.cc:263:22: warning: comparison of unsigned expression in ‘>= 0’ is always true [-Wtype-limits]
[build]   263 |         if (maxFiles >= 0)
[build]       |             ~~~~~~~~~^~~~
[build] [801/824  94% :: 40.337] Building CXX object _deps/drogon-build/CMakeFiles/drogon.dir/lib/src/HttpAppFrameworkImpl.cc.o
[build] drogon-src/lib/src/HttpAppFrameworkImpl.cc: In member function ‘virtual void drogon::HttpAppFrameworkImpl::addPlugin(const std::string&, const std::vector<std::__cxx11::basic_string<char> >&, const Json::Value&)’:
[build] drogon-src/lib/src/HttpAppFrameworkImpl.cc:379:21: warning: loop variable ‘dep’ creates a copy from type ‘const std::__cxx11::basic_string<char>’ [-Wrange-loop-construct]
[build]   379 |     for (const auto dep : dependencies)
[build]       |                     ^~~
[build] drogon-src/lib/src/HttpAppFrameworkImpl.cc:379:21: note: use reference type to prevent copying
[build]   379 |     for (const auto dep : dependencies)
[build]       |                     ^~~
[build]       |                     &
[build] drogon-src/lib/src/HttpAppFrameworkImpl.cc: In member function ‘virtual void drogon::HttpAppFrameworkImpl::addPlugins(const Json::Value&)’:
[build] drogon-src/lib/src/HttpAppFrameworkImpl.cc:394:21: warning: loop variable ‘config’ creates a copy from type ‘const Json::Value’ [-Wrange-loop-construct]
[build]   394 |     for (const auto config : configs)
[build]       |                     ^~~~~~
[build] drogon-src/lib/src/HttpAppFrameworkImpl.cc:394:21: note: use reference type to prevent copying
[build]   394 |     for (const auto config : configs)
[build]       |                     ^~~~~~
[build]       |                     &
```