### PR TITLE
Fix drogon_ctl self-registration with clang-cl on Windows (COMDAT elimination of DrObject<T>::alloc_)

### DIFF
--- a/drogon_ctl/create.cc
+++ b/drogon_ctl/create.cc
@@ -56,3 +56,14 @@ void create::handleCommand(std::vector<std::string> &parameters)
     parameters[0] = createObjName;
     exeCommand(parameters);
 }
+
+// Prevent clang-cl/lld-link from discarding DrObject<T>::alloc_ on Windows.
+// On COFF targets, clang places the CRT initializer for the template static
+// member in the same COMDAT group as the variable itself.  When no code in the
+// translation unit takes the address of alloc_ (clang inlines className()),
+// the entire COMDAT is eligible for elimination — and lld-link's /OPT:REF
+// removes it, so DrClassMap is never populated.
+// Explicit template instantiation forces a strong (non-COMDAT) definition,
+// which the linker must keep.  This is a no-op on MSVC, GCC, and ELF targets
+// (where .init_array entries are GC roots and are never discarded).
+template class drogon::DrObject<drogon_ctl::create>;

--- a/drogon_ctl/create_controller.cc
+++ b/drogon_ctl/create_controller.cc
@@ -469,3 +469,6 @@ void create_controller::createARestfulController(const std::string &className,
     std::cout << "File name: " << ctlName << ".h and " << ctlName << ".cc"
               << std::endl;
 }
+
+// See create.cc for rationale.
+template class drogon::DrObject<drogon_ctl::create_controller>;

--- a/drogon_ctl/create_filter.cc
+++ b/drogon_ctl/create_filter.cc
@@ -116,3 +116,6 @@ void create_filter::handleCommand(std::vector<std::string> &parameters)
         createFilterSourceFile(oSourceFile, className, fileName);
     }
 }
+
+// See create.cc for rationale.
+template class drogon::DrObject<drogon_ctl::create_filter>;

--- a/drogon_ctl/create_model.cc
+++ b/drogon_ctl/create_model.cc
@@ -1460,3 +1460,6 @@ void create_model::createRestfulAPIController(
                   << std::endl;
     }
 }
+
+// See create.cc for rationale.
+template class drogon::DrObject<drogon_ctl::create_model>;

--- a/drogon_ctl/create_plugin.cc
+++ b/drogon_ctl/create_plugin.cc
@@ -116,3 +116,6 @@ void create_plugin::handleCommand(std::vector<std::string> &parameters)
         createPluginSourceFile(oSourceFile, className, fileName);
     }
 }
+
+// See create.cc for rationale.
+template class drogon::DrObject<drogon_ctl::create_plugin>;

--- a/drogon_ctl/create_project.cc
+++ b/drogon_ctl/create_project.cc
@@ -141,3 +141,6 @@ void create_project::createProject(const std::string &projectName)
     std::ofstream testCmakeFile("test/CMakeLists.txt", std::ofstream::out);
     newTestCmakeFile(testCmakeFile, projectName);
 }
+
+// See create.cc for rationale.
+template class drogon::DrObject<drogon_ctl::create_project>;

--- a/drogon_ctl/create_view.cc
+++ b/drogon_ctl/create_view.cc
@@ -552,3 +552,6 @@ void create_view::newViewSourceFile(std::ofstream &file,
     file << "return templ->genText(data);\n";
     file << "}\n}\n";
 }
+
+// See create.cc for rationale.
+template class drogon::DrObject<drogon_ctl::create_view>;

--- a/drogon_ctl/help.cc
+++ b/drogon_ctl/help.cc
@@ -68,3 +68,6 @@ void help::handleCommand(std::vector<std::string> &parameters)
         }
     }
 }
+
+// See create.cc for rationale.
+template class drogon::DrObject<drogon_ctl::help>;

--- a/drogon_ctl/press.cc
+++ b/drogon_ctl/press.cc
@@ -470,3 +470,6 @@ void press::outputResults()
               << std::endl;
     exit(0);
 }
+
+// See create.cc for rationale.
+template class drogon::DrObject<drogon_ctl::press>;

--- a/drogon_ctl/version.cc
+++ b/drogon_ctl/version.cc
@@ -66,3 +66,6 @@ void version::handleCommand(std::vector<std::string> &parameters)
     std::cout << "  yaml-cpp: no\n";
 #endif
 }
+
+// See create.cc for rationale.
+template class drogon::DrObject<drogon_ctl::version>;


### PR DESCRIPTION
### Problem
When building drogon with clang-cl (LLVM's MSVC-compatible compiler on Windows), `drogon_ctl` links successfully but **fails at runtime**: every command prints "command error! use help command to get usage!" because `DrClassMap` is empty - no command handler class is registered.

This affects clang-cl 17 through 19 (at least) with lld-link.
MSVC's cl.exe and clang on Linux/macOS are not affected.

### Root cause
*Root cause analysis and fix were found with the help of GitHub Copilot (Claude Opus 4.6), through iterative investigation: reproducer construction, COMDAT section analysis, and testing of multiple candidate fixes ([[gnu::used]], /OPT:NOREF, constructor side-effects) before converging on explicit template instantiation.*

`DrObject<T>::alloc_` is a static template member whose constructor registers `T` into `DrClassMap` before main(). This self-registration relies on the CRT running the static initializer.

On COFF targets (Windows), clang places the CRT initializer for a template static member in the same COMDAT section group as the variable itself.
When the optimizer determines that no code in the translation unit directly references alloc_ - which happens because clang aggressively inlines className() and eliminates the implicit this -> alloc_ reference - the entire COMDAT group becomes unreferenced.
The linker then discards it, so DrAllocator's constructor never runs.

On ELF targets (Linux, macOS), .init_array / .ctors entries are treated as GC roots and are never discarded, which is why this bug is invisible on those platforms.
MSVC's link.exe is also more conservative with CRT initializer sections and preserves them even when unreferenced.

### Fix
This PR adds explicit template instantiation (`template class drogon::DrObject<T>`) at the end of each drogon_ctl/*.cc file that defines a DrObject<T> subclass.
This forces the compiler to emit a strong (non-COMDAT) definition that the linker cannot discard.

This is standard C++ and has no effect on compilers/linkers that already preserve the initializer (MSVC, GCC, non-microsoft clang).

### Scope and limitations
This PR only fixes `drogon_ctl`.
The same problem could potentially affect any application that statically links the drogon library with clang-cl on Windows and relies on DrObject<T> self-registration without directly referencing the derived classes.
Users building their own apps with clang-cl would need to add similar explicit instantiations for their own DrObject<T> subclasses.

There may be a better or more elegant compiler/linker-level solution, but we were unable to find one that works on COFF targets.
[[[gnu::used]]](http://vscodecontentref/23) / __attribute__((used)) do not prevent COMDAT elimination on COFF.
/OPT:NOREF does not help either — the issue is at the compiler level (clang-cl does not emit the initializer when it determines alloc_ is unused), not at the linker level.

### Reproducer
A self-contained multi-file reproducer is attached to this PR.

### Environment
Windows 10, Visual Studio 2022 Professional
clang-cl 19.1.5 (VS-bundled LLVM), lld-link
Also tested with MSVC 19.44 (works without the fix)
