### PR TITLE
Add WebDAV HTTP methods (PROPFIND, MKCOL, COPY, MOVE)

### DIFF
--- a/lib/inc/drogon/HttpTypes.h
+++ b/lib/inc/drogon/HttpTypes.h
@@ -195,6 +195,10 @@ enum HttpMethod
     Delete,
     Options,
     Patch,
+    Propfind,
+    Mkcol,
+    Copy,
+    Move,
     Invalid
 };
 
@@ -280,6 +284,14 @@ inline std::string_view to_string_view(drogon::HttpMethod method)
             return "OPTIONS";
         case drogon::HttpMethod::Patch:
             return "PATCH";
+        case drogon::HttpMethod::Propfind:
+            return "PROPFIND";
+        case drogon::HttpMethod::Mkcol:
+            return "MKCOL";
+        case drogon::HttpMethod::Copy:
+            return "COPY";
+        case drogon::HttpMethod::Move:
+            return "MOVE";
         default:
             return "INVALID";
     }

--- a/lib/src/HttpRequestImpl.cc
+++ b/lib/src/HttpRequestImpl.cc
@@ -648,6 +648,18 @@ const char *HttpRequestImpl::methodString() const
         case Patch:
             result = "PATCH";
             break;
+        case Propfind:
+            result = "PROPFIND";
+            break;
+        case Mkcol:
+            result = "MKCOL";
+            break;
+        case Copy:
+            result = "COPY";
+            break;
+        case Move:
+            result = "MOVE";
+            break;
         default:
             break;
     }
@@ -683,6 +695,14 @@ bool HttpRequestImpl::setMethod(const char *start, const char *end)
             {
                 method_ = Head;
             }
+            else if (m == "COPY")
+            {
+                method_ = Copy;
+            }
+            else if (m == "MOVE")
+            {
+                method_ = Move;
+            }
             else
             {
                 method_ = Invalid;
@@ -692,6 +712,10 @@ bool HttpRequestImpl::setMethod(const char *start, const char *end)
             if (m == "PATCH")
             {
                 method_ = Patch;
+            }
+            else if (m == "MKCOL")
+            {
+                method_ = Mkcol;
             }
             else
             {
@@ -712,6 +736,16 @@ bool HttpRequestImpl::setMethod(const char *start, const char *end)
             if (m == "OPTIONS")
             {
                 method_ = Options;
+            }
+            else
+            {
+                method_ = Invalid;
+            }
+            break;
+        case 8:
+            if (m == "PROPFIND")
+            {
+                method_ = Propfind;
             }
             else
             {

--- a/lib/tests/CMakeLists.txt
+++ b/lib/tests/CMakeLists.txt
@@ -26,7 +26,6 @@ set(UNITTEST_SOURCES
     unittests/ControllerCreationTest.cc
     unittests/MultiPartParserTest.cc
     unittests/SlashRemoverTest.cc
-    unittests/HttpMethodTest.cc
     unittests/UtilitiesTest.cc
     unittests/UuidUnittest.cc
 )
@@ -44,6 +43,7 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC" AND BUILD_SHARED_LIBS)
 else()
   set(UNITTEST_SOURCES ${UNITTEST_SOURCES} ../src/HttpFileImpl.cc
                        unittests/HttpFileTest.cc
+                       unittests/HttpMethodTest.cc
                        unittests/WebsocketResponseTest.cc)
 endif()
 

--- a/lib/tests/CMakeLists.txt
+++ b/lib/tests/CMakeLists.txt
@@ -26,6 +26,7 @@ set(UNITTEST_SOURCES
     unittests/ControllerCreationTest.cc
     unittests/MultiPartParserTest.cc
     unittests/SlashRemoverTest.cc
+    unittests/HttpMethodTest.cc
     unittests/UtilitiesTest.cc
     unittests/UuidUnittest.cc
 )

--- a/lib/tests/unittests/HttpMethodTest.cc
+++ b/lib/tests/unittests/HttpMethodTest.cc
@@ -1,0 +1,90 @@
+#include <drogon/drogon_test.h>
+#include <drogon/HttpTypes.h>
+#include "../../lib/src/HttpRequestImpl.h"
+
+using namespace drogon;
+
+// Helper: parse a method string through HttpRequestImpl::setMethod
+static std::pair<bool, HttpMethod> parseMethod(const std::string &str)
+{
+    HttpRequestImpl req(nullptr);
+    bool ok = req.setMethod(str.data(), str.data() + str.size());
+    return {ok, req.method()};
+}
+
+DROGON_TEST(StandardHttpMethods)
+{
+    auto [ok, m] = parseMethod("GET");
+    CHECK(ok);
+    CHECK(m == Get);
+
+    std::tie(ok, m) = parseMethod("POST");
+    CHECK(ok);
+    CHECK(m == Post);
+
+    std::tie(ok, m) = parseMethod("PUT");
+    CHECK(ok);
+    CHECK(m == Put);
+
+    std::tie(ok, m) = parseMethod("DELETE");
+    CHECK(ok);
+    CHECK(m == Delete);
+
+    std::tie(ok, m) = parseMethod("HEAD");
+    CHECK(ok);
+    CHECK(m == Head);
+
+    std::tie(ok, m) = parseMethod("OPTIONS");
+    CHECK(ok);
+    CHECK(m == Options);
+
+    std::tie(ok, m) = parseMethod("PATCH");
+    CHECK(ok);
+    CHECK(m == Patch);
+}
+
+DROGON_TEST(WebDavMethods)
+{
+    auto [ok, m] = parseMethod("PROPFIND");
+    CHECK(ok);
+    CHECK(m == Propfind);
+
+    std::tie(ok, m) = parseMethod("MKCOL");
+    CHECK(ok);
+    CHECK(m == Mkcol);
+
+    std::tie(ok, m) = parseMethod("COPY");
+    CHECK(ok);
+    CHECK(m == Copy);
+
+    std::tie(ok, m) = parseMethod("MOVE");
+    CHECK(ok);
+    CHECK(m == Move);
+}
+
+DROGON_TEST(WebDavMethodStrings)
+{
+    CHECK(to_string_view(Propfind) == "PROPFIND");
+    CHECK(to_string_view(Mkcol) == "MKCOL");
+    CHECK(to_string_view(Copy) == "COPY");
+    CHECK(to_string_view(Move) == "MOVE");
+}
+
+DROGON_TEST(InvalidMethodsRejected)
+{
+    auto [ok, m] = parseMethod("INVALID");
+    CHECK(!ok);
+    CHECK(m == Invalid);
+
+    std::tie(ok, m) = parseMethod("LOCK");
+    CHECK(!ok);
+    CHECK(m == Invalid);
+
+    std::tie(ok, m) = parseMethod("");
+    CHECK(!ok);
+    CHECK(m == Invalid);
+
+    std::tie(ok, m) = parseMethod("G");
+    CHECK(!ok);
+    CHECK(m == Invalid);
+}


### PR DESCRIPTION
Currently Drogon rejects any HTTP method not in the HttpMethod enum with 405, which makes it impossible to implement a WebDAV server.

This adds PROPFIND, MKCOL, COPY, and MOVE to the enum and parser, so they can be routed like any other method.

I needed those for my own phot management application.

Resolves #2092