### PR TITLE
Redirect to path+/ if path doesn't end with /

### DIFF
--- a/lib/src/StaticFileRouter.cc
+++ b/lib/src/StaticFileRouter.cc
@@ -169,7 +169,18 @@ void StaticFileRouter::route(
             if (std::filesystem::is_directory(fsFilePath, err))
             {
                 // Check if path is eligible for an implicit index.html
-                if (implicitPageEnable_)
+                if (implicitPageEnable_ && req->path().back() != '/')
+                {
+                    std::string newLocation = req->path() + "/";
+                    if (!req->query().empty())
+                    {
+                        newLocation += "?" + req->query();
+                    }
+                    callback(HttpResponse::newRedirectionResponse(
+                        newLocation, k301MovedPermanently));
+                    return;
+                }
+                else if (implicitPageEnable_)
                 {
                     filePath = filePath + "/" + implicitPage_;
                 }
@@ -244,7 +255,19 @@ void StaticFileRouter::route(
         if (std::filesystem::is_directory(fsDirectoryPath, err))
         {
             // Check if path is eligible for an implicit index.html
-            if (implicitPageEnable_)
+            if (implicitPageEnable_ && req->path().back() != '/')
+            {
+                std::string newLocation = req->path() + "/";
+                if (!req->query().empty())
+                {
+                    newLocation += "?" + req->query();
+                }
+                callback(
+                    HttpResponse::newRedirectionResponse(newLocation,
+                                                         k301MovedPermanently));
+                return;
+            }
+            else if (implicitPageEnable_)
             {
                 std::string filePath = directoryPath + "/" + implicitPage_;
                 sendStaticFileResponse(filePath, req, std::move(callback), "");

--- a/lib/tests/integration_test/client/main.cc
+++ b/lib/tests/integration_test/client/main.cc
@@ -673,6 +673,15 @@ void doTest(const HttpClientPtr &client, std::shared_ptr<test::Case> TEST_CTX)
     req = HttpRequest::newHttpRequest();
     req->setMethod(drogon::Get);
     req->setPath("/a-directory");
+    client->sendRequest(
+        req, [req, TEST_CTX](ReqResult result, const HttpResponsePtr &resp) {
+            REQUIRE(result == ReqResult::Ok);
+            CHECK(resp->getStatusCode() == k301MovedPermanently);
+            CHECK(resp->getHeader("Location") == "/a-directory/");
+        });
+    req = HttpRequest::newHttpRequest();
+    req->setMethod(drogon::Get);
+    req->setPath("/a-directory/");
     client->sendRequest(req,
                         [req, TEST_CTX, body](ReqResult result,
                                               const HttpResponsePtr &resp) {


### PR DESCRIPTION
If HTML document uses relative paths, it'll fail to load them otherwise.

$ echo hello > index.html && mkdir test && echo world > test/index.html
$ curl -I http://127.0.0.1:8848
HTTP/1.1 200 OK
content-length: 13
content-type: text/html; charset=utf-8
server: drogon/1.9.11
date: Wed, 26 Nov 2025 13:09:28 GMT

$ curl -I http://127.0.0.1:8848/test
HTTP/1.1 301 Moved Permanently
content-length: 0
content-type: text/html; charset=utf-8
server: drogon/1.9.11
location: /test/
date: Wed, 26 Nov 2025 13:09:33 GMT

$ curl -I http://127.0.0.1:8848/test/
HTTP/1.1 200 OK
content-length: 6
content-type: text/html; charset=utf-8
server: drogon/1.9.11
accept-range: bytes
expires: Thu, 01 Jan 1970 00:00:00 GMT
last-modified: Wed, 26 Nov 2025 13:08:38 GMT
date: Wed, 26 Nov 2025 13:09:34 GMT