### PR TITLE
Fix: change auto-generated model fields prefix to suffix to avoid macros collisions

### DIFF
--- a/drogon_ctl/templates/model_cc.csp
+++ b/drogon_ctl/templates/model_cc.csp
@@ -76,7 +76,7 @@ else
 
 <%c++for(auto col:cols){
 %>
-const std::string [[className]]::Cols::_{%col.colName_%} = "{%escapeIdentifier(col.colName_, rdbms)%}";
+const std::string [[className]]::Cols::{%col.colName_%}_ = "{%escapeIdentifier(col.colName_, rdbms)%}";
 <%c++
 }%>
 <%c++if(@@.get<int>("hasPrimaryKey")<=1){%>

--- a/drogon_ctl/templates/model_h.csp
+++ b/drogon_ctl/templates/model_h.csp
@@ -81,7 +81,7 @@ class [[className]]
 auto cols=@@.get<std::vector<ColumnInfo>>("columns");
     for(size_t i=0;i<cols.size();i++)
     {
-        $$<<"        static const std::string _"<<cols[i].colName_<<";\n";
+        $$<<"        static const std::string "<<cols[i].colName_<<"_;\n";
     }
 %>
     };


### PR DESCRIPTION
### Description of the problem I faced during the developing
Currently, `drogon_ctl` generates model field constants in the `Cols` struct with a leading underscore (e.g., `_id`, `_name`). This causes compilation issues on Windows (especially with MSVC) due to collisions with system macros and standard library reserved identifiers.

This PR moves the underscore to the end of the variable name (e.g., `id_`, `name_`) in the generated templates to follow standard C++ naming conventions and avoid these collisions.

### Changes made
- Updated `drogon_ctl/templates/model_h.csp` and `drogon_ctl/templates/model_cc.csp` templates.
- Changed the generated field names in the `Cols` struct from `_fieldName` to `fieldName_`.

*Note: This is a breaking change for existing user code that directly uses `ModelName::Cols::_fieldName` in their ORM queries, but it is necessary for cross-platform compatibility.*