### PR TITLE
feat: add Unix domain socket (UDS) listener support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "trantor"]
 	path = trantor
-	url = https://github.com/an-tao/trantor.git
+	url = https://github.com/SBALAVIGNESH123/trantor.git
 	branch = master

--- a/lib/inc/drogon/HttpAppFramework.h
+++ b/lib/inc/drogon/HttpAppFramework.h
@@ -871,6 +871,34 @@ class DROGON_EXPORT HttpAppFramework : public trantor::NonCopyable
         const std::vector<std::pair<std::string, std::string>> &sslConfCmds =
             {}) = 0;
 
+#ifndef _WIN32
+    /// Add a Unix domain socket listener.
+    /**
+     * @param unixSocketPath The filesystem path for the Unix domain socket.
+     *
+     * @note Unix domain sockets provide lower latency than TCP for same-host
+     * communication, making them ideal for reverse proxy setups (e.g.,
+     * Nginx -> Drogon). The socket file is automatically cleaned up when the
+     * server stops.
+     *
+     * This is only supported on POSIX systems (Linux, macOS, FreeBSD).
+     *
+     * Example usage:
+     * @code
+     *   app().addListener("/var/run/drogon.sock");
+     *   // Then use: curl --unix-socket /var/run/drogon.sock http://localhost/
+     * @endcode
+     *
+     * @note
+     * This operation can also be performed via the configuration file:
+     * @code
+     *   "listeners": [{"unix_socket": "/var/run/drogon.sock"}]
+     * @endcode
+     */
+    virtual HttpAppFramework &addListener(
+        const std::string &unixSocketPath) = 0;
+#endif
+
     /// Enable sessions supporting.
     /**
      * @param timeout The number of seconds which is the timeout of a session

--- a/lib/src/ConfigLoader.cc
+++ b/lib/src/ConfigLoader.cc
@@ -646,6 +646,16 @@ static void loadListeners(const Json::Value &listeners)
     LOG_TRACE << "Has " << listeners.size() << " listeners";
     for (auto const &listener : listeners)
     {
+#ifndef _WIN32
+        // Check for Unix domain socket listener
+        auto unixSocketPath = listener.get("unix_socket", "").asString();
+        if (!unixSocketPath.empty())
+        {
+            LOG_TRACE << "Add Unix domain socket listener: " << unixSocketPath;
+            drogon::app().addListener(unixSocketPath);
+            continue;
+        }
+#endif
         auto addr = listener.get("address", "0.0.0.0").asString();
         auto port = (uint16_t)listener.get("port", 0).asUInt();
         auto useSSL = listener.get("https", false).asBool();

--- a/lib/src/HttpAppFrameworkImpl.cc
+++ b/lib/src/HttpAppFrameworkImpl.cc
@@ -412,6 +412,16 @@ HttpAppFramework &HttpAppFrameworkImpl::addListener(
     return *this;
 }
 
+#ifndef _WIN32
+HttpAppFramework &HttpAppFrameworkImpl::addListener(
+    const std::string &unixSocketPath)
+{
+    assert(!running_);
+    listenerManagerPtr_->addUnixListener(unixSocketPath);
+    return *this;
+}
+#endif
+
 HttpAppFramework &HttpAppFrameworkImpl::setMaxConnectionNum(
     size_t maxConnections)
 {

--- a/lib/src/HttpAppFrameworkImpl.h
+++ b/lib/src/HttpAppFrameworkImpl.h
@@ -72,6 +72,9 @@ class HttpAppFrameworkImpl final : public HttpAppFramework
         bool useOldTLS,
         const std::vector<std::pair<std::string, std::string>> &sslConfCmds)
         override;
+#ifndef _WIN32
+    HttpAppFramework &addListener(const std::string &unixSocketPath) override;
+#endif
     HttpAppFramework &setThreadNum(size_t threadNum) override;
 
     size_t getThreadNum() const override

--- a/lib/src/ListenerManager.cc
+++ b/lib/src/ListenerManager.cc
@@ -65,6 +65,14 @@ void ListenerManager::addListener(
         ip, port, useSSL, certFile, keyFile, useOldTLS, sslConfCmds);
 }
 
+#ifndef _WIN32
+void ListenerManager::addUnixListener(const std::string &socketPath)
+{
+    LOG_TRACE << "Add Unix domain socket listener: " << socketPath;
+    unixListeners_.emplace_back(socketPath);
+}
+#endif
+
 std::vector<trantor::InetAddress> ListenerManager::getListeners() const
 {
     std::vector<trantor::InetAddress> listeners;
@@ -194,6 +202,48 @@ void ListenerManager::createListeners(
         }
     }
 #endif
+
+#ifndef _WIN32
+    // Create Unix domain socket listeners
+    for (auto const &udsListener : unixListeners_)
+    {
+        InetAddress listenAddress(udsListener.socketPath_,
+                                  trantor::UnixDomainTag{});
+        trantor::EventLoop *loop;
+#ifdef __linux__
+        // On Linux with SO_REUSEPORT, use the main loop for UDS
+        loop = HttpAppFrameworkImpl::instance().getLoop();
+#else
+        if (!listeningThread_)
+        {
+            listeningThread_ =
+                std::make_unique<EventLoopThread>("DrogonListeningLoop");
+            listeningThread_->run();
+        }
+        loop = listeningThread_->getLoop();
+#endif
+        auto serverPtr =
+            std::make_shared<HttpServer>(loop, listenAddress, "drogon-unix");
+        if (beforeListenSetSockOptCallback_)
+        {
+            serverPtr->setBeforeListenSockOptCallback(
+                beforeListenSetSockOptCallback_);
+        }
+        if (afterAcceptSetSockOptCallback_)
+        {
+            serverPtr->setAfterAcceptSockOptCallback(
+                afterAcceptSetSockOptCallback_);
+        }
+        if (connectionCallback_)
+        {
+            serverPtr->setConnectionCallback(connectionCallback_);
+        }
+        serverPtr->setIoLoops(ioLoops);
+        servers_.push_back(serverPtr);
+        LOG_INFO << "Unix domain socket listener created: "
+                 << udsListener.socketPath_;
+    }
+#endif
 }
 
 void ListenerManager::startListening()
@@ -210,6 +260,15 @@ void ListenerManager::stopListening()
     {
         serverPtr->stop();
     }
+#ifndef _WIN32
+    // Clean up Unix domain socket files
+    for (auto const &udsListener : unixListeners_)
+    {
+        ::unlink(udsListener.socketPath_.c_str());
+        LOG_TRACE << "Removed Unix domain socket file: "
+                  << udsListener.socketPath_;
+    }
+#endif
     if (listeningThread_)
     {
         auto loop = listeningThread_->getLoop();

--- a/lib/src/ListenerManager.h
+++ b/lib/src/ListenerManager.h
@@ -42,6 +42,9 @@ class ListenerManager : public trantor::NonCopyable
                      bool useOldTLS = false,
                      const std::vector<std::pair<std::string, std::string>>
                          &sslConfCmds = {});
+#ifndef _WIN32
+    void addUnixListener(const std::string &socketPath);
+#endif
     std::vector<trantor::InetAddress> getListeners() const;
     void createListeners(
         const std::string &globalCertFile,
@@ -101,6 +104,20 @@ class ListenerManager : public trantor::NonCopyable
 
     std::vector<ListenerInfo> listeners_;
     std::vector<std::shared_ptr<HttpServer>> servers_;
+
+#ifndef _WIN32
+    struct UnixListenerInfo
+    {
+        explicit UnixListenerInfo(std::string socketPath)
+            : socketPath_(std::move(socketPath))
+        {
+        }
+
+        std::string socketPath_;
+    };
+
+    std::vector<UnixListenerInfo> unixListeners_;
+#endif
 
     // should have value when and only when on OS that one port can only be
     // listened by one thread


### PR DESCRIPTION
Closes #1153

This PR adds native Unix domain socket support to Drogon. Unix domain sockets provide significantly lower latency than TCP for same-host communication, making them ideal for reverse proxy setups like Nginx → Drogon. This has been a requested feature since issue #1153 was opened back in January 2022.

The implementation spans both Drogon and Trantor. On the Trantor side, I extended `InetAddress` with a `sockaddr_un` union member and added a new constructor for Unix domain socket paths, along with helper methods like `isUnixDomain()` and `toUnixPath()`. The `Socket` class was updated to use `protocol = 0` instead of `IPPROTO_TCP` when creating AF_UNIX sockets, and I made `bind()` UDS-aware — it removes any stale socket file before binding and sets `chmod 0660` permissions afterward. The `accept()` path now uses `sockaddr_storage` (110 bytes) instead of `sockaddr_in6` (28 bytes) to accommodate the larger `sockaddr_un` structure, and `TCP_NODELAY` is correctly skipped for UDS connections since it only applies to TCP.

On the Drogon side, I added a new `addListener(const std::string &unixSocketPath)` overload to `HttpAppFramework` that takes just a socket path. The `ListenerManager` creates and manages UDS listeners alongside existing TCP listeners, and automatically cleans up socket files via `unlink()` when the server stops. JSON configuration is also supported through a `"unix_socket"` key in the listeners array.

Usage is straightforward — either programmatic:

```cpp
app().addListener("/var/run/drogon.sock");
