### PR TITLE
feat(orm): Add JOIN support to Mapper/BaseBuilder and FK auto-detection in code generator

### DIFF
--- a/drogon_ctl/create_model.cc
+++ b/drogon_ctl/create_model.cc
@@ -207,9 +207,10 @@ static void tryAddAutoRelationship(
     {
         Relationship autoRel(relJson);
         allRelationships.push_back(autoRel);
-        std::cout << "    Auto-detected FK: " << originalTable << "."
-                  << fkColumn << " -> " << referencedTable << "."
-                  << referencedColumn << std::endl;
+        std::cout << "    Auto-detected FK: " << originalTable
+                  << "." << fkColumn << " -> "
+                  << referencedTable << "." << referencedColumn
+                  << std::endl;
     }
     catch (const std::runtime_error &e)
     {

--- a/drogon_ctl/create_model.cc
+++ b/drogon_ctl/create_model.cc
@@ -182,8 +182,9 @@ void create_model::createModelClassFromPG(
     data["primaryKeyName"] = "";
     data["dbName"] = dbname_;
     data["rdbms"] = std::string("postgresql");
-    data["relationships"] = relationships;
     data["convertMethods"] = convertMethods;
+    // Start with user-configured relationships (mutable copy)
+    std::vector<Relationship> allRelationships(relationships);
     if (schema != "public")
     {
         data["schema"] = schema;
@@ -397,6 +398,71 @@ void create_model::createModelClassFromPG(
         data["primaryKeyValNames"] = pkValNames;
     }
 
+    // Auto-detect foreign key relationships from database schema
+    *client << "SELECT "
+               "kcu.column_name AS fk_column, "
+               "ccu.table_name AS referenced_table, "
+               "ccu.column_name AS referenced_column "
+               "FROM information_schema.key_column_usage kcu "
+               "JOIN information_schema.referential_constraints rc "
+               "ON kcu.constraint_name = rc.constraint_name "
+               "AND kcu.constraint_schema = rc.constraint_schema "
+               "JOIN information_schema.constraint_column_usage ccu "
+               "ON rc.unique_constraint_name = ccu.constraint_name "
+               "WHERE kcu.table_name = $1 "
+               "AND kcu.table_schema = $2"
+            << tableName << schema << Mode::Blocking >>
+        [&](bool isNull,
+            const std::string &fkColumn,
+            const std::string &referencedTable,
+            const std::string &referencedColumn) {
+            if (!isNull)
+            {
+                // Check if this relationship already exists in user config
+                bool exists = false;
+                for (const auto &r : allRelationships)
+                {
+                    if (r.originalKey() == fkColumn &&
+                        r.targetTableName() == referencedTable)
+                    {
+                        exists = true;
+                        break;
+                    }
+                }
+                if (!exists)
+                {
+                    Json::Value relJson;
+                    relJson["type"] = "has one";
+                    relJson["original_table_name"] = tableName;
+                    relJson["original_key"] = fkColumn;
+                    relJson["target_table_name"] = referencedTable;
+                    relJson["target_key"] = referencedColumn;
+                    relJson["enable_reverse"] = true;
+                    try
+                    {
+                        Relationship autoRel(relJson);
+                        allRelationships.push_back(autoRel);
+                        std::cout << "    Auto-detected FK: "
+                                  << tableName << "." << fkColumn
+                                  << " -> " << referencedTable << "."
+                                  << referencedColumn << std::endl;
+                    }
+                    catch (const std::runtime_error &e)
+                    {
+                        std::cerr << "Warning: Could not create "
+                                     "auto-relationship: "
+                                  << e.what() << std::endl;
+                    }
+                }
+            }
+        } >>
+        [](const DrogonDbException &e) {
+            // FK detection is best-effort; don't fail if unsupported
+            std::cerr << "Note: FK auto-detection not available: "
+                      << e.base().what() << std::endl;
+        };
+
+    data["relationships"] = allRelationships;
     data["columns"] = cols;
     std::ofstream headerFile(path + "/" + className + ".h", std::ofstream::out);
     std::ofstream sourceFile(path + "/" + className + ".cc",
@@ -467,8 +533,9 @@ void create_model::createModelClassFromMysql(
     data["primaryKeyName"] = "";
     data["dbName"] = dbname_;
     data["rdbms"] = std::string("mysql");
-    data["relationships"] = relationships;
     data["convertMethods"] = convertMethods;
+    // Start with user-configured relationships (mutable copy)
+    std::vector<Relationship> allRelationships(relationships);
     std::vector<ColumnInfo> cols;
     int i = 0;
     *client << "desc `" + tableName + "`" << Mode::Blocking >>
@@ -593,6 +660,64 @@ void create_model::createModelClassFromMysql(
         data["primaryKeyType"] = pkTypes;
         data["primaryKeyValNames"] = pkValNames;
     }
+
+    // Auto-detect foreign key relationships from MySQL schema
+    *client << "SELECT COLUMN_NAME, REFERENCED_TABLE_NAME, "
+               "REFERENCED_COLUMN_NAME "
+               "FROM information_schema.KEY_COLUMN_USAGE "
+               "WHERE TABLE_SCHEMA = DATABASE() "
+               "AND TABLE_NAME = ? "
+               "AND REFERENCED_TABLE_NAME IS NOT NULL"
+            << tableName << Mode::Blocking >>
+        [&](bool isNull,
+            const std::string &fkColumn,
+            const std::string &referencedTable,
+            const std::string &referencedColumn) {
+            if (!isNull)
+            {
+                bool exists = false;
+                for (const auto &r : allRelationships)
+                {
+                    if (r.originalKey() == fkColumn &&
+                        r.targetTableName() == referencedTable)
+                    {
+                        exists = true;
+                        break;
+                    }
+                }
+                if (!exists)
+                {
+                    Json::Value relJson;
+                    relJson["type"] = "has one";
+                    relJson["original_table_name"] = toLower(tableName);
+                    relJson["original_key"] = fkColumn;
+                    relJson["target_table_name"] = toLower(referencedTable);
+                    relJson["target_key"] = referencedColumn;
+                    relJson["enable_reverse"] = true;
+                    try
+                    {
+                        Relationship autoRel(relJson);
+                        allRelationships.push_back(autoRel);
+                        std::cout << "    Auto-detected FK: "
+                                  << tableName << "." << fkColumn
+                                  << " -> " << referencedTable << "."
+                                  << referencedColumn << std::endl;
+                    }
+                    catch (const std::runtime_error &e)
+                    {
+                        std::cerr << "Warning: Could not create "
+                                     "auto-relationship: "
+                                  << e.what() << std::endl;
+                    }
+                }
+            }
+        } >>
+        [](const DrogonDbException &e) {
+            std::cerr << "Note: FK auto-detection not available: "
+                      << e.base().what() << std::endl;
+        };
+
+    data["relationships"] = allRelationships;
     data["columns"] = cols;
     std::ofstream headerFile(path + "/" + className + ".h", std::ofstream::out);
     std::ofstream sourceFile(path + "/" + className + ".cc",
@@ -646,8 +771,9 @@ void create_model::createModelClassFromSqlite3(
     data["primaryKeyName"] = "";
     data["dbName"] = std::string("sqlite3");
     data["rdbms"] = std::string("sqlite3");
-    data["relationships"] = relationships;
     data["convertMethods"] = convertMethods;
+    // Start with user-configured relationships (mutable copy)
+    std::vector<Relationship> allRelationships(relationships);
     std::vector<ColumnInfo> cols;
     std::string sql = "PRAGMA table_info(" + tableName + ");";
     *client << sql << Mode::Blocking >> [&](const Result &result) {
@@ -774,6 +900,58 @@ void create_model::createModelClassFromSqlite3(
         data["primaryKeyType"] = pkTypes;
         data["primaryKeyValNames"] = pkValNames;
     }
+
+    // Auto-detect foreign key relationships from SQLite3 schema
+    std::string fkSql = "PRAGMA foreign_key_list(" + tableName + ");";
+    *client << fkSql << Mode::Blocking >> [&](const Result &fkResult) {
+        for (auto &fkRow : fkResult)
+        {
+            auto referencedTable = fkRow["table"].as<std::string>();
+            auto fkColumn = fkRow["from"].as<std::string>();
+            auto referencedColumn = fkRow["to"].as<std::string>();
+
+            bool exists = false;
+            for (const auto &r : allRelationships)
+            {
+                if (r.originalKey() == fkColumn &&
+                    r.targetTableName() == referencedTable)
+                {
+                    exists = true;
+                    break;
+                }
+            }
+            if (!exists)
+            {
+                Json::Value relJson;
+                relJson["type"] = "has one";
+                relJson["original_table_name"] = toLower(tableName);
+                relJson["original_key"] = fkColumn;
+                relJson["target_table_name"] = toLower(referencedTable);
+                relJson["target_key"] = referencedColumn;
+                relJson["enable_reverse"] = true;
+                try
+                {
+                    Relationship autoRel(relJson);
+                    allRelationships.push_back(autoRel);
+                    std::cout << "    Auto-detected FK: "
+                              << tableName << "." << fkColumn
+                              << " -> " << referencedTable << "."
+                              << referencedColumn << std::endl;
+                }
+                catch (const std::runtime_error &e)
+                {
+                    std::cerr << "Warning: Could not create "
+                                 "auto-relationship: "
+                              << e.what() << std::endl;
+                }
+            }
+        }
+    } >> [](const DrogonDbException &e) {
+        std::cerr << "Note: FK auto-detection not available: "
+                  << e.base().what() << std::endl;
+    };
+
+    data["relationships"] = allRelationships;
     data["columns"] = cols;
     std::ofstream headerFile(path + "/" + className + ".h", std::ofstream::out);
     std::ofstream sourceFile(path + "/" + className + ".cc",

--- a/drogon_ctl/create_model.cc
+++ b/drogon_ctl/create_model.cc
@@ -178,13 +178,12 @@ bool drogon_ctl::ConvertMethod::shouldConvert(const std::string &tableName,
  * @param referencedColumn The column referenced by the FK.
  * @param normalizeNames If true, apply toLower() to table names.
  */
-static void tryAddAutoRelationship(
-    std::vector<Relationship> &allRelationships,
-    const std::string &originalTable,
-    const std::string &fkColumn,
-    const std::string &referencedTable,
-    const std::string &referencedColumn,
-    bool normalizeNames)
+static void tryAddAutoRelationship(std::vector<Relationship> &allRelationships,
+                                   const std::string &originalTable,
+                                   const std::string &fkColumn,
+                                   const std::string &referencedTable,
+                                   const std::string &referencedColumn,
+                                   bool normalizeNames)
 {
     for (const auto &r : allRelationships)
     {
@@ -207,15 +206,14 @@ static void tryAddAutoRelationship(
     {
         Relationship autoRel(relJson);
         allRelationships.push_back(autoRel);
-        std::cout << "    Auto-detected FK: " << originalTable
-                  << "." << fkColumn << " -> "
-                  << referencedTable << "." << referencedColumn
-                  << std::endl;
+        std::cout << "    Auto-detected FK: " << originalTable << "."
+                  << fkColumn << " -> " << referencedTable << "."
+                  << referencedColumn << std::endl;
     }
     catch (const std::runtime_error &e)
     {
-        std::cerr << "Warning: Could not create auto-relationship: "
-                  << e.what() << std::endl;
+        std::cerr << "Warning: Could not create auto-relationship: " << e.what()
+                  << std::endl;
     }
 }
 
@@ -899,8 +897,7 @@ void create_model::createModelClassFromSqlite3(
     }
 
     // Auto-detect foreign key relationships from SQLite3 schema
-    std::string fkSql =
-        "PRAGMA foreign_key_list(\"" + tableName + "\");";
+    std::string fkSql = "PRAGMA foreign_key_list(\"" + tableName + "\");";
     *client << fkSql << Mode::Blocking >> [&](const Result &fkResult) {
         for (auto &fkRow : fkResult)
         {

--- a/drogon_ctl/create_model.cc
+++ b/drogon_ctl/create_model.cc
@@ -164,6 +164,60 @@ bool drogon_ctl::ConvertMethod::shouldConvert(const std::string &tableName,
     }  // endif
 }
 
+/**
+ * @brief Try to add an auto-detected FK relationship to the list.
+ *
+ * Checks for duplicates against existing relationships, creates a
+ * Relationship object from the FK info, and appends it to the list.
+ * User-configured relationships always take priority.
+ *
+ * @param allRelationships The mutable vector of relationships.
+ * @param originalTable The table containing the FK column.
+ * @param fkColumn The FK column name.
+ * @param referencedTable The table referenced by the FK.
+ * @param referencedColumn The column referenced by the FK.
+ * @param normalizeNames If true, apply toLower() to table names.
+ */
+static void tryAddAutoRelationship(
+    std::vector<Relationship> &allRelationships,
+    const std::string &originalTable,
+    const std::string &fkColumn,
+    const std::string &referencedTable,
+    const std::string &referencedColumn,
+    bool normalizeNames)
+{
+    for (const auto &r : allRelationships)
+    {
+        if (r.originalKey() == fkColumn &&
+            r.targetTableName() == referencedTable)
+        {
+            return;  // Already exists in user config
+        }
+    }
+    Json::Value relJson;
+    relJson["type"] = "has one";
+    relJson["original_table_name"] =
+        normalizeNames ? toLower(originalTable) : originalTable;
+    relJson["original_key"] = fkColumn;
+    relJson["target_table_name"] =
+        normalizeNames ? toLower(referencedTable) : referencedTable;
+    relJson["target_key"] = referencedColumn;
+    relJson["enable_reverse"] = true;
+    try
+    {
+        Relationship autoRel(relJson);
+        allRelationships.push_back(autoRel);
+        std::cout << "    Auto-detected FK: " << originalTable << "."
+                  << fkColumn << " -> " << referencedTable << "."
+                  << referencedColumn << std::endl;
+    }
+    catch (const std::runtime_error &e)
+    {
+        std::cerr << "Warning: Could not create auto-relationship: "
+                  << e.what() << std::endl;
+    }
+}
+
 #if USE_POSTGRESQL
 void create_model::createModelClassFromPG(
     const std::string &path,
@@ -409,6 +463,7 @@ void create_model::createModelClassFromPG(
                "AND kcu.constraint_schema = rc.constraint_schema "
                "JOIN information_schema.constraint_column_usage ccu "
                "ON rc.unique_constraint_name = ccu.constraint_name "
+               "AND rc.unique_constraint_schema = ccu.constraint_schema "
                "WHERE kcu.table_name = $1 "
                "AND kcu.table_schema = $2"
             << tableName << schema << Mode::Blocking >>
@@ -418,42 +473,12 @@ void create_model::createModelClassFromPG(
             const std::string &referencedColumn) {
             if (!isNull)
             {
-                // Check if this relationship already exists in user config
-                bool exists = false;
-                for (const auto &r : allRelationships)
-                {
-                    if (r.originalKey() == fkColumn &&
-                        r.targetTableName() == referencedTable)
-                    {
-                        exists = true;
-                        break;
-                    }
-                }
-                if (!exists)
-                {
-                    Json::Value relJson;
-                    relJson["type"] = "has one";
-                    relJson["original_table_name"] = tableName;
-                    relJson["original_key"] = fkColumn;
-                    relJson["target_table_name"] = referencedTable;
-                    relJson["target_key"] = referencedColumn;
-                    relJson["enable_reverse"] = true;
-                    try
-                    {
-                        Relationship autoRel(relJson);
-                        allRelationships.push_back(autoRel);
-                        std::cout << "    Auto-detected FK: "
-                                  << tableName << "." << fkColumn
-                                  << " -> " << referencedTable << "."
-                                  << referencedColumn << std::endl;
-                    }
-                    catch (const std::runtime_error &e)
-                    {
-                        std::cerr << "Warning: Could not create "
-                                     "auto-relationship: "
-                                  << e.what() << std::endl;
-                    }
-                }
+                tryAddAutoRelationship(allRelationships,
+                                       tableName,
+                                       fkColumn,
+                                       referencedTable,
+                                       referencedColumn,
+                                       true);
             }
         } >>
         [](const DrogonDbException &e) {
@@ -675,41 +700,12 @@ void create_model::createModelClassFromMysql(
             const std::string &referencedColumn) {
             if (!isNull)
             {
-                bool exists = false;
-                for (const auto &r : allRelationships)
-                {
-                    if (r.originalKey() == fkColumn &&
-                        r.targetTableName() == referencedTable)
-                    {
-                        exists = true;
-                        break;
-                    }
-                }
-                if (!exists)
-                {
-                    Json::Value relJson;
-                    relJson["type"] = "has one";
-                    relJson["original_table_name"] = toLower(tableName);
-                    relJson["original_key"] = fkColumn;
-                    relJson["target_table_name"] = toLower(referencedTable);
-                    relJson["target_key"] = referencedColumn;
-                    relJson["enable_reverse"] = true;
-                    try
-                    {
-                        Relationship autoRel(relJson);
-                        allRelationships.push_back(autoRel);
-                        std::cout << "    Auto-detected FK: "
-                                  << tableName << "." << fkColumn
-                                  << " -> " << referencedTable << "."
-                                  << referencedColumn << std::endl;
-                    }
-                    catch (const std::runtime_error &e)
-                    {
-                        std::cerr << "Warning: Could not create "
-                                     "auto-relationship: "
-                                  << e.what() << std::endl;
-                    }
-                }
+                tryAddAutoRelationship(allRelationships,
+                                       tableName,
+                                       fkColumn,
+                                       referencedTable,
+                                       referencedColumn,
+                                       true);
             }
         } >>
         [](const DrogonDbException &e) {
@@ -902,49 +898,20 @@ void create_model::createModelClassFromSqlite3(
     }
 
     // Auto-detect foreign key relationships from SQLite3 schema
-    std::string fkSql = "PRAGMA foreign_key_list(" + tableName + ");";
+    std::string fkSql =
+        "PRAGMA foreign_key_list(\"" + tableName + "\");";
     *client << fkSql << Mode::Blocking >> [&](const Result &fkResult) {
         for (auto &fkRow : fkResult)
         {
             auto referencedTable = fkRow["table"].as<std::string>();
             auto fkColumn = fkRow["from"].as<std::string>();
             auto referencedColumn = fkRow["to"].as<std::string>();
-
-            bool exists = false;
-            for (const auto &r : allRelationships)
-            {
-                if (r.originalKey() == fkColumn &&
-                    r.targetTableName() == referencedTable)
-                {
-                    exists = true;
-                    break;
-                }
-            }
-            if (!exists)
-            {
-                Json::Value relJson;
-                relJson["type"] = "has one";
-                relJson["original_table_name"] = toLower(tableName);
-                relJson["original_key"] = fkColumn;
-                relJson["target_table_name"] = toLower(referencedTable);
-                relJson["target_key"] = referencedColumn;
-                relJson["enable_reverse"] = true;
-                try
-                {
-                    Relationship autoRel(relJson);
-                    allRelationships.push_back(autoRel);
-                    std::cout << "    Auto-detected FK: "
-                              << tableName << "." << fkColumn
-                              << " -> " << referencedTable << "."
-                              << referencedColumn << std::endl;
-                }
-                catch (const std::runtime_error &e)
-                {
-                    std::cerr << "Warning: Could not create "
-                                 "auto-relationship: "
-                              << e.what() << std::endl;
-                }
-            }
+            tryAddAutoRelationship(allRelationships,
+                                   tableName,
+                                   fkColumn,
+                                   referencedTable,
+                                   referencedColumn,
+                                   true);
         }
     } >> [](const DrogonDbException &e) {
         std::cerr << "Note: FK auto-detection not available: "

--- a/orm_lib/inc/drogon/orm/BaseBuilder.h
+++ b/orm_lib/inc/drogon/orm/BaseBuilder.h
@@ -188,8 +188,8 @@ class BaseBuilder
         std::string sql = "select " + columns_ + " from " + from_;
         for (const auto &join : joins_)
         {
-            sql += " " + to_join_string(join.type) + " " + join.table +
-                   " ON " + join.onLeft + " = " + join.onRight;
+            sql += " " + to_join_string(join.type) + " " + join.table + " ON " +
+                   join.onLeft + " = " + join.onRight;
         }
         if (!filters_.empty())
         {

--- a/orm_lib/inc/drogon/orm/BaseBuilder.h
+++ b/orm_lib/inc/drogon/orm/BaseBuilder.h
@@ -90,9 +90,9 @@ inline std::string to_join_string(JoinType type)
             return "RIGHT JOIN";
         case JoinType::FullJoin:
             return "FULL JOIN";
-        default:
-            return "INNER JOIN";
     }
+    // Should never reach here
+    return "INNER JOIN";
 }
 
 struct JoinClause
@@ -102,6 +102,33 @@ struct JoinClause
     std::string onLeft;   // e.g. "users.id"
     std::string onRight;  // e.g. "posts.user_id"
 };
+
+/**
+ * @brief Validate that a string is a safe SQL identifier.
+ *
+ * Only allows alphanumeric characters, underscores, and dots
+ * (for table.column notation). This prevents SQL injection when
+ * building JOIN clauses from user-provided identifiers.
+ *
+ * @param identifier The identifier to validate.
+ * @return true if the identifier is safe to use in SQL.
+ */
+inline bool isValidSqlIdentifier(const std::string &identifier)
+{
+    if (identifier.empty())
+    {
+        return false;
+    }
+    for (auto c : identifier)
+    {
+        if (!std::isalnum(static_cast<unsigned char>(c)) && c != '_' &&
+            c != '.')
+        {
+            return false;
+        }
+    }
+    return true;
+}
 
 // Forward declaration to be a friend
 template <typename T, bool SelectAll, bool Single = false>

--- a/orm_lib/inc/drogon/orm/BaseBuilder.h
+++ b/orm_lib/inc/drogon/orm/BaseBuilder.h
@@ -67,6 +67,42 @@ struct Filter
     std::string value;
 };
 
+/**
+ * @brief Represents a SQL JOIN clause.
+ */
+enum class JoinType
+{
+    InnerJoin,
+    LeftJoin,
+    RightJoin,
+    FullJoin
+};
+
+inline std::string to_join_string(JoinType type)
+{
+    switch (type)
+    {
+        case JoinType::InnerJoin:
+            return "INNER JOIN";
+        case JoinType::LeftJoin:
+            return "LEFT JOIN";
+        case JoinType::RightJoin:
+            return "RIGHT JOIN";
+        case JoinType::FullJoin:
+            return "FULL JOIN";
+        default:
+            return "INNER JOIN";
+    }
+}
+
+struct JoinClause
+{
+    JoinType type;
+    std::string table;
+    std::string onLeft;   // e.g. "users.id"
+    std::string onRight;  // e.g. "posts.user_id"
+};
+
 // Forward declaration to be a friend
 template <typename T, bool SelectAll, bool Single = false>
 class TransformBuilder;
@@ -87,6 +123,7 @@ class BaseBuilder
     std::string from_;
     std::string columns_;
     std::vector<Filter> filters_;
+    std::vector<JoinClause> joins_;
     std::optional<std::uint64_t> limit_;
     std::optional<std::uint64_t> offset_;
     // The order is important; use vector<pair> instead of unordered_map and
@@ -122,6 +159,11 @@ class BaseBuilder
         };
 
         std::string sql = "select " + columns_ + " from " + from_;
+        for (const auto &join : joins_)
+        {
+            sql += " " + to_join_string(join.type) + " " + join.table +
+                   " ON " + join.onLeft + " = " + join.onRight;
+        }
         if (!filters_.empty())
         {
             sql += " where " + filters_[0].column + " " +

--- a/orm_lib/inc/drogon/orm/CoroMapper.h
+++ b/orm_lib/inc/drogon/orm/CoroMapper.h
@@ -211,6 +211,54 @@ class CoroMapper : public Mapper<T>
         return *this;
     }
 
+    /**
+     * @brief Add an INNER JOIN clause to the query.
+     *
+     * @param table The table to join.
+     * @param onLeft The left side of ON (e.g. "users.id").
+     * @param onRight The right side of ON (e.g. "posts.user_id").
+     * @return CoroMapper<T>& The CoroMapper itself.
+     */
+    CoroMapper<T> &innerJoin(const std::string &table,
+                             const std::string &onLeft,
+                             const std::string &onRight)
+    {
+        Mapper<T>::innerJoin(table, onLeft, onRight);
+        return *this;
+    }
+
+    /**
+     * @brief Add a LEFT JOIN clause to the query.
+     *
+     * @param table The table to join.
+     * @param onLeft The left side of ON (e.g. "users.id").
+     * @param onRight The right side of ON (e.g. "posts.user_id").
+     * @return CoroMapper<T>& The CoroMapper itself.
+     */
+    CoroMapper<T> &leftJoin(const std::string &table,
+                            const std::string &onLeft,
+                            const std::string &onRight)
+    {
+        Mapper<T>::leftJoin(table, onLeft, onRight);
+        return *this;
+    }
+
+    /**
+     * @brief Add a RIGHT JOIN clause to the query.
+     *
+     * @param table The table to join.
+     * @param onLeft The left side of ON (e.g. "users.id").
+     * @param onRight The right side of ON (e.g. "posts.user_id").
+     * @return CoroMapper<T>& The CoroMapper itself.
+     */
+    CoroMapper<T> &rightJoin(const std::string &table,
+                             const std::string &onLeft,
+                             const std::string &onRight)
+    {
+        Mapper<T>::rightJoin(table, onLeft, onRight);
+        return *this;
+    }
+
     // Read api for coroutines
 
     inline internal::MapperAwaiter<std::vector<T>> findAll()
@@ -225,6 +273,7 @@ class CoroMapper : public Mapper<T>
                                    ExceptPtrCallback &&errCallback) {
             std::string sql = "select count(*) from ";
             sql += T::tableName;
+            sql += this->joinString_;
             if (criteria)
             {
                 sql += " where ";
@@ -250,6 +299,7 @@ class CoroMapper : public Mapper<T>
                                    ExceptPtrCallback &&errCallback) {
             std::string sql = "select * from ";
             sql += T::tableName;
+            sql += this->joinString_;
             bool hasParameters = false;
             if (criteria)
             {
@@ -311,6 +361,7 @@ class CoroMapper : public Mapper<T>
                                    ExceptPtrCallback &&errCallback) {
             std::string sql = "select * from ";
             sql += T::tableName;
+            sql += this->joinString_;
             bool hasParameters = false;
             if (criteria)
             {

--- a/orm_lib/inc/drogon/orm/FilterBuilder.h
+++ b/orm_lib/inc/drogon/orm/FilterBuilder.h
@@ -172,6 +172,9 @@ class FilterBuilder : public TransformBuilder<T, SelectAll, false>
                                     const std::string &onLeft,
                                     const std::string &onRight)
     {
+        assert(isValidSqlIdentifier(table));
+        assert(isValidSqlIdentifier(onLeft));
+        assert(isValidSqlIdentifier(onRight));
         this->joins_.push_back(
             {JoinType::InnerJoin, table, onLeft, onRight});
         return *this;
@@ -191,6 +194,9 @@ class FilterBuilder : public TransformBuilder<T, SelectAll, false>
                                    const std::string &onLeft,
                                    const std::string &onRight)
     {
+        assert(isValidSqlIdentifier(table));
+        assert(isValidSqlIdentifier(onLeft));
+        assert(isValidSqlIdentifier(onRight));
         this->joins_.push_back(
             {JoinType::LeftJoin, table, onLeft, onRight});
         return *this;
@@ -210,6 +216,9 @@ class FilterBuilder : public TransformBuilder<T, SelectAll, false>
                                     const std::string &onLeft,
                                     const std::string &onRight)
     {
+        assert(isValidSqlIdentifier(table));
+        assert(isValidSqlIdentifier(onLeft));
+        assert(isValidSqlIdentifier(onRight));
         this->joins_.push_back(
             {JoinType::RightJoin, table, onLeft, onRight});
         return *this;
@@ -229,6 +238,9 @@ class FilterBuilder : public TransformBuilder<T, SelectAll, false>
                                    const std::string &onLeft,
                                    const std::string &onRight)
     {
+        assert(isValidSqlIdentifier(table));
+        assert(isValidSqlIdentifier(onLeft));
+        assert(isValidSqlIdentifier(onRight));
         this->joins_.push_back(
             {JoinType::FullJoin, table, onLeft, onRight});
         return *this;

--- a/orm_lib/inc/drogon/orm/FilterBuilder.h
+++ b/orm_lib/inc/drogon/orm/FilterBuilder.h
@@ -175,8 +175,7 @@ class FilterBuilder : public TransformBuilder<T, SelectAll, false>
         assert(isValidSqlIdentifier(table));
         assert(isValidSqlIdentifier(onLeft));
         assert(isValidSqlIdentifier(onRight));
-        this->joins_.push_back(
-            {JoinType::InnerJoin, table, onLeft, onRight});
+        this->joins_.push_back({JoinType::InnerJoin, table, onLeft, onRight});
         return *this;
     }
 
@@ -197,8 +196,7 @@ class FilterBuilder : public TransformBuilder<T, SelectAll, false>
         assert(isValidSqlIdentifier(table));
         assert(isValidSqlIdentifier(onLeft));
         assert(isValidSqlIdentifier(onRight));
-        this->joins_.push_back(
-            {JoinType::LeftJoin, table, onLeft, onRight});
+        this->joins_.push_back({JoinType::LeftJoin, table, onLeft, onRight});
         return *this;
     }
 
@@ -219,8 +217,7 @@ class FilterBuilder : public TransformBuilder<T, SelectAll, false>
         assert(isValidSqlIdentifier(table));
         assert(isValidSqlIdentifier(onLeft));
         assert(isValidSqlIdentifier(onRight));
-        this->joins_.push_back(
-            {JoinType::RightJoin, table, onLeft, onRight});
+        this->joins_.push_back({JoinType::RightJoin, table, onLeft, onRight});
         return *this;
     }
 
@@ -241,8 +238,7 @@ class FilterBuilder : public TransformBuilder<T, SelectAll, false>
         assert(isValidSqlIdentifier(table));
         assert(isValidSqlIdentifier(onLeft));
         assert(isValidSqlIdentifier(onRight));
-        this->joins_.push_back(
-            {JoinType::FullJoin, table, onLeft, onRight});
+        this->joins_.push_back({JoinType::FullJoin, table, onLeft, onRight});
         return *this;
     }
 };

--- a/orm_lib/inc/drogon/orm/FilterBuilder.h
+++ b/orm_lib/inc/drogon/orm/FilterBuilder.h
@@ -157,6 +157,82 @@ class FilterBuilder : public TransformBuilder<T, SelectAll, false>
         this->filters_.push_back({column, CompareOperator::Like, pattern});
         return *this;
     }
+
+    /**
+     * @brief Add an INNER JOIN clause to the query.
+     *
+     * @param table The table to join.
+     * @param onLeft The left side of the ON condition (e.g. "users.id").
+     * @param onRight The right side of the ON condition (e.g.
+     * "posts.user_id").
+     *
+     * @return FilterBuilder& The FilterBuilder itself.
+     */
+    inline FilterBuilder &innerJoin(const std::string &table,
+                                    const std::string &onLeft,
+                                    const std::string &onRight)
+    {
+        this->joins_.push_back(
+            {JoinType::InnerJoin, table, onLeft, onRight});
+        return *this;
+    }
+
+    /**
+     * @brief Add a LEFT JOIN clause to the query.
+     *
+     * @param table The table to join.
+     * @param onLeft The left side of the ON condition (e.g. "users.id").
+     * @param onRight The right side of the ON condition (e.g.
+     * "posts.user_id").
+     *
+     * @return FilterBuilder& The FilterBuilder itself.
+     */
+    inline FilterBuilder &leftJoin(const std::string &table,
+                                   const std::string &onLeft,
+                                   const std::string &onRight)
+    {
+        this->joins_.push_back(
+            {JoinType::LeftJoin, table, onLeft, onRight});
+        return *this;
+    }
+
+    /**
+     * @brief Add a RIGHT JOIN clause to the query.
+     *
+     * @param table The table to join.
+     * @param onLeft The left side of the ON condition (e.g. "users.id").
+     * @param onRight The right side of the ON condition (e.g.
+     * "posts.user_id").
+     *
+     * @return FilterBuilder& The FilterBuilder itself.
+     */
+    inline FilterBuilder &rightJoin(const std::string &table,
+                                    const std::string &onLeft,
+                                    const std::string &onRight)
+    {
+        this->joins_.push_back(
+            {JoinType::RightJoin, table, onLeft, onRight});
+        return *this;
+    }
+
+    /**
+     * @brief Add a FULL JOIN clause to the query.
+     *
+     * @param table The table to join.
+     * @param onLeft The left side of the ON condition (e.g. "users.id").
+     * @param onRight The right side of the ON condition (e.g.
+     * "posts.user_id").
+     *
+     * @return FilterBuilder& The FilterBuilder itself.
+     */
+    inline FilterBuilder &fullJoin(const std::string &table,
+                                   const std::string &onLeft,
+                                   const std::string &onRight)
+    {
+        this->joins_.push_back(
+            {JoinType::FullJoin, table, onLeft, onRight});
+        return *this;
+    }
 };
 }  // namespace orm
 }  // namespace drogon

--- a/orm_lib/inc/drogon/orm/Mapper.h
+++ b/orm_lib/inc/drogon/orm/Mapper.h
@@ -178,6 +178,69 @@ class Mapper
      */
     Mapper<T> &forUpdate();
 
+    /**
+     * @brief Add an INNER JOIN clause to the query.
+     *
+     * @param table The table to join.
+     * @param onLeft The left side of ON (e.g. "users.id").
+     * @param onRight The right side of ON (e.g. "posts.user_id").
+     * @return Mapper<T>& The Mapper itself.
+     */
+    Mapper<T> &innerJoin(const std::string &table,
+                         const std::string &onLeft,
+                         const std::string &onRight)
+    {
+        joinString_ += " INNER JOIN ";
+        joinString_ += table;
+        joinString_ += " ON ";
+        joinString_ += onLeft;
+        joinString_ += " = ";
+        joinString_ += onRight;
+        return *this;
+    }
+
+    /**
+     * @brief Add a LEFT JOIN clause to the query.
+     *
+     * @param table The table to join.
+     * @param onLeft The left side of ON (e.g. "users.id").
+     * @param onRight The right side of ON (e.g. "posts.user_id").
+     * @return Mapper<T>& The Mapper itself.
+     */
+    Mapper<T> &leftJoin(const std::string &table,
+                        const std::string &onLeft,
+                        const std::string &onRight)
+    {
+        joinString_ += " LEFT JOIN ";
+        joinString_ += table;
+        joinString_ += " ON ";
+        joinString_ += onLeft;
+        joinString_ += " = ";
+        joinString_ += onRight;
+        return *this;
+    }
+
+    /**
+     * @brief Add a RIGHT JOIN clause to the query.
+     *
+     * @param table The table to join.
+     * @param onLeft The left side of ON (e.g. "users.id").
+     * @param onRight The right side of ON (e.g. "posts.user_id").
+     * @return Mapper<T>& The Mapper itself.
+     */
+    Mapper<T> &rightJoin(const std::string &table,
+                         const std::string &onLeft,
+                         const std::string &onRight)
+    {
+        joinString_ += " RIGHT JOIN ";
+        joinString_ += table;
+        joinString_ += " ON ";
+        joinString_ += onLeft;
+        joinString_ += " = ";
+        joinString_ += onRight;
+        return *this;
+    }
+
     using SingleRowCallback = std::function<void(T)>;
     using MultipleRowsCallback = std::function<void(std::vector<T>)>;
     using CountCallback = std::function<void(const size_t)>;
@@ -719,6 +782,7 @@ class Mapper
     size_t limit_{0};
     size_t offset_{0};
     std::string orderByString_;
+    std::string joinString_;
     bool forUpdate_{false};
 
     void clear()
@@ -726,6 +790,7 @@ class Mapper
         limit_ = 0;
         offset_ = 0;
         orderByString_.clear();
+        joinString_.clear();
         forUpdate_ = false;
     }
 
@@ -792,6 +857,7 @@ inline T Mapper<T>::findOne(const Criteria &criteria) noexcept(false)
 {
     std::string sql = "select * from ";
     sql += T::tableName;
+    sql += joinString_;
     bool hasParameters = false;
     if (criteria)
     {
@@ -849,6 +915,7 @@ inline void Mapper<T>::findOne(const Criteria &criteria,
 {
     std::string sql = "select * from ";
     sql += T::tableName;
+    sql += joinString_;
     bool hasParameters = false;
     if (criteria)
     {
@@ -904,6 +971,7 @@ inline std::future<T> Mapper<T>::findFutureOne(
 {
     std::string sql = "select * from ";
     sql += T::tableName;
+    sql += joinString_;
     bool hasParameters = false;
     if (criteria)
     {
@@ -964,6 +1032,7 @@ inline std::vector<T> Mapper<T>::findBy(const Criteria &criteria) noexcept(
 {
     std::string sql = "select * from ";
     sql += T::tableName;
+    sql += joinString_;
     bool hasParameters = false;
     if (criteria)
     {
@@ -1017,6 +1086,7 @@ inline void Mapper<T>::findBy(const Criteria &criteria,
 {
     std::string sql = "select * from ";
     sql += T::tableName;
+    sql += joinString_;
     bool hasParameters = false;
     if (criteria)
     {
@@ -1066,6 +1136,7 @@ inline std::future<std::vector<T>> Mapper<T>::findFutureBy(
 {
     std::string sql = "select * from ";
     sql += T::tableName;
+    sql += joinString_;
     bool hasParameters = false;
     if (criteria)
     {
@@ -1137,6 +1208,7 @@ inline size_t Mapper<T>::count(const Criteria &criteria) noexcept(false)
 {
     std::string sql = "select count(*) from ";
     sql += T::tableName;
+    sql += joinString_;
     if (criteria)
     {
         sql += " where ";
@@ -1164,6 +1236,7 @@ inline void Mapper<T>::count(const Criteria &criteria,
 {
     std::string sql = "select count(*) from ";
     sql += T::tableName;
+    sql += joinString_;
     if (criteria)
     {
         sql += " where ";
@@ -1187,6 +1260,7 @@ inline std::future<size_t> Mapper<T>::countFuture(
 {
     std::string sql = "select count(*) from ";
     sql += T::tableName;
+    sql += joinString_;
     if (criteria)
     {
         sql += " where ";

--- a/orm_lib/inc/drogon/orm/Mapper.h
+++ b/orm_lib/inc/drogon/orm/Mapper.h
@@ -190,6 +190,9 @@ class Mapper
                          const std::string &onLeft,
                          const std::string &onRight)
     {
+        assert(isValidSqlIdentifier(table));
+        assert(isValidSqlIdentifier(onLeft));
+        assert(isValidSqlIdentifier(onRight));
         joinString_ += " INNER JOIN ";
         joinString_ += table;
         joinString_ += " ON ";
@@ -211,6 +214,9 @@ class Mapper
                         const std::string &onLeft,
                         const std::string &onRight)
     {
+        assert(isValidSqlIdentifier(table));
+        assert(isValidSqlIdentifier(onLeft));
+        assert(isValidSqlIdentifier(onRight));
         joinString_ += " LEFT JOIN ";
         joinString_ += table;
         joinString_ += " ON ";
@@ -232,6 +238,9 @@ class Mapper
                          const std::string &onLeft,
                          const std::string &onRight)
     {
+        assert(isValidSqlIdentifier(table));
+        assert(isValidSqlIdentifier(onLeft));
+        assert(isValidSqlIdentifier(onRight));
         joinString_ += " RIGHT JOIN ";
         joinString_ += table;
         joinString_ += " ON ";

--- a/orm_lib/inc/drogon/orm/Mapper.h
+++ b/orm_lib/inc/drogon/orm/Mapper.h
@@ -14,6 +14,7 @@
 
 #pragma once
 #include <drogon/orm/Criteria.h>
+#include <drogon/orm/BaseBuilder.h>
 #include <drogon/orm/DbClient.h>
 #include <drogon/utils/Utilities.h>
 #include <string>


### PR DESCRIPTION
This addresses #241.

After studying the codebase, I noticed that Drogon already has a solid relationship system — the Relationship class, PivotTable, CSP template code generation, and the lazy loading getRelated() methods all work well through the JSON config. What's missing are three things: JOIN clause support in the query builder, join methods on the Mapper, and automatic foreign key detection in the code generator so users don't have to manually write relationship JSON for every FK constraint.This PR adds all three. The BaseBuilder now has a JoinClause struct and emits JOIN clauses in gen_sql() between FROM and WHERE. FilterBuilder and Mapper both get fluent innerJoin(), leftJoin(), rightJoin() methods that chain naturally with the existing API. On the code generator side, I added FK detection queries for all three backends — PostgreSQL via information_schema, MySQL via KEY_COLUMN_USAGE, and SQLite3 via PRAGMA foreign_key_list. The detected FKs get converted into Relationship objects and merged with any user-specified config, where user config always takes priority. The detection is best-effort so it won't break anything if a database doesn't support FK introspection.
Everything is additive and fully backward compatible — no existing APIs were changed or removed. 
