### PR TITLE
Add: setQueryParameter/setBodyParameter methods

### DIFF
--- a/lib/inc/drogon/HttpRequest.h
+++ b/lib/inc/drogon/HttpRequest.h
@@ -415,6 +415,8 @@ class DROGON_EXPORT HttpRequest
     virtual void setMethod(const HttpMethod method) = 0;
 
     /// Set the path of the request
+    /// @note The path is automatically encoded. use
+    /// @c setPathEncode(false) to avoid this.
     virtual void setPath(const std::string &path) = 0;
     virtual void setPath(std::string &&path) = 0;
 
@@ -430,6 +432,20 @@ class DROGON_EXPORT HttpRequest
 
     /// Set the parameter of the request
     virtual void setParameter(const std::string &key,
+                              const std::string &value) = 0;
+
+    /**
+     * Set the parameter to the query,
+     * regardless of the HTTP method or content type
+     */
+    virtual void setQueryParameter(const std::string &key,
+                              const std::string &value) = 0;
+    /**
+     * Set the parameter to the request body.
+     * @warning The content type must be @c application/x-www-form-urlencoded
+     * or @c multipart/form-data
+     */
+    virtual void setBodyParameter(const std::string &key,
                               const std::string &value) = 0;
 
     /// Set or get the content type

--- a/lib/inc/drogon/HttpRequest.h
+++ b/lib/inc/drogon/HttpRequest.h
@@ -439,14 +439,14 @@ class DROGON_EXPORT HttpRequest
      * regardless of the HTTP method or content type
      */
     virtual void setQueryParameter(const std::string &key,
-                              const std::string &value) = 0;
+                                   const std::string &value) = 0;
     /**
      * Set the parameter to the request body.
      * @warning The content type must be @c application/x-www-form-urlencoded
      * or @c multipart/form-data
      */
     virtual void setBodyParameter(const std::string &key,
-                              const std::string &value) = 0;
+                                  const std::string &value) = 0;
 
     /// Set or get the content type
     virtual void setContentTypeCode(const ContentType type) = 0;

--- a/lib/src/HttpRequestImpl.cc
+++ b/lib/src/HttpRequestImpl.cc
@@ -236,7 +236,7 @@ void HttpRequestImpl::appendToBuffer(trantor::MsgBuffer *output) const
     }
 
     std::string content;
-    if (passThrough_ && !query_.empty())
+    if (!query_.empty())
     {
         output->append("?");
         output->append(query_);

--- a/lib/src/HttpRequestImpl.h
+++ b/lib/src/HttpRequestImpl.h
@@ -408,6 +408,24 @@ class HttpRequestImpl : public HttpRequest
         parameters_[key] = value;
     }
 
+    void setQueryParameter(const std::string &key, const std::string &value) override
+    {
+        if (!query_.empty())
+        {
+            query_.append("&");
+        }
+        query_.append(utils::urlEncodeComponent(key));
+        query_.append("=");
+        query_.append(utils::urlEncodeComponent(value));
+    }
+
+    void setBodyParameter(const std::string &key, const std::string &value) override
+    {
+        assert(contentType_ == CT_MULTIPART_FORM_DATA || contentType_ == CT_APPLICATION_X_FORM);
+        flagForParsingParameters_ = true;
+        parameters_[key] = value;
+    }
+
     const std::string &getContent() const
     {
         return content_;

--- a/lib/src/HttpRequestImpl.h
+++ b/lib/src/HttpRequestImpl.h
@@ -408,7 +408,8 @@ class HttpRequestImpl : public HttpRequest
         parameters_[key] = value;
     }
 
-    void setQueryParameter(const std::string &key, const std::string &value) override
+    void setQueryParameter(const std::string &key,
+                           const std::string &value) override
     {
         if (!query_.empty())
         {
@@ -419,9 +420,11 @@ class HttpRequestImpl : public HttpRequest
         query_.append(utils::urlEncodeComponent(value));
     }
 
-    void setBodyParameter(const std::string &key, const std::string &value) override
+    void setBodyParameter(const std::string &key,
+                          const std::string &value) override
     {
-        assert(contentType_ == CT_MULTIPART_FORM_DATA || contentType_ == CT_APPLICATION_X_FORM);
+        assert(contentType_ == CT_MULTIPART_FORM_DATA ||
+               contentType_ == CT_APPLICATION_X_FORM);
         flagForParsingParameters_ = true;
         parameters_[key] = value;
     }


### PR DESCRIPTION
issue #2489

setQueryParameter adds a parameter to the URL query string, regardless of the HTTP method or content type. setBodyParameter adds a parameter to the request text and requires the content type to be application/x-www-form-urlencoded or multipart/form-data. A note has also been added to the setPath doc comment about
automatic path encoding