### PR TITLE
Fix Redis client stuck on stale IP after DNS record changes

### DIFF
--- a/lib/src/ConfigLoader.cc
+++ b/lib/src/ConfigLoader.cc
@@ -604,13 +604,7 @@ static void loadRedisClients(const Json::Value &redisClients)
         return;
     for (auto const &client : redisClients)
     {
-        std::promise<std::string> promise;
-        auto future = promise.get_future();
         auto host = client.get("host", "127.0.0.1").asString();
-        trantor::Resolver::newResolver()->resolve(
-            host, [&promise](const trantor::InetAddress &address) {
-                promise.set_value(address.toIp());
-            });
         auto port = client.get("port", 6379).asUInt();
         auto username = client.get("username", "").asString();
         auto password = client.get("passwd", "").asString();
@@ -627,16 +621,8 @@ static void loadRedisClients(const Json::Value &redisClients)
         auto isFast = client.get("is_fast", false).asBool();
         auto timeout = client.get("timeout", -1.0).asDouble();
         auto db = client.get("db", 0).asUInt();
-        auto hostIp = future.get();
-        drogon::app().createRedisClient(hostIp,
-                                        port,
-                                        name,
-                                        password,
-                                        connNum,
-                                        isFast,
-                                        timeout,
-                                        db,
-                                        username);
+        drogon::app().createRedisClient(
+            host, port, name, password, connNum, isFast, timeout, db, username);
     }
 }
 

--- a/nosql_lib/redis/src/RedisClientImpl.cc
+++ b/nosql_lib/redis/src/RedisClientImpl.cc
@@ -27,13 +27,18 @@ std::shared_ptr<RedisClient> RedisClient::newRedisClient(
     unsigned int db,
     const std::string &username)
 {
-    auto client = std::make_shared<RedisClientImpl>(
-        serverAddress, connectionNumber, username, password, db);
+    auto client = std::make_shared<RedisClientImpl>(serverAddress,
+                                                    serverAddress.toIp(),
+                                                    connectionNumber,
+                                                    username,
+                                                    password,
+                                                    db);
     client->init();
     return client;
 }
 
 RedisClientImpl::RedisClientImpl(const trantor::InetAddress &serverAddress,
+                                 std::string hostname,
                                  size_t numberOfConnections,
                                  std::string username,
                                  std::string password,
@@ -43,6 +48,7 @@ RedisClientImpl::RedisClientImpl(const trantor::InetAddress &serverAddress,
                  : std::thread::hardware_concurrency(),
              "RedisLoop"),
       serverAddr_(serverAddress),
+      hostname_(std::move(hostname)),
       username_(std::move(username)),
       password_(std::move(password)),
       db_(db),
@@ -66,7 +72,7 @@ void RedisClientImpl::init()
 RedisConnectionPtr RedisClientImpl::newConnection(trantor::EventLoop *loop)
 {
     auto conn = std::make_shared<RedisConnection>(
-        serverAddr_, username_, password_, db_, loop);
+        serverAddr_, hostname_, username_, password_, db_, loop);
     std::weak_ptr<RedisClientImpl> thisWeakPtr = shared_from_this();
     conn->setConnectCallback([thisWeakPtr](RedisConnectionPtr &&conn) {
         auto thisPtr = thisWeakPtr.lock();
@@ -119,7 +125,7 @@ RedisConnectionPtr RedisClientImpl::newSubscribeConnection(
     const std::shared_ptr<RedisSubscriberImpl> &subscriber)
 {
     auto conn = std::make_shared<RedisConnection>(
-        serverAddr_, username_, password_, db_, loop);
+        serverAddr_, hostname_, username_, password_, db_, loop);
     std::weak_ptr<RedisClientImpl> weakThis = shared_from_this();
     std::weak_ptr<RedisSubscriberImpl> weakSub(subscriber);
     conn->setConnectCallback([weakThis, weakSub](RedisConnectionPtr &&conn) {

--- a/nosql_lib/redis/src/RedisClientImpl.h
+++ b/nosql_lib/redis/src/RedisClientImpl.h
@@ -38,6 +38,7 @@ class RedisClientImpl final
 {
   public:
     RedisClientImpl(const trantor::InetAddress &serverAddress,
+                    std::string hostname,
                     size_t numberOfConnections,
                     std::string username = "",
                     std::string password = "",
@@ -85,6 +86,7 @@ class RedisClientImpl final
     std::vector<RedisConnectionPtr> readyConnections_;
     size_t connectionPos_{0};
     const trantor::InetAddress serverAddr_;
+    const std::string hostname_;
     const std::string username_;
     const std::string password_;
     const unsigned int db_;

--- a/nosql_lib/redis/src/RedisClientLockFree.cc
+++ b/nosql_lib/redis/src/RedisClientLockFree.cc
@@ -21,6 +21,7 @@ using namespace drogon::nosql;
 
 RedisClientLockFree::RedisClientLockFree(
     const trantor::InetAddress &serverAddress,
+    std::string hostname,
     size_t numberOfConnections,
     trantor::EventLoop *loop,
     std::string username,
@@ -28,6 +29,7 @@ RedisClientLockFree::RedisClientLockFree(
     unsigned int db)
     : loop_(loop),
       serverAddr_(serverAddress),
+      hostname_(std::move(hostname)),
       username_(std::move(username)),
       password_(std::move(password)),
       db_(db),
@@ -44,7 +46,7 @@ RedisConnectionPtr RedisClientLockFree::newConnection()
 {
     loop_->assertInLoopThread();
     auto conn = std::make_shared<RedisConnection>(
-        serverAddr_, username_, password_, db_, loop_);
+        serverAddr_, hostname_, username_, password_, db_, loop_);
     std::weak_ptr<RedisClientLockFree> thisWeakPtr = shared_from_this();
     conn->setConnectCallback([thisWeakPtr](RedisConnectionPtr &&conn) {
         auto thisPtr = thisWeakPtr.lock();
@@ -90,7 +92,7 @@ RedisConnectionPtr RedisClientLockFree::newSubscribeConnection(
 {
     loop_->assertInLoopThread();
     auto conn = std::make_shared<RedisConnection>(
-        serverAddr_, username_, password_, db_, loop_);
+        serverAddr_, hostname_, username_, password_, db_, loop_);
     std::weak_ptr<RedisClientLockFree> weakThis = shared_from_this();
     std::weak_ptr<RedisSubscriberImpl> weakSub(subscriber);
     conn->setConnectCallback([weakThis, weakSub](RedisConnectionPtr &&conn) {

--- a/nosql_lib/redis/src/RedisClientLockFree.h
+++ b/nosql_lib/redis/src/RedisClientLockFree.h
@@ -37,6 +37,7 @@ class RedisClientLockFree final
 {
   public:
     RedisClientLockFree(const trantor::InetAddress &serverAddress,
+                        std::string hostname,
                         size_t numberOfConnections,
                         trantor::EventLoop *loop,
                         std::string username = "",
@@ -76,6 +77,7 @@ class RedisClientLockFree final
     std::vector<RedisConnectionPtr> readyConnections_;
     size_t connectionPos_{0};
     const trantor::InetAddress serverAddr_;
+    const std::string hostname_;
     const std::string username_;
     const std::string password_;
     const unsigned int db_;

--- a/nosql_lib/redis/src/RedisClientManager.cc
+++ b/nosql_lib/redis/src/RedisClientManager.cc
@@ -38,6 +38,7 @@ void RedisClientManager::createRedisClients(
                 LOG_TRACE << "create fast redis client for the thread " << idx;
                 c = std::make_shared<RedisClientLockFree>(
                     trantor::InetAddress(redisInfo.addr_, redisInfo.port_),
+                    redisInfo.addr_,
                     redisInfo.connectionNumber_,
                     ioLoops[idx],
                     redisInfo.username_,
@@ -53,6 +54,7 @@ void RedisClientManager::createRedisClients(
         {
             auto clientPtr = std::make_shared<RedisClientImpl>(
                 trantor::InetAddress(redisInfo.addr_, redisInfo.port_),
+                redisInfo.addr_,
                 redisInfo.connectionNumber_,
                 redisInfo.username_,
                 redisInfo.password_,

--- a/nosql_lib/redis/src/RedisConnection.cc
+++ b/nosql_lib/redis/src/RedisConnection.cc
@@ -24,11 +24,13 @@
 using namespace drogon::nosql;
 
 RedisConnection::RedisConnection(const trantor::InetAddress &serverAddress,
+                                 const std::string &hostname,
                                  const std::string &username,
                                  const std::string &password,
                                  unsigned int db,
                                  trantor::EventLoop *loop)
     : serverAddr_(serverAddress),
+      hostname_(hostname),
       username_(username),
       password_(password),
       db_(db),
@@ -43,8 +45,35 @@ void RedisConnection::startConnectionInLoop()
     loop_->assertInLoopThread();
     assert(!redisContext_);
 
-    redisContext_ =
-        ::redisAsyncConnect(serverAddr_.toIp().c_str(), serverAddr_.toPort());
+    if (!resolver_)
+        resolver_ = trantor::Resolver::newResolver(loop_);
+
+    auto thisPtr = shared_from_this();
+    resolver_->resolve(hostname_, [thisPtr](const trantor::InetAddress &addr) {
+        thisPtr->loop_->runInLoop([thisPtr, addr]() {
+            // trantor::Resolver signals a lookup failure by returning the
+            // unspecified address.
+            if (addr.toIp() == "0.0.0.0")
+            {
+                LOG_ERROR << "Failed to resolve Redis hostname: "
+                          << thisPtr->hostname_;
+                if (thisPtr->disconnectCallback_)
+                {
+                    auto connPtr = thisPtr;
+                    thisPtr->disconnectCallback_(std::move(connPtr));
+                }
+                return;
+            }
+            thisPtr->connectWithResolvedIp(addr.toIp());
+        });
+    });
+}
+
+void RedisConnection::connectWithResolvedIp(const std::string &ip)
+{
+    loop_->assertInLoopThread();
+
+    redisContext_ = ::redisAsyncConnect(ip.c_str(), serverAddr_.toPort());
     status_ = ConnectStatus::kConnecting;
     if (redisContext_->err)
     {
@@ -78,8 +107,8 @@ void RedisConnection::startConnectionInLoop()
             auto thisPtr = static_cast<RedisConnection *>(context->ev.data);
             if (status != REDIS_OK)
             {
-                LOG_ERROR << "Failed to connect to "
-                          << thisPtr->serverAddr_.toIpPort() << "! "
+                LOG_ERROR << "Failed to connect to " << thisPtr->hostname_
+                          << ":" << thisPtr->serverAddr_.toPort() << "! "
                           << context->errstr;
                 thisPtr->handleDisconnect();
                 if (thisPtr->disconnectCallback_)
@@ -89,8 +118,8 @@ void RedisConnection::startConnectionInLoop()
             }
             else
             {
-                LOG_TRACE << "Connected successfully to "
-                          << thisPtr->serverAddr_.toIpPort();
+                LOG_TRACE << "Connected successfully to " << thisPtr->hostname_
+                          << ":" << thisPtr->serverAddr_.toPort();
                 if (thisPtr->password_.empty())
                 {
                     if (thisPtr->db_ == 0)

--- a/nosql_lib/redis/src/RedisConnection.h
+++ b/nosql_lib/redis/src/RedisConnection.h
@@ -21,6 +21,7 @@
 #include <trantor/net/InetAddress.h>
 #include <trantor/net/EventLoop.h>
 #include <trantor/net/Channel.h>
+#include <trantor/net/Resolver.h>
 #include <hiredis/async.h>
 #include <hiredis/hiredis.h>
 #include <memory>
@@ -45,6 +46,7 @@ class RedisConnection : public trantor::NonCopyable,
 {
   public:
     RedisConnection(const trantor::InetAddress &serverAddress,
+                    const std::string &hostname,
                     const std::string &username,
                     const std::string &password,
                     unsigned int db,
@@ -188,6 +190,8 @@ class RedisConnection : public trantor::NonCopyable,
   private:
     redisAsyncContext *redisContext_{nullptr};
     const trantor::InetAddress serverAddr_;
+    const std::string hostname_;
+    std::shared_ptr<trantor::Resolver> resolver_;
     const std::string username_;
     const std::string password_;
     const unsigned int db_;
@@ -206,6 +210,7 @@ class RedisConnection : public trantor::NonCopyable,
         subContexts_;
 
     void startConnectionInLoop();
+    void connectWithResolvedIp(const std::string &ip);
     static void addWrite(void *userData);
     static void delWrite(void *userData);
     static void addRead(void *userData);


### PR DESCRIPTION
## Problem

`ConfigLoader` resolves the Redis `host` to an IP address **once**, synchronously, when the config is loaded, and that IP is baked into every `RedisConnection` for the lifetime of the process:

```cpp
// current behavior
auto hostIp = future.get();  // blocking resolve, done once at startup
drogon::app().createRedisClient(hostIp, port, ...);
```

If the Redis endpoint is fronted by DNS (Kubernetes `Service`, ElastiCache/managed Redis endpoint, Sentinel, any failover setup) and the IP behind that name changes, Drogon has no way to notice — every reconnect attempt keeps dialing the old, now-dead address.

**We hit this in production**: our Redis runs in Kubernetes behind a `Service` hostname. When the pod backing that Service was rescheduled and got a new IP, Drogon kept reconnecting to the old address and our logs started spamming `Failed to connect to 0.0.0.0:6379` (`serverAddr_.toIp()` had gone stale after the failover) until we restarted the app.

## Fix

- `ConfigLoader` no longer pre-resolves the host; it passes the original hostname straight through.
- `RedisConnection` now carries the hostname (not just the resolved `InetAddress`) and calls `trantor::Resolver` **on every connection attempt** (`startConnectionInLoop`), so a reconnect always picks up the current DNS record instead of a value cached at startup.
- A failed resolution triggers the normal `disconnectCallback_` path (so the client's existing reconnect/backoff logic applies) instead of silently connecting to `0.0.0.0`.
- Log lines now print the hostname instead of a stale resolved IP, so connection errors are actually actionable.

This only touches `RedisClientImpl`/`RedisClientLockFree`/`RedisConnection`, which are internal (`src/`, not `inc/`) — _**no public API change.**_

## Testing

- Built locally with `BUILD_REDIS=ON` (hiredis via Homebrew), all touched translation units compile without new warnings.
- Manually verified against a local Redis: connect, kill/restart Redis on a different IP behind the same hostname (via `/etc/hosts` swap), confirm the client reconnects to the new address instead of looping on the old one.
- Running this patch in production at ~200 rps for a while now with no regressions in steady-state Redis traffic. We haven't yet had a live DNS/failover event to observe the recovery path in production, but the manual re-resolution test above exercises exactly that code path.