### PR TITLE
Support custom namespaces for dg_ctl create model(#1591)

### DIFF
--- a/drogon_ctl/create.cc
+++ b/drogon_ctl/create.cc
@@ -44,8 +44,9 @@ std::string create::detail()
            "create a project named project_name\n\n"
            "drogon_ctl create model <model_path> [-o <output path>] [ "
            "--clear-output]"
-           "[--table=<table_name>] [-f]//"
-           "create model classes in model_path\n";
+           "[--table=<table_name>] [--namespace=<namespace_name>] [-f]//"
+           "create model classes in model_path, namespace defaults to database "
+           "name";
 }
 
 void create::handleCommand(std::vector<std::string> &parameters)

--- a/drogon_ctl/create_model.cc
+++ b/drogon_ctl/create_model.cc
@@ -234,6 +234,7 @@ void create_model::createModelClassFromPG(
     data["hasPrimaryKey"] = (int)0;
     data["primaryKeyName"] = "";
     data["dbName"] = dbname_;
+    data["namespaceName"] = namespaceName_;
     data["rdbms"] = std::string("postgresql");
     data["convertMethods"] = convertMethods;
     // Start with user-configured relationships (mutable copy)
@@ -556,6 +557,7 @@ void create_model::createModelClassFromMysql(
     data["hasPrimaryKey"] = (int)0;
     data["primaryKeyName"] = "";
     data["dbName"] = dbname_;
+    data["namespaceName"] = namespaceName_;
     data["rdbms"] = std::string("mysql");
     data["convertMethods"] = convertMethods;
     // Start with user-configured relationships (mutable copy)
@@ -765,6 +767,7 @@ void create_model::createModelClassFromSqlite3(
     data["hasPrimaryKey"] = (int)0;
     data["primaryKeyName"] = "";
     data["dbName"] = std::string("sqlite3");
+    data["namespaceName"] = namespaceName_;
     data["rdbms"] = std::string("sqlite3");
     data["convertMethods"] = convertMethods;
     // Start with user-configured relationships (mutable copy)
@@ -1019,6 +1022,10 @@ void create_model::createModel(const std::string &path,
             exit(1);
         }
         dbname_ = dbname;
+        if (!namespaceOverridden_)
+        {
+            namespaceName_ = config.get("namespace", dbname).asString();
+        }
         auto user = config.get("user", "").asString();
         if (user == "")
         {
@@ -1131,6 +1138,10 @@ void create_model::createModel(const std::string &path,
             exit(1);
         }
         dbname_ = dbname;
+        if (!namespaceOverridden_)
+        {
+            namespaceName_ = config.get("namespace", dbname).asString();
+        }
         auto user = config.get("user", "").asString();
         if (user == "")
         {
@@ -1233,6 +1244,10 @@ void create_model::createModel(const std::string &path,
             std::cerr << "Please configure filename in " << path
                       << "/model.json " << std::endl;
             exit(1);
+        }
+        if (!namespaceOverridden_)
+        {
+            namespaceName_ = config.get("namespace", "sqlite3").asString();
         }
         std::string connStr = "filename=" + escapeConnString(filename);
         DbClientPtr client =
@@ -1417,6 +1432,22 @@ void create_model::handleCommand(std::vector<std::string> &parameters)
             parameters.erase(iter);
             break;
         }
+    }
+
+    for (auto iter = parameters.begin(); iter != parameters.end();)
+    {
+        if ((*iter) == "--namespace")
+        {
+            namespaceOverridden_ = true;
+            iter = parameters.erase(iter);
+            if (iter != parameters.end())
+            {
+                namespaceName_ = *iter;
+                iter = parameters.erase(iter);
+            }
+            continue;
+        }
+        ++iter;
     }
 
     for (auto const &path : parameters)

--- a/drogon_ctl/create_model.h
+++ b/drogon_ctl/create_model.h
@@ -428,6 +428,8 @@ class create_model : public DrObject<create_model>, public CommandHandler
     void createRestfulAPIController(const DrTemplateData &tableInfo,
                                     const Json::Value &restfulApiConfig);
     std::string dbname_;
+    std::string namespaceName_;
+    bool namespaceOverridden_{false};
     bool forceOverwrite_{false};
     std::string outputPath_;
     bool cleanupDirectory_{false};

--- a/drogon_ctl/templates/model_cc.csp
+++ b/drogon_ctl/templates/model_cc.csp
@@ -62,16 +62,22 @@ for(auto convertMethod : convertMethods ) {
 
 using namespace drogon;
 using namespace drogon::orm;
-using namespace drogon_model::[[dbName]]<%c++
-auto &schema=@@.get<std::string>("schema");
-if(!schema.empty())
+<%c++
+auto &namespaceName=@@.get<std::string>("namespaceName");
+if(!namespaceName.empty())
 {
-    $$<<"::"<<schema<<";\n";
+    $$<<"using namespace drogon_model::"<<namespaceName;
 }
 else
 {
-    $$<<";\n";
+    $$<<"using namespace drogon_model";
 }
+auto &schema=@@.get<std::string>("schema");
+if(!schema.empty())
+{
+    $$<<"::"<<schema;
+}
+$$<<";\n";
 %>
 
 <%c++for(auto col:cols){

--- a/drogon_ctl/templates/model_h.csp
+++ b/drogon_ctl/templates/model_h.csp
@@ -39,8 +39,14 @@ using DbClientPtr = std::shared_ptr<DbClient>;
 }
 namespace drogon_model
 {
-namespace [[dbName]]
+<%c++
+auto &namespaceName=@@.get<std::string>("namespaceName");
+if(!namespaceName.empty())
 {
+    $$<<"namespace "<<namespaceName<<"\n";
+    $$<<"{\n";
+}
+%>
 <%c++
 auto &schema=@@.get<std::string>("schema");
     if(!schema.empty())
@@ -565,6 +571,10 @@ if(!schema.empty())
 {
     $$<<"} // namespace "<<schema<<"\n";
 }
+auto &namespaceName2=@@.get<std::string>("namespaceName");
+if(!namespaceName2.empty())
+{
+    $$<<"} // namespace "<<namespaceName2<<"\n";
+}
 %>
-} // namespace [[dbName]]
 } // namespace drogon_model

--- a/drogon_ctl/templates/restful_controller_base_h.csp
+++ b/drogon_ctl/templates/restful_controller_base_h.csp
@@ -21,16 +21,21 @@ bool hasPrimaryKey = (tableInfo.get<int>("hasPrimaryKey")==1);
 $$<<"using namespace drogon;\n";
 $$<<"using namespace drogon::orm;\n";
 
-$$<<"using namespace drogon_model::"<<tableInfo.get<std::string>("dbName");
-auto &schema=tableInfo.get<std::string>("schema");
-if(!schema.empty())
+auto &namespaceName=tableInfo.get<std::string>("namespaceName");
+if(!namespaceName.empty())
 {
-    $$<<"::"<<schema<<";\n";
+    $$<<"using namespace drogon_model::"<<namespaceName;
 }
 else
 {
-    $$<<";\n";
+    $$<<"using namespace drogon_model";
 }
+auto &schema=tableInfo.get<std::string>("schema");
+if(!schema.empty())
+{
+    $$<<"::"<<schema;
+}
+$$<<";\n";
 
 auto namespaceVector=@@.get<std::vector<std::string>>("namespaceVector");
 for(auto &name:namespaceVector)

--- a/drogon_ctl/templates/restful_controller_custom_h.csp
+++ b/drogon_ctl/templates/restful_controller_custom_h.csp
@@ -20,16 +20,21 @@ $$<<"#include \""<<modelName<<".h\"\n";
 bool hasPrimaryKey = (tableInfo.get<int>("hasPrimaryKey")==1);
 $$<<"using namespace drogon;\n";
 
-$$<<"using namespace drogon_model::"<<tableInfo.get<std::string>("dbName");
-auto &schema=tableInfo.get<std::string>("schema");
-if(!schema.empty())
+auto &namespaceName=tableInfo.get<std::string>("namespaceName");
+if(!namespaceName.empty())
 {
-    $$<<"::"<<schema<<";\n";
+    $$<<"using namespace drogon_model::"<<namespaceName;
 }
 else
 {
-    $$<<";\n";
+    $$<<"using namespace drogon_model";
 }
+auto &schema=tableInfo.get<std::string>("schema");
+if(!schema.empty())
+{
+    $$<<"::"<<schema;
+}
+$$<<";\n";
 
 auto namespaceVector=@@.get<std::vector<std::string>>("namespaceVector");
 for(auto &name:namespaceVector)

--- a/test.sh
+++ b/test.sh
@@ -214,7 +214,73 @@ function do_drogon_ctl_test()
         exit -1
     fi
 
-    cd ../views
+    # Test namespace customization feature for model generation
+    cd ..
+    mkdir -p test_models
+    cd test_models
+
+    if command -v sqlite3 > /dev/null 2>&1; then
+        echo "Testing namespace customization feature..."
+        sqlite3 test.db "CREATE TABLE users (id INTEGER PRIMARY KEY AUTOINCREMENT, username TEXT NOT NULL, email TEXT NOT NULL);"
+
+        run_ns_test() {
+            local ns_config="$1"
+            local ns_cli="$2"
+            local expected_ns="$3"
+            local description="$4"
+            local expect_empty="$5"
+
+            cat > model.json <<EOF
+{
+    "rdbms": "sqlite3",
+    "filename": "test.db",
+    "namespace": "$ns_config",
+    "tables": [],
+    "restful_api_controllers": {"enabled": false}
+}
+EOF
+
+            if [ "$ns_cli" != "SKIP" ]; then
+                ${drogon_ctl_exec} create model . --table=users --namespace "$ns_cli" -f > /dev/null 2>&1
+            else
+                ${drogon_ctl_exec} create model . --table=users -f > /dev/null 2>&1
+            fi
+
+            if [ ! -f "Users.h" ] || [ ! -f "Users.cc" ]; then
+                echo "✗ Failed to create model files: $description"
+                exit -1
+            fi
+
+            if [ "$expect_empty" = "true" ]; then
+                if ! grep -q "namespace drogon_model" Users.h || grep -q "namespace drogon_model::" Users.h; then
+                    echo "✗ Empty namespace test failed: $description"
+                    exit -1
+                fi
+            else
+                if ! grep -q "namespace $expected_ns" Users.h || ! grep -q "using namespace drogon_model::$expected_ns" Users.cc; then
+                    echo "✗ Namespace test failed: $description"
+                    exit -1
+                fi
+            fi
+            echo "✓ $description"
+            rm -f Users.h Users.cc
+        }
+
+        run_ns_test "myapp" "SKIP" "myapp" "Custom namespace from config"
+        run_ns_test "" "cli_ns" "cli_ns" "Custom namespace from CLI option"
+        run_ns_test "config_ns" "override_ns" "override_ns" "CLI namespace overrides config"
+        run_ns_test "should_be_ignored" "" "" "Empty namespace from CLI" "true"
+
+        cd ..
+        rm -rf test_models
+        echo "Namespace customization tests passed"
+    else
+        echo "sqlite3 not found, skipping namespace customization tests"
+        cd ..
+        rm -rf test_models
+    fi
+
+    cd views
 
     echo "Hello, world!" >>hello.csp
 


### PR DESCRIPTION
## Description

This PR resolves feature request #1591, decoupling generated model namespace from raw database name and providing two ways to customize namespace: command line argument --namespace and namespace field in model.json.

## Changes

### 1. Command Entry & Header Definition
- **drogon_ctl/create.cc**  
  Update command help text to document `--namespace` option
- **drogon_ctl/create_model.h**  
  Add `namespaceName_` and `namespaceOverridden_` member variables

### 2. Core Logic File
- **drogon_ctl/create_model.cc**  
  - Add parsing logic for `--namespace` CLI argument  
  - Read namespace value from `model.json` as fallback when no CLI override  
  - Inject `namespaceName_` into template render data for PG/MySQL/SQLite three database branches

### 3. Template Files (Dynamic Namespace Generation)
- **drogon_ctl/templates/model_h.csp**  
  Dynamically generate namespace bracket blocks and closing comment
- **drogon_ctl/templates/model_cc.csp**  
  Rewrite `using namespace` splicing logic to use custom namespace
- **drogon_ctl/templates/restful_controller_base_h.csp**  
  Adapt `using` statement template
- **drogon_ctl/templates/restful_controller_custom_h.csp**  
  Adapt `using` statement template

### 4. Test Script
- **test.sh**  
  Add full SQLite test cases covering:
  - Config priority  
  - CLI override  
  - Empty namespace scenarios

Closes #1591