### PR TITLE
fixed linker errors for msys2/mingw64 build

### DIFF
--- a/cmake_modules/FindHiredis.cmake
+++ b/cmake_modules/FindHiredis.cmake
@@ -39,3 +39,7 @@ if(Hiredis_FOUND)
             INTERFACE_LINK_LIBRARIES
             "${HIREDIS_LIBRARIES}")
 endif(Hiredis_FOUND)
+
+if(WIN32 AND MINGW)
+        target_link_libraries(Hiredis_lib INTERFACE ws2_32 secur32 crypt32 bcrypt zstd curl shlwapi)
+endif()


### PR DESCRIPTION
this pull request fix the all linker errors , build the project with mingw64 on windows with all latest installed and updated libraries through msys2 packages ,  now its support mingw64 compiler on windows 

<img width="720" height="120" alt="image" src="https://github.com/user-attachments/assets/5378585f-f5d3-424e-b13a-531fbb67b154" />

and below are error get and solved
<img width="1910" height="361" alt="Screenshot 2025-11-28 155337" src="https://github.com/user-attachments/assets/496cb3d7-26b5-47d4-bedb-e2c13e713b8e" />


<img width="1004" height="286" alt="Screenshot 2025-11-28 171043" src="https://github.com/user-attachments/assets/8eb43946-0047-4bbd-b500-3063366bb19c" />

undefined reference to __imp_getservbyname' 
undefined reference to __imp_freeaddrinfo' 
undefined reference to __imp_WSACleanup' 
undefined reference to __imp_WSACleanup' 
undefined reference to AcquireCredentialsHandleA' 
undefined reference to __imp_FreeCredentialsHandle' 
undefined reference to __imp_DeleteSecurityContext' 
undefined reference to  ___imp_getservbyname_imp_CertNameToStrA''
 undefined reference to QueryContextAttributesA'
 .
.
.many more

undefined reference to text0x+.0x2Bbtext)2:CryptCloseAlgorithmProviderb 
undefined reference to ++0xB'CryptCloseAlgorithmProvider) 2'b0x: 
undefined reference to r: undefined reference to yptBBClCryptCloseAlgorithmProvideroseAlgorithmProviderCryptCloseAlgorithmProviderC': 
undefined reference to C::/msys64/mingw64/lib/libmariadf(4))x:xfB4CryptCreateHashf:'. 
undefined reference to 4text)+b0x :client.a(win_crypt.c.obj)C 
undefined reference t undefined reference to B:CryptCloseAlgorithmProvidero 
.
.
many more

 undefined reference to `ZSTD_compressCCtx'
 undefined reference to `ZSTD_isError'
 undefined reference to `ZSTD_decompressDCtx'
 undefined reference to `ZSTD_createCCtx'

 undefined reference to `__imp_curl_multi_cleanup'
undefined reference to `__imp_curl_easy_init'
 undefined reference to `__imp_mPathRemoveFileSpecAsy's:
 undefined reference to `0x_imp_PathRemoveFileSpecA_b
undefined reference to `__imp_PathRemoveFileSpecA'

many more

Solution :

if(WIN32 AND MINGW)
        target_link_libraries(Hiredis_lib INTERFACE ws2_32 secur32 crypt32 bcrypt zstd curl shlwapi)
endif()

MariaDB client | mariadbclient, ->  ws2_32, secur32 ,bcrypt, crypt32
Drogon HTTP client     ->  curl
Static compression (ZSTD)      ->  zstd
Windows path manipulation  ->  shlwapi



