### PR TITLE
BugFix/inconsistent target naming

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,6 +134,8 @@ if (WIN32)
         PRIVATE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/third_party/mman-win32>)
 endif (WIN32)
 
+add_library(Drogon::Drogon ALIAS ${PROJECT_NAME})
+
 if(USE_SUBMODULE)
 add_subdirectory(trantor)
 target_link_libraries(${PROJECT_NAME} PUBLIC trantor)


### PR DESCRIPTION
### Fix By Adding a CMake Alias library for Drogon Target  with name matching installed target

- When using the library as a downloaded package, either by using as a submodule or downloading the source, we can only link to it by using the project name which is "drogon"
- We can add an Alias library with the same target name that is used when the project is installed.
- This way the cmake "target_link_library" Command would always refer to the library by the same name which is "Drogon::Drogon" while also avoiding the pitfall of the default behaviour of the command just adding the the target name to the link arguments if the library isn't found.