### PR TITLE
Fix ConfigLoader bytesSize failing to parse value ending by 6

### DIFF
--- a/lib/src/ConfigLoader.cc
+++ b/lib/src/ConfigLoader.cc
@@ -81,6 +81,7 @@ static bool bytesSize(std::string &sizeStr, size_t &size)
             case '3':
             case '4':
             case '5':
+            case '6':
             case '7':
             case '8':
             case '9':


### PR DESCRIPTION
 Any digit-only byte size whose last character is '6' causes the server to refuse to start with "Error format of client_max_body_size". So "client_max_body_size": "16" or "60000006" or "1048576" (= 1 MiB literal) all break Drogon startup.

Easy fix by including the `case '6':` line