### PR TITLE
added --clear-output option to drogon_ctl create models

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- dg_ctl create models new command line option --clear-output
+
+
 ## [1.9.12] - 2026-01-26
 
 ### API changes list

--- a/drogon_ctl/create.cc
+++ b/drogon_ctl/create.cc
@@ -42,7 +42,8 @@ std::string create::detail()
            "create a plugin named class_name\n\n"
            "drogon_ctl create project <project_name> //"
            "create a project named project_name\n\n"
-           "drogon_ctl create model <model_path> [-o <output path>] "
+           "drogon_ctl create model <model_path> [-o <output path>] [ "
+           "--clear-output]"
            "[--table=<table_name>] [-f]//"
            "create model classes in model_path\n";
 }

--- a/drogon_ctl/create_model.h
+++ b/drogon_ctl/create_model.h
@@ -430,5 +430,6 @@ class create_model : public DrObject<create_model>, public CommandHandler
     std::string dbname_;
     bool forceOverwrite_{false};
     std::string outputPath_;
+    bool cleanupDirectory_{false};
 };
 }  // namespace drogon_ctl


### PR DESCRIPTION
Goal of this PR is to provide a way to have a clean folder to store generated models.
Because if some tables are deleted, the associated models will remain, so this is to guarantee we don't end up with unnecessary generated models