### PR TITLE
Add coroutine WebSocket controller API and integration tests

### DIFF
--- a/lib/inc/drogon/WebSocketController.h
+++ b/lib/inc/drogon/WebSocketController.h
@@ -164,7 +164,8 @@ class WebSocketCoroControllerBase : public WebSocketControllerBase
 };
 
 /**
- * @brief Reflection base class template for coroutine WebSocket controllers.
+ * @brief Reflection base class template for coroutine WebSocket
+ * controllers.
  */
 template <typename T, bool AutoCreation = true>
 class WebSocketCoroController : public DrObject<T>,

--- a/lib/inc/drogon/WebSocketController.h
+++ b/lib/inc/drogon/WebSocketController.h
@@ -152,33 +152,6 @@ class WebSocketCoroControllerBase : public WebSocketControllerBase
   public:
     ~WebSocketCoroControllerBase() override = default;
 
-    void handleNewMessage(const WebSocketConnectionPtr &conn,
-                          std::string &&message,
-                          const WebSocketMessageType &type) final
-    {
-        drogon::async_run([this,
-                           conn,
-                           message = std::move(message),
-                           type]() mutable -> Task<> {
-            co_await handleNewMessageCoro(conn, std::move(message), type);
-        });
-    }
-
-    void handleNewConnection(const HttpRequestPtr &req,
-                             const WebSocketConnectionPtr &conn) final
-    {
-        drogon::async_run([this, req, conn]() mutable -> Task<> {
-            co_await handleNewConnectionCoro(req, conn);
-        });
-    }
-
-    void handleConnectionClosed(const WebSocketConnectionPtr &conn) final
-    {
-        drogon::async_run([this, conn]() mutable -> Task<> {
-            co_await handleConnectionClosedCoro(conn);
-        });
-    }
-
     virtual Task<> handleNewMessageCoro(const WebSocketConnectionPtr &,
                                         std::string &&,
                                         const WebSocketMessageType &) = 0;
@@ -202,6 +175,38 @@ class WebSocketCoroController : public DrObject<T>,
 
     virtual ~WebSocketCoroController()
     {
+    }
+
+    void handleNewMessage(const WebSocketConnectionPtr &conn,
+                          std::string &&message,
+                          const WebSocketMessageType &type) final
+    {
+        auto objPtr = DrClassMap::getSingleInstance<T>();
+        drogon::async_run([objPtr,
+                           conn,
+                           message = std::move(message),
+                           type]() mutable -> Task<> {
+            co_await objPtr->handleNewMessageCoro(conn,
+                                                  std::move(message),
+                                                  type);
+        });
+    }
+
+    void handleNewConnection(const HttpRequestPtr &req,
+                             const WebSocketConnectionPtr &conn) final
+    {
+        auto objPtr = DrClassMap::getSingleInstance<T>();
+        drogon::async_run([objPtr, req, conn]() mutable -> Task<> {
+            co_await objPtr->handleNewConnectionCoro(req, conn);
+        });
+    }
+
+    void handleConnectionClosed(const WebSocketConnectionPtr &conn) final
+    {
+        auto objPtr = DrClassMap::getSingleInstance<T>();
+        drogon::async_run([objPtr, conn]() mutable -> Task<> {
+            co_await objPtr->handleConnectionClosedCoro(conn);
+        });
     }
 
   protected:

--- a/lib/inc/drogon/WebSocketController.h
+++ b/lib/inc/drogon/WebSocketController.h
@@ -23,6 +23,9 @@
 #include <memory>
 #include <string>
 #include <vector>
+#ifdef __cpp_impl_coroutine
+#include <drogon/utils/coroutine.h>
+#endif
 
 #define WS_PATH_LIST_BEGIN        \
     static void initPathRouting() \
@@ -31,6 +34,11 @@
 #define WS_ADD_PATH_VIA_REGEX(regExp, ...) \
     registerSelfRegex__(regExp, {__VA_ARGS__})
 #define WS_PATH_LIST_END }
+#define WS_CORO_PATH_LIST_BEGIN WS_PATH_LIST_BEGIN
+#define WS_CORO_PATH_ADD(path, ...) WS_PATH_ADD(path, __VA_ARGS__)
+#define WS_CORO_ADD_PATH_VIA_REGEX(regExp, ...) \
+    WS_ADD_PATH_VIA_REGEX(regExp, __VA_ARGS__)
+#define WS_CORO_PATH_LIST_END WS_PATH_LIST_END
 
 namespace drogon
 {
@@ -134,5 +142,124 @@ class WebSocketController : public DrObject<T>, public WebSocketControllerBase
 template <typename T, bool AutoCreation>
 typename WebSocketController<T, AutoCreation>::pathRegistrator
     WebSocketController<T, AutoCreation>::registrator_;
+
+#ifdef __cpp_impl_coroutine
+/**
+ * @brief The abstract base class for coroutine WebSocket controllers.
+ */
+class WebSocketCoroControllerBase : public WebSocketControllerBase
+{
+  public:
+    ~WebSocketCoroControllerBase() override = default;
+
+    void handleNewMessage(const WebSocketConnectionPtr &conn,
+                          std::string &&message,
+                          const WebSocketMessageType &type) final
+    {
+        drogon::async_run([this,
+                           conn,
+                           message = std::move(message),
+                           type]() mutable -> Task<> {
+            co_await handleNewMessageCoro(conn, std::move(message), type);
+        });
+    }
+
+    void handleNewConnection(const HttpRequestPtr &req,
+                             const WebSocketConnectionPtr &conn) final
+    {
+        drogon::async_run([this, req, conn]() mutable -> Task<> {
+            co_await handleNewConnectionCoro(req, conn);
+        });
+    }
+
+    void handleConnectionClosed(const WebSocketConnectionPtr &conn) final
+    {
+        drogon::async_run([this, conn]() mutable -> Task<> {
+            co_await handleConnectionClosedCoro(conn);
+        });
+    }
+
+    virtual Task<> handleNewMessageCoro(const WebSocketConnectionPtr &,
+                                        std::string &&,
+                                        const WebSocketMessageType &) = 0;
+
+    virtual Task<> handleNewConnectionCoro(const HttpRequestPtr &,
+                                           const WebSocketConnectionPtr &) = 0;
+
+    virtual Task<> handleConnectionClosedCoro(
+        const WebSocketConnectionPtr &) = 0;
+};
+
+/**
+ * @brief Reflection base class template for coroutine WebSocket controllers.
+ */
+template <typename T, bool AutoCreation = true>
+class WebSocketCoroController : public DrObject<T>,
+                                public WebSocketCoroControllerBase
+{
+  public:
+    static const bool isAutoCreation = AutoCreation;
+
+    virtual ~WebSocketCoroController()
+    {
+    }
+
+  protected:
+    WebSocketCoroController()
+    {
+    }
+
+    static void registerSelf__(
+        const std::string &path,
+        const std::vector<internal::HttpConstraint> &constraints)
+    {
+        LOG_TRACE << "register websocket coro controller("
+                  << WebSocketCoroController<T, AutoCreation>::classTypeName()
+                  << ") on path:" << path;
+        app().registerWebSocketController(
+            path,
+            WebSocketCoroController<T, AutoCreation>::classTypeName(),
+            constraints);
+    }
+
+    static void registerSelfRegex__(
+        const std::string &regExp,
+        const std::vector<internal::HttpConstraint> &constraints)
+    {
+        LOG_TRACE << "register websocket coro controller("
+                  << WebSocketCoroController<T, AutoCreation>::classTypeName()
+                  << ") on regExp:" << regExp;
+        app().registerWebSocketControllerRegex(
+            regExp,
+            WebSocketCoroController<T, AutoCreation>::classTypeName(),
+            constraints);
+    }
+
+  private:
+    class pathRegistrator
+    {
+      public:
+        pathRegistrator()
+        {
+            if (AutoCreation)
+            {
+                T::initPathRouting();
+            }
+        }
+    };
+
+    friend pathRegistrator;
+    static pathRegistrator registrator_;
+
+    virtual void *touch()
+    {
+        return &registrator_;
+    }
+};
+
+template <typename T, bool AutoCreation>
+typename WebSocketCoroController<T, AutoCreation>::pathRegistrator
+    WebSocketCoroController<T, AutoCreation>::registrator_;
+#endif
 
 }  // namespace drogon

--- a/lib/src/HttpRequestParser.h
+++ b/lib/src/HttpRequestParser.h
@@ -57,16 +57,6 @@ class HttpRequestParser : public trantor::NonCopyable,
         return request_;
     }
 
-    bool firstReq()
-    {
-        if (firstRequest_)
-        {
-            firstRequest_ = false;
-            return true;
-        }
-        return false;
-    }
-
     const WebSocketConnectionImplPtr &webSocketConn() const
     {
         return websockConnPtr_;
@@ -141,7 +131,6 @@ class HttpRequestParser : public trantor::NonCopyable,
     HttpRequestParseStatus status_;
     trantor::EventLoop *loop_;
     HttpRequestImplPtr request_;
-    bool firstRequest_{true};
     WebSocketConnectionImplPtr websockConnPtr_;
     std::deque<std::pair<HttpRequestPtr, std::pair<HttpResponsePtr, bool>>>
         requestPipelining_;

--- a/lib/src/HttpServer.cc
+++ b/lib/src/HttpServer.cc
@@ -758,7 +758,10 @@ void HttpServer::websocketRequestHandling(
     std::function<void(const HttpResponsePtr &)> &&callback,
     WebSocketConnectionImplPtr &&wsConnPtr)
 {
-    binderPtr->handleRequest(
+    auto binder = std::move(binderPtr);
+    auto wsConn = std::move(wsConnPtr);
+
+    binder->handleRequest(
         req,
         [req, callback = std::move(callback)](const HttpResponsePtr &resp) {
             AopAdvice::instance().passPostHandlingAdvices(req, resp);
@@ -766,8 +769,8 @@ void HttpServer::websocketRequestHandling(
         });
 
     // TODO: more elegant?
-    static_cast<WebsocketControllerBinder *>(binderPtr.get())
-        ->handleNewConnection(req, wsConnPtr);
+    static_cast<WebsocketControllerBinder *>(binder.get())
+        ->handleNewConnection(req, wsConn);
 }
 
 void HttpServer::handleResponse(

--- a/lib/src/HttpServer.cc
+++ b/lib/src/HttpServer.cc
@@ -764,8 +764,7 @@ void HttpServer::websocketRequestHandling(
 
     binder->handleRequest(
         request,
-        [request, callback = std::move(callback)](
-            const HttpResponsePtr &resp) {
+        [request, callback = std::move(callback)](const HttpResponsePtr &resp) {
             AopAdvice::instance().passPostHandlingAdvices(request, resp);
             callback(resp);
         });

--- a/lib/src/HttpServer.cc
+++ b/lib/src/HttpServer.cc
@@ -758,19 +758,21 @@ void HttpServer::websocketRequestHandling(
     std::function<void(const HttpResponsePtr &)> &&callback,
     WebSocketConnectionImplPtr &&wsConnPtr)
 {
+    auto request = req;
     auto binder = std::move(binderPtr);
     auto wsConn = std::move(wsConnPtr);
 
     binder->handleRequest(
-        req,
-        [req, callback = std::move(callback)](const HttpResponsePtr &resp) {
-            AopAdvice::instance().passPostHandlingAdvices(req, resp);
+        request,
+        [request, callback = std::move(callback)](
+            const HttpResponsePtr &resp) {
+            AopAdvice::instance().passPostHandlingAdvices(request, resp);
             callback(resp);
         });
 
     // TODO: more elegant?
     static_cast<WebsocketControllerBinder *>(binder.get())
-        ->handleNewConnection(req, wsConn);
+        ->handleNewConnection(request, wsConn);
 }
 
 void HttpServer::handleResponse(

--- a/lib/src/HttpServer.cc
+++ b/lib/src/HttpServer.cc
@@ -278,8 +278,11 @@ void HttpServer::onRequests(
 {
     assert(!requests.empty());
 
-    // will only be checked for the first request
-    if (requestParser->firstReq() && requests.size() == 1 &&
+    // A WebSocket upgrade may arrive after earlier HTTP requests on the same
+    // keep-alive connection. Reverse proxies commonly reuse their upstream
+    // connections, so limiting upgrade detection to the first request causes
+    // valid reconnects to fall through to ordinary HTTP routing.
+    if (requests.size() == 1 && requestParser->emptyPipelining() &&
         isWebSocket(requests[0]))
     {
         auto &req = requests[0];

--- a/lib/tests/CMakeLists.txt
+++ b/lib/tests/CMakeLists.txt
@@ -56,7 +56,6 @@ if (BUILD_CTL)
       integration_test/client/MultipleWsTest.cc
       integration_test/client/HttpPipeliningTest.cc
       integration_test/client/RequestStreamTest.cc)
-  add_executable(integration_test_client ${INTEGRATION_TEST_CLIENT_SOURCES})
 
   set(INTEGRATION_TEST_SERVER_SOURCES
       integration_test/server/CustomCtrl.cc
@@ -94,6 +93,7 @@ if (BUILD_CTL)
     set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
   endif(DROGON_CXX_STANDARD GREATER_EQUAL 20 AND HAS_COROUTINE)
 
+  add_executable(integration_test_client ${INTEGRATION_TEST_CLIENT_SOURCES})
   add_executable(integration_test_server ${INTEGRATION_TEST_SERVER_SOURCES})
   drogon_create_views(integration_test_server
                       ${CMAKE_CURRENT_SOURCE_DIR}/integration_test/server

--- a/lib/tests/CMakeLists.txt
+++ b/lib/tests/CMakeLists.txt
@@ -85,7 +85,11 @@ if (BUILD_CTL)
     set(INTEGRATION_TEST_SERVER_SOURCES
         ${INTEGRATION_TEST_SERVER_SOURCES}
         integration_test/server/CoroFilter.cpp
-        integration_test/server/api_v1_CoroTest.cc)
+        integration_test/server/api_v1_CoroTest.cc
+        integration_test/server/WebSocketCoroTest.cc)
+    set(INTEGRATION_TEST_CLIENT_SOURCES
+        ${INTEGRATION_TEST_CLIENT_SOURCES}
+        integration_test/client/WebSocketCoroTest.cc)
     set(CMAKE_CXX_STANDARD 20)
     set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
   endif(DROGON_CXX_STANDARD GREATER_EQUAL 20 AND HAS_COROUTINE)

--- a/lib/tests/CMakeLists.txt
+++ b/lib/tests/CMakeLists.txt
@@ -53,6 +53,7 @@ if (BUILD_CTL)
   set(INTEGRATION_TEST_CLIENT_SOURCES
       integration_test/client/main.cc
       integration_test/client/WebSocketTest.cc
+      integration_test/client/WebSocketKeepAliveUpgradeTest.cc
       integration_test/client/MultipleWsTest.cc
       integration_test/client/HttpPipeliningTest.cc
       integration_test/client/RequestStreamTest.cc)

--- a/lib/tests/integration_test/client/WebSocketCoroTest.cc
+++ b/lib/tests/integration_test/client/WebSocketCoroTest.cc
@@ -1,0 +1,93 @@
+#include <drogon/WebSocketClient.h>
+#include <drogon/drogon_test.h>
+
+#include <chrono>
+#include <cstdio>
+#include <future>
+
+using namespace drogon;
+using namespace std::chrono_literals;
+
+DROGON_TEST(WebSocketCoroControllerTest)
+{
+#if defined(__cpp_impl_coroutine)
+    auto promise = std::make_shared<std::promise<void>>();
+    auto future = promise->get_future();
+
+    auto first = WebSocketClient::newWebSocketClient("127.0.0.1", 8848);
+    auto second = WebSocketClient::newWebSocketClient("127.0.0.1", 8848);
+
+    first->setMessageHandler(
+        [first, second, promise, TEST_CTX](const std::string &message,
+                                           const WebSocketClientPtr &,
+                                           const WebSocketMessageType &type) {
+            CHECK(type == WebSocketMessageType::Text);
+            if (message == "opened")
+            {
+                first->getConnection()->send("hello-coro");
+            }
+            else if (message == "coro:hello-coro")
+            {
+                first->getConnection()->shutdown();
+            }
+        });
+
+    first->setConnectionClosedHandler([second, promise, TEST_CTX](
+                                          const WebSocketClientPtr &) {
+        auto req2 = HttpRequest::newHttpRequest();
+        req2->setPath("/coro-chat");
+
+        second->setMessageHandler(
+            [second, promise, TEST_CTX](const std::string &message,
+                                        const WebSocketClientPtr &,
+                                        const WebSocketMessageType &type) {
+                CHECK(type == WebSocketMessageType::Text);
+                if (message == "opened")
+                {
+                    second->getConnection()->send("stats");
+                    return;
+                }
+
+                if (message.rfind("stats:", 0) == 0)
+                {
+                    int opened = 0;
+                    int msg = 0;
+                    int closed = 0;
+                    auto parsed = sscanf(message.c_str(),
+                                         "stats:%d:%d:%d",
+                                         &opened,
+                                         &msg,
+                                         &closed);
+                    REQUIRE(parsed == 3);
+                    CHECK(opened >= 2);
+                    CHECK(msg >= 2);
+                    CHECK(closed >= 1);
+                    second->stop();
+                    promise->set_value();
+                }
+            });
+
+        second->connectToServer(req2,
+                                [second, TEST_CTX](ReqResult r,
+                                                   const HttpResponsePtr &resp,
+                                                   const WebSocketClientPtr &) {
+                                    REQUIRE(r == ReqResult::Ok);
+                                    REQUIRE(resp != nullptr);
+                                    CHECK(second->getConnection()->connected());
+                                });
+    });
+
+    auto req = HttpRequest::newHttpRequest();
+    req->setPath("/coro-chat");
+    first->connectToServer(req,
+                           [first, TEST_CTX](ReqResult r,
+                                             const HttpResponsePtr &resp,
+                                             const WebSocketClientPtr &) {
+                               REQUIRE(r == ReqResult::Ok);
+                               REQUIRE(resp != nullptr);
+                               CHECK(first->getConnection()->connected());
+                           });
+
+    REQUIRE(future.wait_for(5s) == std::future_status::ready);
+#endif
+}

--- a/lib/tests/integration_test/client/WebSocketCoroTest.cc
+++ b/lib/tests/integration_test/client/WebSocketCoroTest.cc
@@ -13,79 +13,93 @@ DROGON_TEST(WebSocketCoroControllerTest)
 #if defined(__cpp_impl_coroutine)
     auto promise = std::make_shared<std::promise<void>>();
     auto future = promise->get_future();
+    std::weak_ptr<drogon::test::Case> testContext = TEST_CTX;
 
     auto first = WebSocketClient::newWebSocketClient("127.0.0.1", 8848);
     auto second = WebSocketClient::newWebSocketClient("127.0.0.1", 8848);
 
     first->setMessageHandler(
-        [first, second, promise, TEST_CTX](const std::string &message,
-                                           const WebSocketClientPtr &,
-                                           const WebSocketMessageType &type) {
+        [promise, testContext](const std::string &message,
+                               const WebSocketClientPtr &client,
+                               const WebSocketMessageType &type) {
+            auto TEST_CTX = testContext.lock();
+            if (!TEST_CTX)
+                return;
             CHECK(type == WebSocketMessageType::Text);
             if (message == "opened")
             {
-                first->getConnection()->send("hello-coro");
+                client->getConnection()->send("hello-coro");
             }
             else if (message == "coro:hello-coro")
             {
-                first->getConnection()->shutdown();
+                client->getConnection()->shutdown();
             }
         });
 
-    first->setConnectionClosedHandler([second, promise, TEST_CTX](
-                                          const WebSocketClientPtr &) {
-        auto req2 = HttpRequest::newHttpRequest();
-        req2->setPath("/coro-chat");
+    first->setConnectionClosedHandler(
+        [second, promise, testContext](const WebSocketClientPtr &) {
+            auto req2 = HttpRequest::newHttpRequest();
+            req2->setPath("/coro-chat");
 
-        second->setMessageHandler(
-            [second, promise, TEST_CTX](const std::string &message,
-                                        const WebSocketClientPtr &,
-                                        const WebSocketMessageType &type) {
-                CHECK(type == WebSocketMessageType::Text);
-                if (message == "opened")
-                {
-                    second->getConnection()->send("stats");
-                    return;
-                }
+            second->setMessageHandler(
+                [promise, testContext](const std::string &message,
+                                       const WebSocketClientPtr &client,
+                                       const WebSocketMessageType &type) {
+                    auto TEST_CTX = testContext.lock();
+                    if (!TEST_CTX)
+                        return;
+                    CHECK(type == WebSocketMessageType::Text);
+                    if (message == "opened")
+                    {
+                        client->getConnection()->send("stats");
+                        return;
+                    }
 
-                if (message.rfind("stats:", 0) == 0)
-                {
-                    int opened = 0;
-                    int msg = 0;
-                    int closed = 0;
-                    auto parsed = sscanf(message.c_str(),
-                                         "stats:%d:%d:%d",
-                                         &opened,
-                                         &msg,
-                                         &closed);
-                    REQUIRE(parsed == 3);
-                    CHECK(opened >= 2);
-                    CHECK(msg >= 2);
-                    CHECK(closed >= 1);
-                    second->stop();
-                    promise->set_value();
-                }
-            });
+                    if (message.rfind("stats:", 0) == 0)
+                    {
+                        int opened = 0;
+                        int msg = 0;
+                        int closed = 0;
+                        auto parsed = sscanf(message.c_str(),
+                                             "stats:%d:%d:%d",
+                                             &opened,
+                                             &msg,
+                                             &closed);
+                        REQUIRE(parsed == 3);
+                        CHECK(opened >= 2);
+                        CHECK(msg >= 2);
+                        CHECK(closed >= 1);
+                        client->stop();
+                        promise->set_value();
+                    }
+                });
 
-        second->connectToServer(req2,
-                                [second, TEST_CTX](ReqResult r,
-                                                   const HttpResponsePtr &resp,
-                                                   const WebSocketClientPtr &) {
-                                    REQUIRE(r == ReqResult::Ok);
-                                    REQUIRE(resp != nullptr);
-                                    CHECK(second->getConnection()->connected());
-                                });
-    });
+            second->connectToServer(
+                req2,
+                [testContext](ReqResult r,
+                              const HttpResponsePtr &resp,
+                              const WebSocketClientPtr &client) {
+                    auto TEST_CTX = testContext.lock();
+                    if (!TEST_CTX)
+                        return;
+                    REQUIRE(r == ReqResult::Ok);
+                    REQUIRE(resp != nullptr);
+                    CHECK(client->getConnection()->connected());
+                });
+        });
 
     auto req = HttpRequest::newHttpRequest();
     req->setPath("/coro-chat");
     first->connectToServer(req,
-                           [first, TEST_CTX](ReqResult r,
-                                             const HttpResponsePtr &resp,
-                                             const WebSocketClientPtr &) {
+                           [testContext](ReqResult r,
+                                         const HttpResponsePtr &resp,
+                                         const WebSocketClientPtr &client) {
+                               auto TEST_CTX = testContext.lock();
+                               if (!TEST_CTX)
+                                   return;
                                REQUIRE(r == ReqResult::Ok);
                                REQUIRE(resp != nullptr);
-                               CHECK(first->getConnection()->connected());
+                               CHECK(client->getConnection()->connected());
                            });
 
     REQUIRE(future.wait_for(5s) == std::future_status::ready);

--- a/lib/tests/integration_test/client/WebSocketKeepAliveUpgradeTest.cc
+++ b/lib/tests/integration_test/client/WebSocketKeepAliveUpgradeTest.cc
@@ -1,0 +1,82 @@
+#include <drogon/HttpAppFramework.h>
+#include <drogon/drogon_test.h>
+#include <trantor/net/TcpClient.h>
+
+#include <atomic>
+#include <chrono>
+#include <future>
+#include <memory>
+#include <string>
+
+using namespace drogon;
+using namespace std::chrono_literals;
+
+DROGON_TEST(WebSocketUpgradeAfterKeepAliveRequestTest)
+{
+    auto client = std::make_shared<trantor::TcpClient>(
+        app().getLoop(),
+        trantor::InetAddress{"127.0.0.1", 8848},
+        "websocket-keep-alive-upgrade-test");
+    auto response = std::make_shared<std::string>();
+    auto phase = std::make_shared<std::atomic<int>>(0);
+    auto completed = std::make_shared<std::atomic<bool>>(false);
+    auto promise = std::make_shared<std::promise<void>>();
+    auto future = promise->get_future();
+
+    client->setConnectionCallback([TEST_CTX, phase, completed, promise](
+                                      const trantor::TcpConnectionPtr &conn) {
+        if (conn->connected())
+        {
+            conn->send(
+                "HEAD / HTTP/1.1\r\n"
+                "Host: 127.0.0.1:8848\r\n"
+                "Connection: keep-alive\r\n\r\n");
+            return;
+        }
+
+        if (phase->load() < 2 && !completed->exchange(true))
+        {
+            FAIL("Connection closed before the WebSocket upgrade completed");
+            promise->set_value();
+        }
+    });
+
+    client->setMessageCallback([TEST_CTX, response, phase, completed, promise](
+                                   const trantor::TcpConnectionPtr &conn,
+                                   trantor::MsgBuffer *buffer) {
+        response->append(buffer->read(buffer->readableBytes()));
+        if (response->find("\r\n\r\n") == std::string::npos)
+        {
+            return;
+        }
+
+        if (phase->load() == 0)
+        {
+            REQUIRE(response->find("HTTP/1.1 200") == 0);
+            response->clear();
+            phase->store(1);
+            conn->send(
+                "GET /chat HTTP/1.1\r\n"
+                "Host: 127.0.0.1:8848\r\n"
+                "Connection: Upgrade\r\n"
+                "Upgrade: websocket\r\n"
+                "Sec-WebSocket-Version: 13\r\n"
+                "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n\r\n");
+            return;
+        }
+
+        if (phase->exchange(2) == 1)
+        {
+            CHECK(response->find("HTTP/1.1 101") == 0);
+            CHECK(response->find("upgrade: websocket") != std::string::npos);
+            if (!completed->exchange(true))
+            {
+                promise->set_value();
+            }
+            conn->shutdown();
+        }
+    });
+
+    client->connect();
+    REQUIRE(future.wait_for(5s) == std::future_status::ready);
+}

--- a/lib/tests/integration_test/server/WebSocketCoroTest.cc
+++ b/lib/tests/integration_test/server/WebSocketCoroTest.cc
@@ -1,0 +1,53 @@
+#include "WebSocketCoroTest.h"
+
+#include <drogon/drogon.h>
+
+using namespace example;
+
+std::atomic<int> WebSocketCoroTest::openedCount_{0};
+std::atomic<int> WebSocketCoroTest::messageCount_{0};
+std::atomic<int> WebSocketCoroTest::closedCount_{0};
+
+drogon::Task<> WebSocketCoroTest::handleNewConnectionCoro(
+    const drogon::HttpRequestPtr &,
+    const drogon::WebSocketConnectionPtr &conn)
+{
+    ++openedCount_;
+    co_await drogon::sleepCoro(drogon::app().getLoop(), 0.001);
+    conn->send("opened");
+    co_return;
+}
+
+drogon::Task<> WebSocketCoroTest::handleNewMessageCoro(
+    const drogon::WebSocketConnectionPtr &conn,
+    std::string &&message,
+    const drogon::WebSocketMessageType &type)
+{
+    if (type != drogon::WebSocketMessageType::Text)
+    {
+        co_return;
+    }
+
+    ++messageCount_;
+    co_await drogon::sleepCoro(drogon::app().getLoop(), 0.001);
+
+    if (message == "stats")
+    {
+        conn->send("stats:" + std::to_string(openedCount_.load()) + ":" +
+                   std::to_string(messageCount_.load()) + ":" +
+                   std::to_string(closedCount_.load()));
+    }
+    else
+    {
+        conn->send("coro:" + message);
+    }
+    co_return;
+}
+
+drogon::Task<> WebSocketCoroTest::handleConnectionClosedCoro(
+    const drogon::WebSocketConnectionPtr &)
+{
+    ++closedCount_;
+    co_await drogon::sleepCoro(drogon::app().getLoop(), 0.001);
+    co_return;
+}

--- a/lib/tests/integration_test/server/WebSocketCoroTest.h
+++ b/lib/tests/integration_test/server/WebSocketCoroTest.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <drogon/WebSocketController.h>
+#include <atomic>
+
+namespace example
+{
+class WebSocketCoroTest
+    : public drogon::WebSocketCoroController<WebSocketCoroTest>
+{
+  public:
+    drogon::Task<> handleNewMessageCoro(
+        const drogon::WebSocketConnectionPtr &,
+        std::string &&,
+        const drogon::WebSocketMessageType &) override;
+    drogon::Task<> handleConnectionClosedCoro(
+        const drogon::WebSocketConnectionPtr &) override;
+    drogon::Task<> handleNewConnectionCoro(
+        const drogon::HttpRequestPtr &,
+        const drogon::WebSocketConnectionPtr &) override;
+
+    WS_CORO_PATH_LIST_BEGIN
+    WS_CORO_PATH_ADD("/coro-chat", drogon::Get);
+    WS_CORO_PATH_LIST_END
+
+  private:
+    static std::atomic<int> openedCount_;
+    static std::atomic<int> messageCount_;
+    static std::atomic<int> closedCount_;
+};
+}  // namespace example

--- a/nosql_lib/redis/src/RedisConnection.cc
+++ b/nosql_lib/redis/src/RedisConnection.cc
@@ -230,7 +230,10 @@ void RedisConnection::startConnectionInLoop()
             thisPtr->handleDisconnect();
             if (thisPtr->disconnectCallback_)
             {
-                thisPtr->disconnectCallback_(thisPtr->shared_from_this());
+                if (auto self = thisPtr->weak_from_this().lock())
+                {
+                    thisPtr->disconnectCallback_(std::move(self));
+                }
             }
 
             LOG_TRACE << "Disconnected from "
@@ -361,7 +364,10 @@ void RedisConnection::handleResult(redisReply *result)
         assert(exceptionCallbacks_.empty());
         if (idleCallback_)
         {
-            idleCallback_(shared_from_this());
+            if (auto self = weak_from_this().lock())
+            {
+                idleCallback_(std::move(self));
+            }
         }
     }
 }
@@ -514,9 +520,11 @@ void RedisConnection::handleSubscribeResult(redisReply *result,
         LOG_ERROR << "Subscribe callback receive error result type: "
                   << result->type;
     }
-
     if (idleCallback_)
     {
-        idleCallback_(shared_from_this());
+        if (auto self = weak_from_this().lock())
+        {
+            idleCallback_(std::move(self));
+        }
     }
 }


### PR DESCRIPTION
Introduces coroutine-compatible WebSocket controller support and path declaration aliases:

WS_CORO_PATH_LIST_BEGIN
WS_CORO_PATH_ADD
WS_CORO_PATH_LIST_END
WS_CORO_ADD_PATH_VIA_REGEX

It also adds integration tests covering coroutine WebSocket routing/handler behavior.