### PR TITLE
Add HttpAppFramework::hasDbClient() and hasFastDbClient() methods

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### API changes list
+
+- Add `HttpAppFramework::hasDbClient()` and `hasFastDbClient()` methods.
+
 ## [1.9.13] - 2026-05-06
 
 ### API changes list

--- a/lib/inc/drogon/HttpAppFramework.h
+++ b/lib/inc/drogon/HttpAppFramework.h
@@ -1399,6 +1399,23 @@ class DROGON_EXPORT HttpAppFramework : public trantor::NonCopyable
     virtual orm::DbClientPtr getFastDbClient(
         const std::string &name = "default") = 0;
 
+    /// Return true if a database client with the given name has been
+    /// configured
+    /**
+     * @note
+     * This method must be called after the framework has been run.
+     */
+    virtual bool hasDbClient(const std::string &name = "default") const = 0;
+
+    /// Return true if a 'fast' database client with the given name has been
+    /// configured
+    /**
+     * @note
+     * This method must be called after the framework has been run.
+     */
+    virtual bool hasFastDbClient(
+        const std::string &name = "default") const = 0;
+
     /**
      * @brief Check if all database clients in the framework are available
      * (connect to the database successfully).

--- a/lib/inc/drogon/HttpAppFramework.h
+++ b/lib/inc/drogon/HttpAppFramework.h
@@ -1413,8 +1413,7 @@ class DROGON_EXPORT HttpAppFramework : public trantor::NonCopyable
      * @note
      * This method must be called after the framework has been run.
      */
-    virtual bool hasFastDbClient(
-        const std::string &name = "default") const = 0;
+    virtual bool hasFastDbClient(const std::string &name = "default") const = 0;
 
     /**
      * @brief Check if all database clients in the framework are available

--- a/lib/src/DbClientManager.h
+++ b/lib/src/DbClientManager.h
@@ -47,6 +47,16 @@ class DbClientManager : public trantor::NonCopyable
         return iter->second.getThreadData();
     }
 
+    bool hasDbClient(const std::string &name) const noexcept
+    {
+        return dbClientsMap_.find(name) != dbClientsMap_.end();
+    }
+
+    bool hasFastDbClient(const std::string &name) const noexcept
+    {
+        return dbFastClientsMap_.find(name) != dbFastClientsMap_.end();
+    }
+
     void addDbClient(const DbConfig &config);
     bool areAllDbClientsAvailable() const noexcept;
 

--- a/lib/src/HttpAppFrameworkImpl.cc
+++ b/lib/src/HttpAppFrameworkImpl.cc
@@ -906,6 +906,16 @@ orm::DbClientPtr HttpAppFrameworkImpl::getFastDbClient(const std::string &name)
     return dbClientManagerPtr_->getFastDbClient(name);
 }
 
+bool HttpAppFrameworkImpl::hasDbClient(const std::string &name) const
+{
+    return dbClientManagerPtr_->hasDbClient(name);
+}
+
+bool HttpAppFrameworkImpl::hasFastDbClient(const std::string &name) const
+{
+    return dbClientManagerPtr_->hasFastDbClient(name);
+}
+
 nosql::RedisClientPtr HttpAppFrameworkImpl::getRedisClient(
     const std::string &name)
 {

--- a/lib/src/HttpAppFrameworkImpl.h
+++ b/lib/src/HttpAppFrameworkImpl.h
@@ -537,6 +537,8 @@ class HttpAppFrameworkImpl final : public HttpAppFramework
 
     orm::DbClientPtr getDbClient(const std::string &name) override;
     orm::DbClientPtr getFastDbClient(const std::string &name) override;
+    bool hasDbClient(const std::string &name) const override;
+    bool hasFastDbClient(const std::string &name) const override;
 
     HttpAppFramework &createDbClient(const std::string &dbType,
                                      const std::string &host,

--- a/orm_lib/tests/db_api_test.cc
+++ b/orm_lib/tests/db_api_test.cc
@@ -10,6 +10,8 @@ DROGON_TEST(DbApiTest)
 {
 #if USE_POSTGRESQL
     {
+        CHECK(app().hasDbClient("pg_non_fast"));
+        CHECK(app().hasFastDbClient("pg_fast"));
         auto client = app().getDbClient("pg_non_fast");
         CHECK(client != nullptr);
         client->closeAll();
@@ -28,6 +30,8 @@ DROGON_TEST(DbApiTest)
 
 #if USE_MYSQL
     {
+        CHECK(app().hasDbClient("mysql_non_fast"));
+        CHECK(app().hasFastDbClient("mysql_fast"));
         auto client = app().getDbClient("mysql_non_fast");
         CHECK(client != nullptr);
         client->closeAll();
@@ -46,11 +50,15 @@ DROGON_TEST(DbApiTest)
 
 #if USE_SQLITE3
     {
+        CHECK(app().hasDbClient("sqlite3_non_fast"));
         auto client = app().getDbClient("sqlite3_non_fast");
         CHECK(client != nullptr);
         client->closeAll();
     }
 #endif
+
+    CHECK(!app().hasDbClient("this_client_does_not_exist"));
+    CHECK(!app().hasFastDbClient("this_client_does_not_exist"));
 
     app().getLoop()->runAfter(5, [TEST_CTX]() {});  // wait for some time
 }


### PR DESCRIPTION
## Problem
`HttpAppFramework::getDbClient()` / `getFastDbClient()` (backed by
`DbClientManager`) `assert()` when the requested client name doesn't
exist. In release builds this is undefined behavior; in debug builds
it aborts. There is currently no safe way to check whether a named
database client is configured before calling these.

This also makes it hard to write generic code paths that don't know
ahead of time whether a given name is wired up as a regular or a
'fast' (per-IO-thread) client — e.g. a shared repository/service
class that should pick whichever is configured:
`hasFastDbClient(name) ? getFastDbClient(name) : getDbClient(name)`.

## Solution
- Add `DbClientManager::hasDbClient(name)` / `hasFastDbClient(name)`,
  simple `noexcept` map lookups.
- Expose them on the `HttpAppFramework` interface and implement in
  `HttpAppFrameworkImpl`.
- Extend `db_api_test.cc` to check both existing and non-existing
  client names for postgres/mysql/sqlite3.

## Testing
- Extended `orm_lib/tests/db_api_test.cc` (`DbApiTest`), covering
  positive and negative lookups per backend.
