### PR TITLE
Consistent styling across README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,21 +7,23 @@
 [![Docker image](https://img.shields.io/badge/Docker-image-blue.svg)](https://cloud.docker.com/u/drogonframework/repository/docker/drogonframework/drogon)
 
 English | [简体中文](./README.zh-CN.md) | [繁體中文](./README.zh-TW.md)
+
 ### Overview
+
 **Drogon** is a C++17/20 based HTTP application framework. Drogon can be used to easily build various types of web application server programs using C++. **Drogon** is the name of a dragon from the American TV series *Game of Thrones*, which I really enjoy.
 
 Drogon is a cross-platform framework, It supports Linux, macOS, FreeBSD, OpenBSD, HaikuOS, and Windows. Its main features are as follows:
 
 * Use a non-blocking I/O network lib based on epoll (kqueue under macOS/FreeBSD) to provide high-concurrency, high-performance network IO, please visit the [TFB Tests Results](https://www.techempower.com/benchmarks/#section=data-r19&hw=ph&test=composite) for more details;
 * Provide a completely asynchronous programming mode;
-* Support Http1.0/1.1 (server side and client side);
+* Support HTTP 1.0/1.1 (server side and client side);
 * Based on template, a simple reflection mechanism is implemented to completely decouple the main program framework, controllers and views.
 * Support cookies and built-in sessions;
-* Support back-end rendering, the controller generates the data to the view to generate the Html page. Views are described by CSP template files, C++ codes are embedded into Html pages through CSP tags. And the drogon command-line tool automatically generates the C++ code files for compilation;
+* Support back-end rendering, the controller generates the data to the view to generate the HTML page. Views are described by CSP template files, C++ codes are embedded into HTML pages through CSP tags. And the drogon command-line tool automatically generates the C++ code files for compilation;
 * Support view page dynamic loading (dynamic compilation and loading at runtime);
 * Provide a convenient and flexible routing solution from the path to the controller handler;
 * Support filter chains to facilitate the execution of unified logic (such as login verification, Http Method constraint verification, etc.) before handling HTTP requests;
-* Support https (based on OpenSSL);
+* Support HTTPS (based on OpenSSL);
 * Support WebSocket (server side and client side);
 * Support JSON format request and response, very friendly to the Restful API application development;
 * Support file download and upload;
@@ -45,7 +47,9 @@ Below is the main program of a typical drogon application:
 
 ```c++
 #include <drogon/drogon.h>
+
 using namespace drogon;
+
 int main()
 {
     app().setLogPath("./")
@@ -61,38 +65,42 @@ It can be further simplified by using configuration file as follows:
 
 ```c++
 #include <drogon/drogon.h>
+
 using namespace drogon;
+
 int main()
 {
     app().loadConfigFile("./config.json").run();
 }
 ```
 
-Drogon provides some interfaces for adding controller logic directly in the main() function, for example, user can register a handler like this in Drogon:
+Drogon provides some interfaces for adding controller logic directly in the `main()` function, for example, user can register a handler like this in Drogon:
 
 ```c++
 app().registerHandler("/test?username={name}",
                     [](const HttpRequestPtr& req,
                        std::function<void (const HttpResponsePtr &)> &&callback,
-                       const std::string &name)
+                       const std::string &name) -> void
                     {
                         Json::Value json;
-                        json["result"]="ok";
-                        json["message"]=std::string("hello,")+name;
-                        auto resp=HttpResponse::newHttpJsonResponse(json);
+                        json["result"] = "ok";
+                        json["message"] = "hello, " + name;
+                        HttpResponsePtr resp = HttpResponse::newHttpJsonResponse(json);
                         callback(resp);
                     },
                     {Get,"LoginFilter"});
 ```
 
-While such interfaces look intuitive, they are not suitable for complex business logic scenarios. Assuming there are tens or even hundreds of handlers that need to be registered in the framework, isn't it a better practice to implement them separately in their respective classes? So unless your logic is very simple, we don't recommend using above interfaces. Instead, we can create an HttpSimpleController as follows:
+While such interfaces look intuitive, they are not suitable for complex business logic scenarios. Assuming there are tens or even hundreds of handlers that need to be registered in the framework, isn't it a better practice to implement them separately in their respective classes? So unless your logic is very simple, we don't recommend using above interfaces. Instead, we can create an `HttpSimpleController` as follows:
 
 ```c++
 /// The TestCtrl.h file
 #pragma once
 #include <drogon/HttpSimpleController.h>
+
 using namespace drogon;
-class TestCtrl:public drogon::HttpSimpleController<TestCtrl>
+
+class TestCtrl : public HttpSimpleController<TestCtrl>
 {
 public:
     void asyncHandleHttpRequest(const HttpRequestPtr& req, std::function<void (const HttpResponsePtr &)> &&callback) override;
@@ -103,11 +111,12 @@ public:
 
 /// The TestCtrl.cc file
 #include "TestCtrl.h"
+
 void TestCtrl::asyncHandleHttpRequest(const HttpRequestPtr& req,
                                       std::function<void (const HttpResponsePtr &)> &&callback)
 {
-    //write your application logic here
-    auto resp = HttpResponse::newHttpResponse();
+    // write your application logic here
+    HttpResponsePtr resp = HttpResponse::newHttpResponse();
     resp->setBody("<p>Hello, world!</p>");
     resp->setExpiredTime(0);
     callback(resp);
@@ -121,51 +130,55 @@ For JSON format response, we create the controller as follows:
 ```c++
 /// The header file
 #pragma once
+
 #include <drogon/HttpSimpleController.h>
+
 using namespace drogon;
-class JsonCtrl : public drogon::HttpSimpleController<JsonCtrl>
+
+class JsonCtrl : public HttpSimpleController<JsonCtrl>
 {
   public:
     void asyncHandleHttpRequest(const HttpRequestPtr &req, std::function<void(const HttpResponsePtr &)> &&callback) override;
     PATH_LIST_BEGIN
-    //list path definitions here;
+    // list path definitions here;
     PATH_ADD("/json", Get);
     PATH_LIST_END
 };
 
 /// The source file
 #include "JsonCtrl.h"
+
 void JsonCtrl::asyncHandleHttpRequest(const HttpRequestPtr &req,
                                       std::function<void(const HttpResponsePtr &)> &&callback)
 {
     Json::Value ret;
     ret["message"] = "Hello, World!";
-    auto resp = HttpResponse::newHttpJsonResponse(ret);
+    HttpResponsePtr resp = HttpResponse::newHttpJsonResponse(ret);
     callback(resp);
 }
 ```
 
-Let's go a step further and create a demo RESTful API with the HttpController class, as shown below (Omit the source file):
+Let's go a step further and create a demo RESTful API with the `HttpController` class, as shown below (Omit the source file):
 
 ```c++
 /// The header file
 #pragma once
 #include <drogon/HttpController.h>
+
 using namespace drogon;
-namespace api
+
+namespace api::v1
 {
-namespace v1
-{
-class User : public drogon::HttpController<User>
+class User : public HttpController<User>
 {
   public:
     METHOD_LIST_BEGIN
-    //use METHOD_ADD to add your custom processing function here;
-    METHOD_ADD(User::getInfo, "/{id}", Get);                  //path is /api/v1/User/{arg1}
-    METHOD_ADD(User::getDetailInfo, "/{id}/detailinfo", Get);  //path is /api/v1/User/{arg1}/detailinfo
-    METHOD_ADD(User::newUser, "/{name}", Post);                 //path is /api/v1/User/{arg1}
+    // use METHOD_ADD to add your custom processing function here;
+    METHOD_ADD(User::getInfo, "/{id}", Get); // path is /api/v1/User/{arg1}
+    METHOD_ADD(User::getDetailInfo, "/{id}/detailinfo", Get); // path is /api/v1/User/{arg1}/detailinfo
+    METHOD_ADD(User::newUser, "/{name}", Post); // path is /api/v1/User/{arg1}
     METHOD_LIST_END
-    //your declaration of processing function maybe like this:
+    // your declaration of processing function maybe like this:
     void getInfo(const HttpRequestPtr &req, std::function<void(const HttpResponsePtr &)> &&callback, int userId) const;
     void getDetailInfo(const HttpRequestPtr &req, std::function<void(const HttpResponsePtr &)> &&callback, int userId) const;
     void newUser(const HttpRequestPtr &req, std::function<void(const HttpResponsePtr &)> &&callback, std::string &&userName);
@@ -175,8 +188,7 @@ class User : public drogon::HttpController<User>
         LOG_DEBUG << "User constructor!";
     }
 };
-} // namespace v1
-} // namespace api
+} // namespace api::v1
 ```
 
 As you can see, users can use the `HttpController` to map paths and parameters at the same time. This is a very convenient way to create a RESTful API application.
@@ -188,7 +200,7 @@ After compiling all of the above source files, we get a very simple web applicat
 ## Cross-compilation
 
 Drogon supports cross-compilation, you should define the `CMAKE_SYSTEM_NAME` in toolchain file, for example:
-    
+
 ```cmake
 set(CMAKE_SYSTEM_NAME Linux)
 set(CMAKE_SYSTEM_PROCESSOR arm)
@@ -215,7 +227,7 @@ Drogon provides some building options, you can enable or disable them by setting
 
 ## Contributions
 
-This project exists thanks to all the people who contribute code. 
+This project exists thanks to all the people who contribute code.
 
 <a href="https://github.com/drogonframework/drogon/graphs/contributors"><img src="https://contributors-svg.opencollective.com/drogon/contributors.svg?width=890&button=false" alt="Code contributors" /></a>
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -15,16 +15,16 @@ Drogon是一个跨平台框架，它支持Linux，也支持macOS、FreeBSD，Ope
 
 * 网络层使用基于epoll(macOS/FreeBSD下是kqueue)的非阻塞IO框架，提供高并发、高性能的网络IO。详细请见[TFB Tests Results](https://www.techempower.com/benchmarks/#section=data-r19&hw=ph&test=composite)；
 * 全异步编程模式；
-* 支持Http1.0/1.1(server端和client端)；
+* 支持HTTP 1.0/1.1(server端和client端)；
 * 基于template实现了简单的反射机制，使主程序框架、控制器(controller)和视图(view)完全解耦；
 * 支持cookies和内建的session；
-* 支持后端渲染，把控制器生成的数据交给视图生成Html页面，视图由CSP模板文件描述，通过CSP标签把C++代码嵌入到Html页面，由drogon的命令行工具在编译阶段自动生成C++代码并编译；
+* 支持后端渲染，把控制器生成的数据交给视图生成Html页面，视图由CSP模板文件描述，通过CSP标签把C++代码嵌入到HTML页面，由drogon的命令行工具在编译阶段自动生成C++代码并编译；
 * 支持运行期的视图页面动态加载(动态编译和加载so文件)；
 * 非常方便灵活的路径(path)到控制器处理函数(handler)的映射方案；
-* 支持过滤器(filter)链，方便在控制器之前执行统一的逻辑(如登录验证、Http Method约束验证等)；
-* 支持https(基于OpenSSL实现);
-* 支持websocket(server端和client端);
-* 支持Json格式请求和应答, 对Restful API应用开发非常友好;
+* 支持过滤器(filter)链，方便在控制器之前执行统一的逻辑(如登录验证、HTTP Method约束验证等)；
+* 支持HTTPS(基于OpenSSL实现);
+* 支持WebSocket(server端和client端);
+* 支持JSON格式请求和应答, 对Restful API应用开发非常友好;
 * 支持文件下载和上传,支持sendfile系统调用；
 * 支持gzip/brotli压缩传输；
 * 支持pipelining；
@@ -46,7 +46,9 @@ Drogon是一个跨平台框架，它支持Linux，也支持macOS、FreeBSD，Ope
 
 ```c++
 #include <drogon/drogon.h>
+
 using namespace drogon;
+
 int main()
 {
     app().setLogPath("./")
@@ -62,7 +64,9 @@ int main()
 
 ```c++
 #include <drogon/drogon.h>
+
 using namespace drogon;
+
 int main()
 {
     app().loadConfigFile("./config.json").run();
@@ -75,42 +79,44 @@ int main()
 app().registerHandler("/test?username={name}",
                     [](const HttpRequestPtr& req,
                        std::function<void (const HttpResponsePtr &)> &&callback,
-                       const std::string &name)
+                       const std::string &name) -> void
                     {
                         Json::Value json;
-                        json["result"]="ok";
-                        json["message"]=std::string("hello,")+name;
-                        auto resp=HttpResponse::newHttpJsonResponse(json);
+                        json["result"] = "ok";
+                        json["message"] = "hello, " + name;
+                        HttpResponsePtr resp = HttpResponse::newHttpJsonResponse(json);
                         callback(resp);
                     },
                     {Get,"LoginFilter"});
 ```
 
-
-这看起来是很方便，但是这并不适用于复杂的应用，试想假如有数十个或者数百个处理函数要注册进框架，main()函数将膨胀到不可读的程度。显然，让每个包含处理函数的类在自己的定义中完成注册是更好的选择。所以，除非你的应用逻辑非常简单，我们不推荐使用上述接口，更好的实践是，我们可以创建一个HttpSimpleController对象，如下：
-
+这看起来是很方便，但是这并不适用于复杂的应用，试想假如有数十个或者数百个处理函数要注册进框架，`main()`函数将膨胀到不可读的程度。显然，让每个包含处理函数的类在自己的定义中完成注册是更好的选择。所以，除非你的应用逻辑非常简单，我们不推荐使用上述接口，更好的实践是，我们可以创建一个`HttpSimpleController`对象，如下：
 
 ```c++
 /// The TestCtrl.h file
 #pragma once
+
 #include <drogon/HttpSimpleController.h>
+
 using namespace drogon;
-class TestCtrl:public drogon::HttpSimpleController<TestCtrl>
+
+class TestCtrl : public HttpSimpleController<TestCtrl>
 {
 public:
     void asyncHandleHttpRequest(const HttpRequestPtr& req, std::function<void (const HttpResponsePtr &)> &&callback) override;
     PATH_LIST_BEGIN
-    PATH_ADD("/test",Get);
+    PATH_ADD("/test", Get);
     PATH_LIST_END
 };
 
 /// The TestCtrl.cc file
 #include "TestCtrl.h"
+
 void TestCtrl::asyncHandleHttpRequest(const HttpRequestPtr& req,
                                       std::function<void (const HttpResponsePtr &)> &&callback)
 {
-    //write your application logic here
-    auto resp = HttpResponse::newHttpResponse();
+    // write your application logic here
+    HttpResponsePtr resp = HttpResponse::newHttpResponse();
     resp->setBody("<p>Hello, world!</p>");
     resp->setExpiredTime(0);
     callback(resp);
@@ -125,50 +131,53 @@ void TestCtrl::asyncHandleHttpRequest(const HttpRequestPtr& req,
 /// The header file
 #pragma once
 #include <drogon/HttpSimpleController.h>
+
 using namespace drogon;
-class JsonCtrl : public drogon::HttpSimpleController<JsonCtrl>
+
+class JsonCtrl : public HttpSimpleController<JsonCtrl>
 {
   public:
     void asyncHandleHttpRequest(const HttpRequestPtr &req, std::function<void(const HttpResponsePtr &)> &&callback) override;
     PATH_LIST_BEGIN
-    //list path definitions here;
+    // list path definitions here;
     PATH_ADD("/json", Get);
     PATH_LIST_END
 };
 
 /// The source file
 #include "JsonCtrl.h"
+
 void JsonCtrl::asyncHandleHttpRequest(const HttpRequestPtr &req,
                                       std::function<void(const HttpResponsePtr &)> &&callback)
 {
     Json::Value ret;
     ret["message"] = "Hello, World!";
-    auto resp = HttpResponse::newHttpJsonResponse(ret);
+    HttpResponsePtr resp = HttpResponse::newHttpJsonResponse(ret);
     callback(resp);
 }
 ```
 
-让我们更进一步，通过HttpController类创建一个RESTful API的例子，如下所示（忽略了实现文件）：
+让我们更进一步，通过`HttpController`类创建一个RESTful API的例子，如下所示（忽略了实现文件）：
 
 ```c++
 /// The header file
 #pragma once
 #include <drogon/HttpController.h>
+
 using namespace drogon;
-namespace api
+
+namespace api::v1
 {
-namespace v1
-{
-class User : public drogon::HttpController<User>
+class User : public HttpController<User>
 {
   public:
     METHOD_LIST_BEGIN
-    //use METHOD_ADD to add your custom processing function here;
-    METHOD_ADD(User::getInfo, "/{id}", Get);                  //path is /api/v1/User/{arg1}
-    METHOD_ADD(User::getDetailInfo, "/{id}/detailinfo", Get);  //path is /api/v1/User/{arg1}/detailinfo
-    METHOD_ADD(User::newUser, "/{name}", Post);                 //path is /api/v1/User/{arg1}
+    // use METHOD_ADD to add your custom processing function here;
+    METHOD_ADD(User::getInfo, "/{id}", Get); // path is /api/v1/User/{arg1}
+    METHOD_ADD(User::getDetailInfo, "/{id}/detailinfo", Get); // path is /api/v1/User/{arg1}/detailinfo
+    METHOD_ADD(User::newUser, "/{name}", Post); // path is /api/v1/User/{arg1}
     METHOD_LIST_END
-    //your declaration of processing function maybe like this:
+    // your declaration of processing function maybe like this:
     void getInfo(const HttpRequestPtr &req, std::function<void(const HttpResponsePtr &)> &&callback, int userId) const;
     void getDetailInfo(const HttpRequestPtr &req, std::function<void(const HttpResponsePtr &)> &&callback, int userId) const;
     void newUser(const HttpRequestPtr &req, std::function<void(const HttpResponsePtr &)> &&callback, std::string &&userName);
@@ -178,8 +187,7 @@ class User : public drogon::HttpController<User>
         LOG_DEBUG << "User constructor!";
     }
 };
-} // namespace v1
-} // namespace api
+} // namespace api::v1
 ```
 
 如你所见，通过`HttpController`类，用户可以同时映射路径和路径参数，这对RESTful API应用来说非常方便。

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -47,7 +47,9 @@ Drogon 是一個跨平台框架，支援 Linux、macOS、FreeBSD/OpenBSD、Haiku
 
 ```c++
 #include <drogon/drogon.h>
+
 using namespace drogon;
+
 int main()
 {
     app().setLogPath("./")
@@ -63,7 +65,9 @@ int main()
 
 ```c++
 #include <drogon/drogon.h>
+
 using namespace drogon;
+
 int main()
 {
     app().loadConfigFile("./config.json").run();
@@ -76,40 +80,43 @@ int main()
 app().registerHandler("/test?username={name}",
                     [](const HttpRequestPtr& req,
                        std::function<void (const HttpResponsePtr &)> &&callback,
-                       const std::string &name)
+                       const std::string &name) -> void
                     {
                         Json::Value json;
-                        json["result"]="ok";
-                        json["message"]=std::string("hello,")+name;
-                        auto resp=HttpResponse::newHttpJsonResponse(json);
+                        json["result"] = "ok";
+                        json["message"] = "hello, " + name;
+                        HttpResponsePtr resp = HttpResponse::newHttpJsonResponse(json);
                         callback(resp);
                     },
                     {Get,"LoginFilter"});
 ```
 
-這看起來很方便，但不適用於複雜的場景，試想如果有數十個或數百個處理函式要註冊進框架，`main()` 函式將變得難以閱讀。顯然，讓每個包含處理函式的類別在自己的定義中完成註冊是更好的選擇。所以，除非你的應用邏輯非常簡單，我們不建議使用上述介面，更好的做法是建立一個 HttpSimpleController 類別，如下：
+這看起來很方便，但不適用於複雜的場景，試想如果有數十個或數百個處理函式要註冊進框架，`main()` 函式將變得難以閱讀。顯然，讓每個包含處理函式的類別在自己的定義中完成註冊是更好的選擇。所以，除非你的應用邏輯非常簡單，我們不建議使用上述介面，更好的做法是建立一個 `HttpSimpleController` 類別，如下：
 
 ```c++
 /// The TestCtrl.h file
 #pragma once
 #include <drogon/HttpSimpleController.h>
+
 using namespace drogon;
-class TestCtrl:public drogon::HttpSimpleController<TestCtrl>
+
+class TestCtrl : public HttpSimpleController<TestCtrl>
 {
 public:
     void asyncHandleHttpRequest(const HttpRequestPtr& req, std::function<void (const HttpResponsePtr &)> &&callback) override;
     PATH_LIST_BEGIN
-    PATH_ADD("/test",Get);
+    PATH_ADD("/test", Get);
     PATH_LIST_END
 };
 
 /// The TestCtrl.cc file
 #include "TestCtrl.h"
+
 void TestCtrl::asyncHandleHttpRequest(const HttpRequestPtr& req,
                                       std::function<void (const HttpResponsePtr &)> &&callback)
 {
-    //write your application logic here
-    auto resp = HttpResponse::newHttpResponse();
+    // write your application logic here
+    HttpResponsePtr resp = HttpResponse::newHttpResponse();
     resp->setBody("<p>Hello, world!</p>");
     resp->setExpiredTime(0);
     callback(resp);
@@ -124,50 +131,53 @@ void TestCtrl::asyncHandleHttpRequest(const HttpRequestPtr& req,
 /// The header file
 #pragma once
 #include <drogon/HttpSimpleController.h>
+
 using namespace drogon;
-class JsonCtrl : public drogon::HttpSimpleController<JsonCtrl>
+
+class JsonCtrl : public HttpSimpleController<JsonCtrl>
 {
   public:
     void asyncHandleHttpRequest(const HttpRequestPtr &req, std::function<void(const HttpResponsePtr &)> &&callback) override;
     PATH_LIST_BEGIN
-    //list path definitions here;
+    // list path definitions here;
     PATH_ADD("/json", Get);
     PATH_LIST_END
 };
 
 /// The source file
 #include "JsonCtrl.h"
+
 void JsonCtrl::asyncHandleHttpRequest(const HttpRequestPtr &req,
                                       std::function<void(const HttpResponsePtr &)> &&callback)
 {
     Json::Value ret;
     ret["message"] = "Hello, World!";
-    auto resp = HttpResponse::newHttpJsonResponse(ret);
+    HttpResponsePtr resp = HttpResponse::newHttpJsonResponse(ret);
     callback(resp);
 }
 ```
 
-讓我們更進一步，透過 HttpController 類別建立一個 RESTful API 的範例，如下所示（省略實作檔案）：
+讓我們更進一步，透過 `HttpController` 類別建立一個 RESTful API 的範例，如下所示（省略實作檔案）：
 
 ```c++
 /// The header file
 #pragma once
 #include <drogon/HttpController.h>
+
 using namespace drogon;
-namespace api
+
+namespace api::v1
 {
-namespace v1
-{
-class User : public drogon::HttpController<User>
+class User : public HttpController<User>
 {
   public:
     METHOD_LIST_BEGIN
-    //use METHOD_ADD to add your custom processing function here;
-    METHOD_ADD(User::getInfo, "/{id}", Get);                  //path is /api/v1/User/{arg1}
-    METHOD_ADD(User::getDetailInfo, "/{id}/detailinfo", Get);  //path is /api/v1/User/{arg1}/detailinfo
-    METHOD_ADD(User::newUser, "/{name}", Post);                 //path is /api/v1/User/{arg1}
+    // use METHOD_ADD to add your custom processing function here;
+    METHOD_ADD(User::getInfo, "/{id}", Get); // path is /api/v1/User/{arg1}
+    METHOD_ADD(User::getDetailInfo, "/{id}/detailinfo", Get); // path is /api/v1/User/{arg1}/detailinfo
+    METHOD_ADD(User::newUser, "/{name}", Post); // path is /api/v1/User/{arg1}
     METHOD_LIST_END
-    //your declaration of processing function maybe like this:
+    // your declaration of processing function maybe like this:
     void getInfo(const HttpRequestPtr &req, std::function<void(const HttpResponsePtr &)> &&callback, int userId) const;
     void getDetailInfo(const HttpRequestPtr &req, std::function<void(const HttpResponsePtr &)> &&callback, int userId) const;
     void newUser(const HttpRequestPtr &req, std::function<void(const HttpResponsePtr &)> &&callback, std::string &&userName);
@@ -177,8 +187,7 @@ class User : public drogon::HttpController<User>
         LOG_DEBUG << "User constructor!";
     }
 };
-} // namespace v1
-} // namespace api
+} // namespace api::v1
 ```
 
 如你所見，透過 `HttpController` 類別，使用者可以同時對應路徑和路徑參數，這對 RESTful API 應用來說非常方便。


### PR DESCRIPTION
This PR makes styling in the README files more consistent:

- Add missing whitespace, such as between function parameters, between assignment operators, and between comment lines
- Remove the `drogon::` prefix (when it is already imported by `using namespace drogon;`)
- Capitalise HTTP, HTTPS, JSON, HTML, WebSocket
- Label classes in monospace (such as `HttpController`, `HttpSimpleController`, etc.)
- Clearly indicate `HttpResponse::newHttpJsonResponse()` as returning `HttpResponsePtr`
- Use concise namespace declarations (`namespace api { namespace v1 { /* ... */ } }` -> `namespace api::v1 { /* ... */ }`), as the library is minimum C++17