### PR TITLE
mysql exception forward errorNo to SqlError

### DIFF
--- a/orm_lib/src/mysql_impl/MysqlConnection.cc
+++ b/orm_lib/src/mysql_impl/MysqlConnection.cc
@@ -532,7 +532,7 @@ void MysqlConnection::outputError()
     {
         // TODO: exception type
         auto exceptPtr = std::make_exception_ptr(
-            SqlError(mysql_error(mysqlPtr_.get()), sql_, errorNo, errorNo));
+            SqlError(mysql_error(mysqlPtr_.get()), sql_, errorNo, 0));
         exceptionCallback_(exceptPtr);
         exceptionCallback_ = nullptr;
 


### PR DESCRIPTION
Till know mysql_errno is not forwarded . I've added the value to SqlError constructor.