### PR TITLE
Manually install g++-9 in workflow

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -175,12 +175,12 @@ jobs:
           sudo apt-get --purge remove postgresql postgresql-doc postgresql-common postgresql-client-common
           sudo apt-get -y install postgresql-all
 
-      - name: Install g++-13
-        if: startsWith(matrix.compiler.cxx, 'g++') && matrix.compiler.ver == 13
+      - name: Install g++
+        if: startsWith(matrix.compiler.cxx, 'g++') && (matrix.compiler.ver == 13 || matrix.compiler.ver == 9)
         run: |
           sudo add-apt-repository ppa:ubuntu-toolchain-r/test
           sudo apt-get install g++-${{ matrix.compiler.ver }}
-          sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-13 13
+          sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-${{ matrix.compiler.ver }} ${{ matrix.compiler.ver }}
 
       - name: Install Clang
         if: startsWith(matrix.compiler.cxx, 'clang') && matrix.compiler.ver < 13


### PR DESCRIPTION
`g++-9` is deprecated (https://github.com/actions/runner-images/issues/12898, https://github.com/actions/runner-images/pull/13232). This PR manually installs `g++-9` in the workflow.