### PR TITLE
Add HttpRequest::clearHeaders() to clear all headers efficiently (#2046)

### DIFF
--- a/lib/inc/drogon/HttpRequest.h
+++ b/lib/inc/drogon/HttpRequest.h
@@ -159,6 +159,9 @@ class DROGON_EXPORT HttpRequest
      */
     virtual void removeHeader(std::string key) = 0;
 
+    // Clear all HTTP headers
+    virtual void clearHeaders() = 0;
+
     /// Get the cookie string identified by the field parameter
     virtual const std::string &getCookie(const std::string &field) const = 0;
 

--- a/lib/src/HttpRequestImpl.h
+++ b/lib/src/HttpRequestImpl.h
@@ -351,6 +351,11 @@ class HttpRequestImpl : public HttpRequest
         headers_.erase(lowerKey);
     }
 
+    void clearHeaders() override
+    {
+        headers_.clear();
+    }
+
     const std::string &getHeader(std::string field) const override
     {
         std::transform(field.begin(),

--- a/lib/tests/unittests/HttpHeaderTest.cc
+++ b/lib/tests/unittests/HttpHeaderTest.cc
@@ -239,3 +239,22 @@ DROGON_TEST(AddHttpCorsHeaders)
     resp->addCorsHeaders(req);
     CHECK(resp->getHeader("Access-Control-Allow-Credentials") == "true");
 }
+
+DROGON_TEST(ClearHeaders)
+{
+    auto req = HttpRequest::newHttpRequest();
+    // set a custom path to ensure it is not cleared
+    req->setPath("/api/test");
+    req->addHeader("X-Test", "value");
+    req->addHeader("Authorization", "Bearer token");
+
+    CHECK(req->headers().size() == 2);
+    CHECK(req->getHeader("X-Test") == "value");
+    CHECK(req->getHeader("Authorization") == "Bearer token");
+
+    req->clearHeaders();
+
+    CHECK(req->headers().empty());
+    // verify path unchanged
+    CHECK(req->path() == "/api/test");
+}


### PR DESCRIPTION
Add clearHeaders() method to reuse HttpRequestPtr efficiently.

Closes #2046