### PR TITLE
Configurable drogon_ctl location

### DIFF
--- a/cmake/DrogonUtilities.cmake
+++ b/cmake/DrogonUtilities.cmake
@@ -7,6 +7,7 @@ function(drogon_create_views arg)
     message(STATUS "arguments error when calling drogon_create_views")
     return()
   endif()
+  find_program(DROGON_CTL drogon_ctl REQUIRED)
   file(MAKE_DIRECTORY ${ARGV2})
   file(GLOB_RECURSE SCP_LIST ${ARGV1}/*.csp)
   foreach(cspFile ${SCP_LIST})
@@ -39,7 +40,7 @@ function(drogon_create_views arg)
         set(ns "")
       endif()
       add_custom_command(OUTPUT ${ARGV2}/${outputFile}.h ${ARGV2}/${outputFile}.cc
-                         COMMAND drogon_ctl
+                         COMMAND ${DROGON_CTL}
                                  ARGS
                                  create
                                  view
@@ -55,7 +56,7 @@ function(drogon_create_views arg)
     else()
       get_filename_component(classname ${cspFile} NAME_WE)
       add_custom_command(OUTPUT ${ARGV2}/${classname}.h ${ARGV2}/${classname}.cc
-                         COMMAND drogon_ctl
+                         COMMAND ${DROGON_CTL}
                                  ARGS
                                  create
                                  view


### PR DESCRIPTION
Hello. Please make the location of the drogon_ctl command configurable from CMake scripts directly.

[https://cmake.org/cmake/help/latest/command/find_program.html](https://cmake.org/cmake/help/latest/command/find_program.html)

[https://cmake.org/cmake/help/latest/variable/CMAKE_PROGRAM_PATH.html](https://cmake.org/cmake/help/latest/variable/CMAKE_PROGRAM_PATH.html)

> [Semicolon-separated list](https://cmake.org/cmake/help/latest/manual/cmake-language.7.html#cmake-language-lists) of directories specifying a search path for the [find_program()](https://cmake.org/cmake/help/latest/command/find_program.html#command:find_program) command. By default it is empty, it is intended to be set by the project.

The Drogon library is not always installed on the system so that the path to the `drogon_ctl` command globally set in the `PATH` environment variable. At the same time, the CMAKE_PROGRAM_PATH variable is configurable from CMake scripts.

[https://github.com/drogonframework/drogon/blob/master/cmake/DrogonUtilities.cmake](https://github.com/drogonframework/drogon/blob/master/cmake/DrogonUtilities.cmake) 

I'm considering a scenario where the Drogon library is installed by package managers such as Conan which creates its own environment.

From my system:
`~/.conan2$ find . -iname 'drogon_ctl'
./p/b/drogoa449f6147cb12/p/bin/drogon_ctl
./p/b/drogoa449f6147cb12/b/build/Release/drogon_ctl
./p/b/drogoa449f6147cb12/b/build/Release/drogon_ctl/drogon_ctl
./p/b/drogoa449f6147cb12/b/src/drogon_ctl
./p/b/drogo79535e018a23d/p/bin/drogon_ctl
./p/b/drogo79535e018a23d/b/build/Debug/drogon_ctl
./p/b/drogo79535e018a23d/b/build/Debug/drogon_ctl/drogon_ctl
./p/b/drogo79535e018a23d/b/src/drogon_ctl
./p/drogo60067c88c49b2/s/src/drogon_ctl
`

This has been fixed. Hence, this script is included automatically in the builds, but the drogon_create_views() function still does not work because it is impossible to configure the path to this command anywhere 🤔
```
./p/b/drogoa449f6147cb12/p/lib/cmake/Drogon/DrogonUtilities.cmake
./p/b/drogoa449f6147cb12/b/src/cmake/DrogonUtilities.cmake
./p/b/drogo79535e018a23d/p/lib/cmake/Drogon/DrogonUtilities.cmake
./p/b/drogo79535e018a23d/b/src/cmake/DrogonUtilities.cmake
./p/drogo60067c88c49b2/s/src/cmake/DrogonUtilities.cmake
```
