### PR TITLE
Fix HttpClient not sending WebDAV requests

### DIFF
--- a/lib/src/HttpRequestImpl.cc
+++ b/lib/src/HttpRequestImpl.cc
@@ -215,6 +215,18 @@ void HttpRequestImpl::appendToBuffer(trantor::MsgBuffer *output) const
         case Patch:
             output->append("PATCH ");
             break;
+        case Propfind:
+            output->append("PROPFIND ");
+            break;
+        case Mkcol:
+            output->append("MKCOL ");
+            break;
+        case Copy:
+            output->append("COPY ");
+            break;
+        case Move:
+            output->append("MOVE ");
+            break;
         default:
             return;
     }

--- a/lib/tests/unittests/HttpMethodTest.cc
+++ b/lib/tests/unittests/HttpMethodTest.cc
@@ -1,5 +1,6 @@
 #include <drogon/drogon_test.h>
 #include <drogon/HttpTypes.h>
+#include <trantor/utils/MsgBuffer.h>
 #include "../../lib/src/HttpRequestImpl.h"
 
 using namespace drogon;
@@ -68,6 +69,35 @@ DROGON_TEST(WebDavMethodStrings)
     CHECK(to_string_view(Mkcol) == "MKCOL");
     CHECK(to_string_view(Copy) == "COPY");
     CHECK(to_string_view(Move) == "MOVE");
+}
+
+// Helper: serialize a request and return the first line (method + path)
+static std::string serializeMethod(HttpMethod method)
+{
+    HttpRequestImpl req(nullptr);
+    req.setMethod(method);
+    req.setPath("/test");
+    trantor::MsgBuffer buf;
+    req.appendToBuffer(&buf);
+    std::string result(buf.peek(), buf.readableBytes());
+    // Return just up to the first space after the method
+    auto pos = result.find(' ');
+    return result.substr(0, pos);
+}
+
+DROGON_TEST(MethodSerialization)
+{
+    CHECK(serializeMethod(Get) == "GET");
+    CHECK(serializeMethod(Post) == "POST");
+    CHECK(serializeMethod(Put) == "PUT");
+    CHECK(serializeMethod(Delete) == "DELETE");
+    CHECK(serializeMethod(Head) == "HEAD");
+    CHECK(serializeMethod(Options) == "OPTIONS");
+    CHECK(serializeMethod(Patch) == "PATCH");
+    CHECK(serializeMethod(Propfind) == "PROPFIND");
+    CHECK(serializeMethod(Mkcol) == "MKCOL");
+    CHECK(serializeMethod(Copy) == "COPY");
+    CHECK(serializeMethod(Move) == "MOVE");
 }
 
 DROGON_TEST(InvalidMethodsRejected)


### PR DESCRIPTION
`appendToBuffer()` didn't have cases for the methods added in #2505. Falls through to `default: return;` which writes nothing to the buffer, so the connection opens but no request is ever sent.

Server side (`setMethod`, `methodString`) was fine, only the client serialization was missed as I did not need it yet.

Both server and client are now working properly with WebDAV requests