### PR TITLE
Fix Cookie::stricmp to safely lowercase signed chars

### DIFF
--- a/lib/inc/drogon/Cookie.h
+++ b/lib/inc/drogon/Cookie.h
@@ -359,7 +359,8 @@ class DROGON_EXPORT Cookie
             return false;
         for (size_t idx{0}; idx < str1Len; ++idx)
         {
-            auto lowerChar{tolower(str1[idx])};
+            auto lowerChar{static_cast<char>(
+                std::tolower(static_cast<unsigned char>(str1[idx])))};
 
             if (lowerChar != str2[idx])
             {


### PR DESCRIPTION

Fix undefined behavior in cookie SameSite case-insensitive comparison.

`Cookie::stricmp` used `tolower(str1[idx])` directly on `char`.  
When `char` is signed and contains non-ASCII byte values, calling `tolower` this way is undefined behavior.

Cast each character to `unsigned char` before passing it to `std::tolower`, then cast back to `char` for comparison.

This makes SameSite string comparison standards-compliant and safe across platforms/char signedness, with no behavior change for normal ASCII inputs.
- Built `unittest` target.
- Ran: `./build/lib/tests/unittest -r CookieTest -s`
- Result: **All tests passed** (12 assertions, 1 test case).
- Minimal, targeted change in cookie comparison logic only.
- No API changes.
