### PR TITLE
Remove MacOS 13 from CI

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -70,7 +70,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        osver: [13, 14, 15]
+        osver: [14, 15]
     steps:
       - name: Checkout Drogon source code
         uses: actions/checkout@v4


### PR DESCRIPTION
MacOS 13 is removed from GitHub CI support, see https://github.com/actions/runner-images/issues/13046

Removing it from CI