### PR TITLE
Fix compile error caused by the deprecated MICRO_SECONDS_PRE_SEC macro

### DIFF
--- a/lib/src/HttpResponseImpl.cc
+++ b/lib/src/HttpResponseImpl.cc
@@ -654,13 +654,13 @@ std::shared_ptr<trantor::MsgBuffer> HttpResponseImpl::renderToBuffer()
             {
                 auto now = trantor::Date::now();
                 bool isDateChanged =
-                    ((now.microSecondsSinceEpoch() / MICRO_SECONDS_PER_SEC) !=
-                     httpStringDate_);
+                    ((now.microSecondsSinceEpoch() /
+                      Date::MICRO_SECONDS_PER_SEC) != httpStringDate_);
                 assert(httpString_);
                 if (isDateChanged)
                 {
-                    httpStringDate_ =
-                        now.microSecondsSinceEpoch() / MICRO_SECONDS_PER_SEC;
+                    httpStringDate_ = now.microSecondsSinceEpoch() /
+                                      Date::MICRO_SECONDS_PER_SEC;
                     auto newDate = utils::getHttpFullDate(now);
 
                     httpString_ =

--- a/lib/src/Utilities.cc
+++ b/lib/src/Utilities.cc
@@ -1022,7 +1022,8 @@ char *getHttpFullDate(const trantor::Date &date)
 {
     static thread_local int64_t lastSecond = 0;
     static thread_local char lastTimeString[128] = {0};
-    auto nowSecond = date.microSecondsSinceEpoch() / MICRO_SECONDS_PER_SEC;
+    auto nowSecond =
+        date.microSecondsSinceEpoch() / trantor::Date::MICRO_SECONDS_PER_SEC;
     if (nowSecond == lastSecond)
     {
         return lastTimeString;
@@ -1038,7 +1039,8 @@ void dateToCustomFormattedString(const std::string &fmtStr,
                                  std::string &str,
                                  const trantor::Date &date)
 {
-    auto nowSecond = date.microSecondsSinceEpoch() / MICRO_SECONDS_PER_SEC;
+    auto nowSecond =
+        date.microSecondsSinceEpoch() / trantor::Date::MICRO_SECONDS_PER_SEC;
     time_t seconds = static_cast<time_t>(nowSecond);
     struct tm tm_LValue = date.tmStruct();
     std::stringstream Out;
@@ -1051,7 +1053,8 @@ const std::string &getHttpFullDateStr(const trantor::Date &date)
 {
     static thread_local int64_t lastSecond = 0;
     static thread_local std::string lastTimeString(128, 0);
-    auto nowSecond = date.microSecondsSinceEpoch() / MICRO_SECONDS_PER_SEC;
+    auto nowSecond =
+        date.microSecondsSinceEpoch() / trantor::Date::MICRO_SECONDS_PER_SEC;
     if (nowSecond == lastSecond)
     {
         return lastTimeString;
@@ -1081,7 +1084,7 @@ trantor::Date getHttpDate(const std::string &httpFullDateString)
         if (strptime(httpFullDateString.c_str(), format, &tmptm) != NULL)
         {
             auto epoch = timegm(&tmptm);
-            return trantor::Date(epoch * MICRO_SECONDS_PER_SEC);
+            return trantor::Date(epoch * trantor::Date::MICRO_SECONDS_PER_SEC);
         }
     }
     LOG_WARN << "invalid datetime format: '" << httpFullDateString << "'";
@@ -1318,7 +1321,7 @@ const size_t fixedRandomNumber = []() {
     utils::secureRandomBytes(&res, sizeof(res));
     return res;
 }();
-}
+}  // namespace internal
 
 }  // namespace utils
 }  // namespace drogon

--- a/lib/tests/unittests/HttpDateTest.cc
+++ b/lib/tests/unittests/HttpDateTest.cc
@@ -6,11 +6,15 @@ DROGON_TEST(HttpDate)
 {
     // RFC 850
     auto date = utils::getHttpDate("Fri, 05-Jun-20 09:19:38 GMT");
-    CHECK(date.microSecondsSinceEpoch() / MICRO_SECONDS_PRE_SEC == 1591348778);
+    CHECK(date.microSecondsSinceEpoch() /
+              trantor::Date::MICRO_SECONDS_PER_SEC ==
+          1591348778);
 
     // Reddit format
     date = utils::getHttpDate("Fri, 05-Jun-2020 09:19:38 GMT");
-    CHECK(date.microSecondsSinceEpoch() / MICRO_SECONDS_PRE_SEC == 1591348778);
+    CHECK(date.microSecondsSinceEpoch() /
+              trantor::Date::MICRO_SECONDS_PER_SEC ==
+          1591348778);
 
     // Invalid
     date = utils::getHttpDate("Fri, this format is invalid");
@@ -20,5 +24,7 @@ DROGON_TEST(HttpDate)
     auto epoch = time(nullptr);
     auto str = asctime(gmtime(&epoch));
     date = utils::getHttpDate(str);
-    CHECK(date.microSecondsSinceEpoch() / MICRO_SECONDS_PRE_SEC == epoch);
+    CHECK(date.microSecondsSinceEpoch() /
+              trantor::Date::MICRO_SECONDS_PER_SEC ==
+          epoch);
 }


### PR DESCRIPTION
This pull request fixes the compile error caused by the outdated `MICRO_SECONDS_PRE_SEC` macro, which was replaced to `MICRO_SECONDS_PER_SEC` in Trantor.

- Fixes #2415 (Drogon)
- Related xmake-io/xmake-repo#8750