### PR TITLE
utilities: make utils::isBase64 support padding

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,6 +8,9 @@ All notable changes to this project will be documented in this file.
 
 - dg_ctl create models new command line option --clear-output
 
+### Changed
+
+- make utils::isBase64 support padding
 
 ## [1.9.12] - 2026-01-26
 

--- a/lib/src/Utilities.cc
+++ b/lib/src/Utilities.cc
@@ -155,9 +155,24 @@ bool isInteger(std::string_view str)
 
 bool isBase64(std::string_view str)
 {
-    for (auto c : str)
-        if (!isBase64(c))
+    if (str.empty())
+        return false;
+
+    size_t padding = 0;
+    if (str.back() == '=')
+        padding++;
+    if (str.size() > 1 && str[str.size() - 2] == '=')
+        padding++;
+
+    for (size_t i = 0; i < str.size() - padding; ++i)
+    {
+        if (!isBase64(str[i]))
             return false;
+    }
+
+    if (padding > 0 && (str.size() % 4 != 0))
+        return false;
+
     return true;
 }
 

--- a/lib/tests/unittests/Base64Test.cc
+++ b/lib/tests/unittests/Base64Test.cc
@@ -9,6 +9,7 @@ DROGON_TEST(Base64)
     auto decoded = drogon::utils::base64Decode(encoded);
     CHECK(encoded == "ZHJvZ29uIGZyYW1ld29yaw==");
     CHECK(decoded == in);
+    CHECK(drogon::utils::isBase64(encoded));
 
     SUBSECTION(InvalidChars)
     {
@@ -31,6 +32,7 @@ DROGON_TEST(Base64)
         auto decoded = drogon::utils::base64Decode(encoded);
         CHECK(encoded == "ZHJvZ29uIGZyYW1ld29yaw");
         CHECK(decoded == in);
+        CHECK(drogon::utils::isBase64(encoded));
     }
 
     SUBSECTION(LongString)
@@ -46,6 +48,9 @@ DROGON_TEST(Base64)
         auto encoded = drogon::utils::base64Encode(in);
         auto decoded = drogon::utils::base64Decode(encoded);
         CHECK(decoded == in);
+        CHECK(out == encoded);
+        CHECK(drogon::utils::isBase64(out));
+        CHECK(drogon::utils::isBase64(encoded));
     }
 
     SUBSECTION(URLSafe)
@@ -55,6 +60,7 @@ DROGON_TEST(Base64)
         auto decoded = drogon::utils::base64Decode(encoded);
         CHECK(encoded == "ZHJvZ29uIGZyYW1ld29yaw==");
         CHECK(decoded == in);
+        CHECK(drogon::utils::isBase64(encoded));
     }
 
     SUBSECTION(UnpaddedURLSafe)
@@ -64,6 +70,7 @@ DROGON_TEST(Base64)
         auto decoded = drogon::utils::base64Decode(encoded);
         CHECK(encoded == "ZHJvZ29uIGZyYW1ld29yaw");
         CHECK(decoded == in);
+        CHECK(drogon::utils::isBase64(encoded));
     }
 
     SUBSECTION(LongURLSafe)
@@ -77,5 +84,24 @@ DROGON_TEST(Base64)
         auto encoded = drogon::utils::base64Encode(in, true);
         auto decoded = drogon::utils::base64Decode(encoded);
         CHECK(decoded == in);
+        CHECK(drogon::utils::isBase64(encoded));
+    }
+
+    SUBSECTION(emptyString)
+    {
+        auto encoded = "";
+        CHECK(!drogon::utils::isBase64(encoded));
+    }
+
+    SUBSECTION(size1Padding)
+    {
+        auto encoded = "ZHJvZ29uIGZyYW1ld29=";
+        CHECK(drogon::utils::isBase64(encoded));
+    }
+
+    SUBSECTION(size1PaddingNotModulo4)
+    {
+        auto encoded = "ZHJvZ29uIGZyYW1ld29ya=";
+        CHECK(!drogon::utils::isBase64(encoded));
     }
 }


### PR DESCRIPTION
Following [RFC 4648](https://datatracker.ietf.org/doc/html/rfc4648#section-6) utils::isBase64 should accept padded encoded data. Current implementation allows URL characters '-, _' so it should also support padding character ('=').

More over with current implementation the following code fails, which doesn't make sense.

``` c++
std::string in{"drogon framework"};
auto encoded = drogon::utils::base64Encode(in);
if (!drogon::utils::isBase64(encoded))
    std::cerr << "Not base64" << std::endl;
```

$ output = Not base64