### PR TITLE
Bugfix/2530 atomic requests buffer size

### DIFF
--- a/lib/inc/drogon/HttpClient.h
+++ b/lib/inc/drogon/HttpClient.h
@@ -185,6 +185,11 @@ class DROGON_EXPORT HttpClient : public trantor::NonCopyable
      */
     virtual std::size_t requestsBufferSize() = 0;
 
+    /**
+     * @brief Get the total number of outstanding requests (buffered + in-flight).
+     */
+    virtual std::size_t outstandingRequests() const = 0;
+
     /// Set the pipelining depth, which is the number of requests that are not
     /// responding.
     /**

--- a/lib/inc/drogon/HttpClient.h
+++ b/lib/inc/drogon/HttpClient.h
@@ -186,7 +186,8 @@ class DROGON_EXPORT HttpClient : public trantor::NonCopyable
     virtual std::size_t requestsBufferSize() = 0;
 
     /**
-     * @brief Get the total number of outstanding requests (buffered + in-flight).
+     * @brief Get the total number of outstanding requests (buffered +
+     * in-flight).
      */
     virtual std::size_t outstandingRequests() const = 0;
 

--- a/lib/src/HttpClientImpl.cc
+++ b/lib/src/HttpClientImpl.cc
@@ -79,7 +79,10 @@ void HttpClientImpl::createTcpClient()
                                      thisPtr->requestsBuffer_.front().first);
                     thisPtr->pipeliningCallbacks_.push(
                         std::move(thisPtr->requestsBuffer_.front()));
-                    thisPtr->requestsBuffer_.pop_front();
+                    thisPtr->pipeliningCallbacksSize_.fetch_add(
+                        1, std::memory_order_relaxed);
+
+                    thisPtr->popFrontRequest();
                 }
             }
             else
@@ -340,7 +343,7 @@ void HttpClientImpl::sendRequestInLoop(const HttpRequestPtr &req,
                 {
                     if (iter->first == callbackParamsPtr->requestPtr)
                     {
-                        thisPtr->requestsBuffer_.erase(iter);
+                        thisPtr->eraseRequest(iter);
                         break;
                     }
                 }
@@ -419,12 +422,12 @@ void HttpClientImpl::sendRequestInLoop(const drogon::HttpRequestPtr &req,
     {
         auto callbackPtr =
             std::make_shared<drogon::HttpReqCallback>(std::move(callback));
-        requestsBuffer_.push_back(
-            {req,
-             [thisPtr = shared_from_this(),
-              callbackPtr](ReqResult result, const HttpResponsePtr &response) {
-                 (*callbackPtr)(result, response);
-             }});
+        enqueueRequest(req,
+                       [thisPtr = shared_from_this(),
+                        callbackPtr](ReqResult result,
+                                     const HttpResponsePtr &response) {
+                           (*callbackPtr)(result, response);
+                       });
 
         if (domain_.empty() || !isDomainName_)
         {
@@ -436,7 +439,7 @@ void HttpClientImpl::sendRequestInLoop(const drogon::HttpRequestPtr &req,
             // No ip address and no domain, respond with BadServerAddress
             else
             {
-                requestsBuffer_.pop_front();
+                popFrontRequest();
                 (*callbackPtr)(ReqResult::BadServerAddress, nullptr);
                 assert(requestsBuffer_.empty());
             }
@@ -480,7 +483,8 @@ void HttpClientImpl::sendRequestInLoop(const drogon::HttpRequestPtr &req,
                     {
                         auto &reqAndCb = (thisPtr->requestsBuffer_).front();
                         reqAndCb.second(ReqResult::BadServerAddress, nullptr);
-                        (thisPtr->requestsBuffer_).pop_front();
+
+                        thisPtr->popFrontRequest();
                     }
                 });
             });
@@ -495,13 +499,11 @@ void HttpClientImpl::sendRequestInLoop(const drogon::HttpRequestPtr &req,
     // Not connected, push request to buffer and wait for connection
     if (!connPtr || connPtr->disconnected())
     {
-        requestsBuffer_.push_back(
-            {req,
-             [thisPtr,
-              callback = std::move(callback)](ReqResult result,
-                                              const HttpResponsePtr &response) {
-                 callback(result, response);
-             }});
+        enqueueRequest(req,
+                       [thisPtr, callback = std::move(callback)](
+                           ReqResult result, const HttpResponsePtr &response) {
+                           callback(result, response);
+                       });
         return;
     }
 
@@ -517,16 +519,15 @@ void HttpClientImpl::sendRequestInLoop(const drogon::HttpRequestPtr &req,
                                               const HttpResponsePtr &response) {
                  callback(result, response);
              }});
+        pipeliningCallbacksSize_.fetch_add(1, std::memory_order_relaxed);
     }
     else
     {
-        requestsBuffer_.push_back(
-            {req,
-             [thisPtr,
-              callback = std::move(callback)](ReqResult result,
-                                              const HttpResponsePtr &response) {
-                 callback(result, response);
-             }});
+        enqueueRequest(req,
+                       [thisPtr, callback = std::move(callback)](
+                           ReqResult result, const HttpResponsePtr &response) {
+                           callback(result, response);
+                       });
     }
 }
 
@@ -562,6 +563,7 @@ void HttpClientImpl::handleResponse(
 #endif
     auto cb = std::move(reqAndCb);
     pipeliningCallbacks_.pop();
+    pipeliningCallbacksSize_.fetch_sub(1, std::memory_order_relaxed);
     handleCookies(resp);
     cb.second(ReqResult::Ok, resp);
 
@@ -576,7 +578,8 @@ void HttpClientImpl::handleResponse(
             auto &reqAndCallback = requestsBuffer_.front();
             sendReq(connPtr, reqAndCallback.first);
             pipeliningCallbacks_.push(std::move(reqAndCallback));
-            requestsBuffer_.pop_front();
+            pipeliningCallbacksSize_.fetch_add(1, std::memory_order_relaxed);
+            popFrontRequest();
         }
         else
         {
@@ -592,6 +595,7 @@ void HttpClientImpl::handleResponse(
         {
             auto cb = std::move(pipeliningCallbacks_.front());
             pipeliningCallbacks_.pop();
+            pipeliningCallbacksSize_.fetch_sub(1, std::memory_order_relaxed);
             cb.second(ReqResult::NetworkFailure, nullptr);
         }
     }
@@ -674,12 +678,13 @@ void HttpClientImpl::onError(ReqResult result)
     {
         auto cb = std::move(pipeliningCallbacks_.front());
         pipeliningCallbacks_.pop();
+        pipeliningCallbacksSize_.fetch_sub(1, std::memory_order_relaxed);
         cb.second(result, nullptr);
     }
     while (!requestsBuffer_.empty())
     {
         auto cb = std::move(requestsBuffer_.front().second);
-        requestsBuffer_.pop_front();
+        popFrontRequest();
         cb(result, nullptr);
     }
     tcpClientPtr_.reset();

--- a/lib/src/HttpClientImpl.h
+++ b/lib/src/HttpClientImpl.h
@@ -19,6 +19,7 @@
 #include <trantor/net/EventLoop.h>
 #include <trantor/net/Resolver.h>
 #include <trantor/net/TcpClient.h>
+#include <atomic>
 #include <cstddef>
 #include <functional>
 #include <future>
@@ -118,19 +119,40 @@ class HttpClientImpl final : public HttpClient,
         sockOptCallback_ = std::move(cb);
     }
 
+    std::size_t outstandingRequests() const override
+    {
+        return requestsBufferSize_.load(std::memory_order_relaxed) +
+               pipeliningCallbacksSize_.load(std::memory_order_relaxed);
+    }
+
     std::size_t requestsBufferSize() override
     {
-        if (loop_->isInLoopThread())
+        return requestsBufferSize_.load(std::memory_order_relaxed);
+    }
+
+    void enqueueRequest(const HttpRequestPtr &req,
+                        const HttpReqCallback &callback)
+    {
+        requestsBuffer_.push_back({req, callback});
+        requestsBufferSize_.fetch_add(1, std::memory_order_relaxed);
+    }
+
+    void popFrontRequest()
+    {
+        if (!requestsBuffer_.empty())
         {
-            return requestsBuffer_.size();
+            requestsBuffer_.pop_front();
+            requestsBufferSize_.fetch_sub(1, std::memory_order_relaxed);
         }
-        else
-        {
-            std::promise<std::size_t> bufferSize;
-            loop_->queueInLoop(
-                [&] { bufferSize.set_value(requestsBuffer_.size()); });
-            return bufferSize.get_future().get();
-        }
+    }
+
+    using RequestBufferIter =
+        std::list<std::pair<HttpRequestPtr, HttpReqCallback>>::iterator;
+
+    void eraseRequest(RequestBufferIter iter)
+    {
+        requestsBuffer_.erase(iter);
+        requestsBufferSize_.fetch_sub(1, std::memory_order_relaxed);
     }
 
   private:
@@ -157,6 +179,8 @@ class HttpClientImpl final : public HttpClient,
     void onError(ReqResult result);
     std::string domain_;
     bool isDomainName_{true};  // true if domain_ is name
+    std::atomic<std::size_t> requestsBufferSize_{0};
+    std::atomic<std::size_t> pipeliningCallbacksSize_{0};
     size_t pipeliningDepth_{0};
     bool enableCookies_{false};
     std::vector<Cookie> validCookies_;

--- a/lib/tests/CMakeLists.txt
+++ b/lib/tests/CMakeLists.txt
@@ -64,6 +64,7 @@ if (BUILD_CTL)
       integration_test/server/CustomHeaderFilter.cc
       integration_test/server/DoNothingPlugin.cc
       integration_test/server/ForwardCtrl.cc
+      integration_test/server/HttpClientOutstandingRequests.cc
       integration_test/server/JsonTestController.cc
       integration_test/server/ListParaCtl.cc
       integration_test/server/PipeliningTest.cc

--- a/lib/tests/integration_test/server/HttpClientOutstandingRequests.cc
+++ b/lib/tests/integration_test/server/HttpClientOutstandingRequests.cc
@@ -1,0 +1,52 @@
+#include <drogon/drogon_test.h>
+#include <drogon/HttpClient.h>
+#include <atomic>
+#include <thread>
+#include <chrono>
+
+using namespace drogon;
+
+DROGON_TEST(HttpClientOutstandingRequests)
+{
+    auto client = HttpClient::newHttpClient("http://127.0.0.1:8848");
+
+    // Enable pipelining to allow multiple in-flight requests simultaneously
+    client->setPipeliningDepth(64);
+
+    CHECK(client->requestsBufferSize() == 0);
+    CHECK(client->outstandingRequests() == 0);
+
+    const int totalRequests = 50;
+    std::atomic<int> completedRequests{0};
+
+    for (int i = 0; i < totalRequests; ++i)
+    {
+        auto req = HttpRequest::newHttpRequest();
+        req->setPath("/PipeliningTest/normalPipe");
+
+        client->sendRequest(
+            req,
+            [&completedRequests](ReqResult result,
+                                 const HttpResponsePtr &response) {
+                if (result == ReqResult::Ok)
+                {
+                    completedRequests++;
+                }
+            });
+    }
+
+    size_t currentOutstanding = client->outstandingRequests();
+    size_t currentBuffer = client->outstandingRequests();
+
+    CHECK(currentOutstanding > 0);
+
+    CHECK(currentOutstanding >= currentBuffer);
+
+    while (completedRequests < totalRequests)
+    {
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+
+    CHECK(client->requestsBufferSize() == 0);
+    CHECK(client->outstandingRequests() == 0);
+}


### PR DESCRIPTION
Fixes Issue #2530

Description:
Replaced the `std::promise/std::future` implementation in `requestsBufferSize()` with an `std::atomic<std::size_t>`. Previously, calling this method from outside the event loop forced a cross-thread future resolution, blocking the calling thread entirely and preventing efficient async connection pooling.

This PR centralizes the requestsBuffer_ mutations (push_back, pop_front, erase) to safely track the queue depth natively within the background thread. Reads now use `std::memory_order_relaxed` for zero-overhead, non-blocking execution.

Testing Performed:
- Passed the full existing CTest suite.
- Formatted via clang-format-17.
- Wrote a standalone local test to flood the client with delayed requests. Verified that the atomic counter correctly tracks the enqueuing, popping, and erasing of requests natively in the background thread, while allowing the main thread to poll requestsBufferSize() instantly in O(1) time without deadlocking.