### PR TITLE
Enhance error handling in CacheFile methods

### DIFF
--- a/lib/src/CacheFile.cc
+++ b/lib/src/CacheFile.cc
@@ -36,6 +36,8 @@ CacheFile::CacheFile(const std::string &path, bool autoDelete)
         file_ = nullptr;
     }
 #endif
+    if (!file_)
+        LOG_SYSERR << "CacheFile fopen:";
 }
 
 CacheFile::~CacheFile()
@@ -63,7 +65,10 @@ CacheFile::~CacheFile()
 void CacheFile::append(const char *data, size_t length)
 {
     if (file_)
-        fwrite(data, length, 1, file_);
+    {
+        if (!fwrite(data, length, 1, file_))
+            LOG_SYSERR << "CacheFile append:";
+    }
 }
 
 size_t CacheFile::length()
@@ -95,7 +100,7 @@ char *CacheFile::data()
         if (data_ == MAP_FAILED)
         {
             data_ = nullptr;
-            LOG_SYSERR << "mmap:";
+            LOG_SYSERR << "CacheFile mmap:";
         }
     }
     return data_;


### PR DESCRIPTION
Add error logging for file operations in CacheFile.

Hi,
We faced a big issue where some foreign scripts delete the Drogon upload folder.
We searched a while before finding the problem. Here, as least, a log of the Cachefile would have helped us much.

Thats's why I want to submit you 2 more "Trantor" logs (create and append to cache file).
**Ideally**, the server should return an error 500 if the cache file can't be opened or written ? But a log is a first start I think ?

Best Regards,
Patrick Colis
Zenom-Media GmbH
