### PR TITLE
Fix DST handling in ORM model date/datetime conversion

### DIFF
--- a/drogon_ctl/templates/model_cc.csp
+++ b/drogon_ctl/templates/model_cc.csp
@@ -138,6 +138,7 @@ const std::string &[[className]]::getColumnName(size_t index) noexcept(false)
                 $$<<"            auto daysStr = r[\""<<col.colName_<<"\"].as<std::string>();\n";
                 $$<<"            struct tm stm;\n";
                 $$<<"            memset(&stm,0,sizeof(stm));\n";
+                $$<<"            stm.tm_isdst = -1;\n";
                 $$<<"            strptime(daysStr.c_str(),\"%Y-%m-%d\",&stm);\n";
                 $$<<"            time_t t = mktime(&stm);\n";
 //                $$<<"            "<<col.colValName_<<"_=std::make_shared<::trantor::Date>(::trantor::Date(946656000000000).after(daysNum*86400));\n";
@@ -154,6 +155,7 @@ const std::string &[[className]]::getColumnName(size_t index) noexcept(false)
                 $$<<"            auto timeStr = r[\""<<col.colName_<<"\"].as<std::string>();\n";
                 $$<<"            struct tm stm;\n";
                 $$<<"            memset(&stm,0,sizeof(stm));\n";
+                $$<<"            stm.tm_isdst = -1;\n";
                 $$<<"            auto p = strptime(timeStr.c_str(),\"%Y-%m-%d %H:%M:%S\",&stm);\n";
                 $$<<"            time_t t = mktime(&stm);\n";
                 $$<<"            size_t decimalNum = 0;\n";
@@ -229,6 +231,7 @@ const std::string &[[className]]::getColumnName(size_t index) noexcept(false)
                 $$<<"            auto daysStr = r[index].as<std::string>();\n";
                 $$<<"            struct tm stm;\n";
                 $$<<"            memset(&stm,0,sizeof(stm));\n";
+                $$<<"            stm.tm_isdst = -1;\n";
                 $$<<"            strptime(daysStr.c_str(),\"%Y-%m-%d\",&stm);\n";
                 $$<<"            time_t t = mktime(&stm);\n";
  //               $$<<"            "<<col.colValName_<<"_=std::make_shared<::trantor::Date>(::trantor::Date(946656000000000).after(daysNum*86400));\n";
@@ -245,6 +248,7 @@ const std::string &[[className]]::getColumnName(size_t index) noexcept(false)
                 $$<<"            auto timeStr = r[index].as<std::string>();\n";
                 $$<<"            struct tm stm;\n";
                 $$<<"            memset(&stm,0,sizeof(stm));\n";
+                $$<<"            stm.tm_isdst = -1;\n";
                 $$<<"            auto p = strptime(timeStr.c_str(),\"%Y-%m-%d %H:%M:%S\",&stm);\n";
                 $$<<"            time_t t = mktime(&stm);\n";
                 $$<<"            size_t decimalNum = 0;\n";
@@ -336,6 +340,7 @@ const std::string &[[className]]::getColumnName(size_t index) noexcept(false)
                 $$<<"            auto daysStr = pJson[pMasqueradingVector["<<i<<"]].asString();\n";
                 $$<<"            struct tm stm;\n";
                 $$<<"            memset(&stm,0,sizeof(stm));\n";
+                $$<<"            stm.tm_isdst = -1;\n";
                 $$<<"            strptime(daysStr.c_str(),\"%Y-%m-%d\",&stm);\n";
                 $$<<"            time_t t = mktime(&stm);\n";
  //               $$<<"            "<<col.colValName_<<"_=std::make_shared<::trantor::Date>(::trantor::Date(946656000000000).after(daysNum*86400));\n";
@@ -355,6 +360,7 @@ const std::string &[[className]]::getColumnName(size_t index) noexcept(false)
                 $$<<"            auto timeStr = pJson[pMasqueradingVector["<<i<<"]].asString();\n";
                 $$<<"            struct tm stm;\n";
                 $$<<"            memset(&stm,0,sizeof(stm));\n";
+                $$<<"            stm.tm_isdst = -1;\n";
                 $$<<"            auto p = strptime(timeStr.c_str(),\"%Y-%m-%d %H:%M:%S\",&stm);\n";
                 $$<<"            time_t t = mktime(&stm);\n";
                 $$<<"            size_t decimalNum = 0;\n";
@@ -499,6 +505,7 @@ const std::string &[[className]]::getColumnName(size_t index) noexcept(false)
                 $$<<"            auto daysStr = pJson[\""<<col.colName_<<"\"].asString();\n";
                 $$<<"            struct tm stm;\n";
                 $$<<"            memset(&stm,0,sizeof(stm));\n";
+                $$<<"            stm.tm_isdst = -1;\n";
                 $$<<"            strptime(daysStr.c_str(),\"%Y-%m-%d\",&stm);\n";
                 $$<<"            time_t t = mktime(&stm);\n";
  //               $$<<"            "<<col.colValName_<<"_=std::make_shared<::trantor::Date>(::trantor::Date(946656000000000).after(daysNum*86400));\n";
@@ -518,6 +525,7 @@ const std::string &[[className]]::getColumnName(size_t index) noexcept(false)
                 $$<<"            auto timeStr = pJson[\""<<col.colName_<<"\"].asString();\n";
                 $$<<"            struct tm stm;\n";
                 $$<<"            memset(&stm,0,sizeof(stm));\n";
+                $$<<"            stm.tm_isdst = -1;\n";
                 $$<<"            auto p = strptime(timeStr.c_str(),\"%Y-%m-%d %H:%M:%S\",&stm);\n";
                 $$<<"            time_t t = mktime(&stm);\n";
                 $$<<"            size_t decimalNum = 0;\n";
@@ -671,6 +679,7 @@ void [[className]]::updateByMasqueradedJson(const Json::Value &pJson,
                 $$<<"            auto daysStr = pJson[pMasqueradingVector["<<i<<"]].asString();\n";
                 $$<<"            struct tm stm;\n";
                 $$<<"            memset(&stm,0,sizeof(stm));\n";
+                $$<<"            stm.tm_isdst = -1;\n";
                 $$<<"            strptime(daysStr.c_str(),\"%Y-%m-%d\",&stm);\n";
                 $$<<"            time_t t = mktime(&stm);\n";
  //               $$<<"            "<<col.colValName_<<"_=std::make_shared<::trantor::Date>(::trantor::Date(946656000000000).after(daysNum*86400));\n";
@@ -690,6 +699,7 @@ void [[className]]::updateByMasqueradedJson(const Json::Value &pJson,
                 $$<<"            auto timeStr = pJson[pMasqueradingVector["<<i<<"]].asString();\n";
                 $$<<"            struct tm stm;\n";
                 $$<<"            memset(&stm,0,sizeof(stm));\n";
+                $$<<"            stm.tm_isdst = -1;\n";
                 $$<<"            auto p = strptime(timeStr.c_str(),\"%Y-%m-%d %H:%M:%S\",&stm);\n";
                 $$<<"            time_t t = mktime(&stm);\n";
                 $$<<"            size_t decimalNum = 0;\n";
@@ -837,6 +847,7 @@ void [[className]]::updateByJson(const Json::Value &pJson) noexcept(false)
                 $$<<"            auto daysStr = pJson[\""<<col.colName_<<"\"].asString();\n";
                 $$<<"            struct tm stm;\n";
                 $$<<"            memset(&stm,0,sizeof(stm));\n";
+                $$<<"            stm.tm_isdst = -1;\n";
                 $$<<"            strptime(daysStr.c_str(),\"%Y-%m-%d\",&stm);\n";
                 $$<<"            time_t t = mktime(&stm);\n";
  //               $$<<"            "<<col.colValName_<<"_=std::make_shared<::trantor::Date>(::trantor::Date(946656000000000).after(daysNum*86400));\n";
@@ -856,6 +867,7 @@ void [[className]]::updateByJson(const Json::Value &pJson) noexcept(false)
                 $$<<"            auto timeStr = pJson[\""<<col.colName_<<"\"].asString();\n";
                 $$<<"            struct tm stm;\n";
                 $$<<"            memset(&stm,0,sizeof(stm));\n";
+                $$<<"            stm.tm_isdst = -1;\n";
                 $$<<"            auto p = strptime(timeStr.c_str(),\"%Y-%m-%d %H:%M:%S\",&stm);\n";
                 $$<<"            time_t t = mktime(&stm);\n";
                 $$<<"            size_t decimalNum = 0;\n";


### PR DESCRIPTION
Fixes #2534

After `memset`, `tm_isdst` is 0, which tells `mktime` DST is not active.
This causes datetime values during DST periods to be converted with the
wrong UTC offset (off by one hour).

Setting `tm_isdst = -1` lets the system determine DST from the local timezone rules, matching the fix already applied in trantor (Date.cc:44).

