### PR TITLE
Fix SQLite cleanup with cached statements

### DIFF
--- a/orm_lib/src/sqlite3_impl/Sqlite3Connection.cc
+++ b/orm_lib/src/sqlite3_impl/Sqlite3Connection.cc
@@ -117,7 +117,9 @@ void Sqlite3Connection::init()
         sqlite3 *tmp = nullptr;
         auto ret = sqlite3_open(filename.data(), &tmp);
         connectionPtr_ = std::shared_ptr<sqlite3>(tmp, [](sqlite3 *ptr) {
-            sqlite3_close(ptr);
+            // Cached prepared statements may outlive disconnect().
+            // Defer deallocation until the final statement is destroyed.
+            sqlite3_close_v2(ptr);
         });
         auto thisPtr = shared_from_this();
         if (ret != SQLITE_OK)

--- a/orm_lib/src/sqlite3_impl/test/CMakeLists.txt
+++ b/orm_lib/src/sqlite3_impl/test/CMakeLists.txt
@@ -5,3 +5,11 @@ add_executable(sqlite3_test1 test1.cc Groups.cc)
 set_property(TARGET sqlite3_test1 PROPERTY CXX_STANDARD ${DROGON_CXX_STANDARD})
 set_property(TARGET sqlite3_test1 PROPERTY CXX_STANDARD_REQUIRED ON)
 set_property(TARGET sqlite3_test1 PROPERTY CXX_EXTENSIONS OFF)
+
+add_executable(sqlite3_disconnect_test Sqlite3DisconnectTest.cc)
+set_property(TARGET sqlite3_disconnect_test
+             PROPERTY CXX_STANDARD ${DROGON_CXX_STANDARD})
+set_property(TARGET sqlite3_disconnect_test
+             PROPERTY CXX_STANDARD_REQUIRED ON)
+set_property(TARGET sqlite3_disconnect_test PROPERTY CXX_EXTENSIONS OFF)
+add_test(NAME sqlite3_disconnect COMMAND sqlite3_disconnect_test)

--- a/orm_lib/src/sqlite3_impl/test/CMakeLists.txt
+++ b/orm_lib/src/sqlite3_impl/test/CMakeLists.txt
@@ -12,4 +12,10 @@ set_property(TARGET sqlite3_disconnect_test
 set_property(TARGET sqlite3_disconnect_test
              PROPERTY CXX_STANDARD_REQUIRED ON)
 set_property(TARGET sqlite3_disconnect_test PROPERTY CXX_EXTENSIONS OFF)
+if (TARGET SQLite3_lib)
+    target_link_libraries(sqlite3_disconnect_test PRIVATE SQLite3_lib)
+else ()
+    target_link_libraries(sqlite3_disconnect_test
+                          PRIVATE unofficial::sqlite3::sqlite3)
+endif ()
 add_test(NAME sqlite3_disconnect COMMAND sqlite3_disconnect_test)

--- a/orm_lib/src/sqlite3_impl/test/Sqlite3DisconnectTest.cc
+++ b/orm_lib/src/sqlite3_impl/test/Sqlite3DisconnectTest.cc
@@ -1,0 +1,49 @@
+#include <drogon/orm/DbClient.h>
+#include <sqlite3.h>
+
+#include <iostream>
+#include <limits>
+#include <stdexcept>
+
+using drogon::orm::DbClient;
+
+namespace
+{
+void runClient(bool cachePreparedStatement)
+{
+    auto client = DbClient::newSqlite3Client("filename=:memory:", 1);
+    if (cachePreparedStatement)
+    {
+        const auto result = client->execSqlSync("SELECT ?", 42);
+        if (result.size() != 1 || result[0][0].as<int>() != 42)
+        {
+            throw std::runtime_error("unexpected SQLite query result");
+        }
+    }
+    else
+    {
+        client->execSqlSync("SELECT 1");
+    }
+    client->closeAll();
+}
+}  // namespace
+
+int main()
+{
+    // Initialize SQLite and Drogon's database machinery before taking the
+    // baseline. A query without parameters does not enter the statement cache.
+    runClient(false);
+    sqlite3_release_memory(std::numeric_limits<int>::max());
+    const auto memoryBefore = sqlite3_memory_used();
+
+    runClient(true);
+    sqlite3_release_memory(std::numeric_limits<int>::max());
+    const auto memoryAfter = sqlite3_memory_used();
+
+    if (memoryAfter > memoryBefore)
+    {
+        std::cerr << "SQLite retained " << memoryAfter - memoryBefore
+                  << " bytes after the client disconnected\n";
+        return 1;
+    }
+}

--- a/orm_lib/src/sqlite3_impl/test/Sqlite3DisconnectTest.cc
+++ b/orm_lib/src/sqlite3_impl/test/Sqlite3DisconnectTest.cc
@@ -33,11 +33,11 @@ int main()
     // Initialize SQLite and Drogon's database machinery before taking the
     // baseline. A query without parameters does not enter the statement cache.
     runClient(false);
-    sqlite3_release_memory(std::numeric_limits<int>::max());
+    sqlite3_release_memory((std::numeric_limits<int>::max)());
     const auto memoryBefore = sqlite3_memory_used();
 
     runClient(true);
-    sqlite3_release_memory(std::numeric_limits<int>::max());
+    sqlite3_release_memory((std::numeric_limits<int>::max)());
     const auto memoryAfter = sqlite3_memory_used();
 
     if (memoryAfter > memoryBefore)


### PR DESCRIPTION
## Summary

Fix SQLite connection cleanup when Drogon has cached prepared statements.

`Sqlite3Connection` previously used `sqlite3_close()` as the connection deleter. If cached prepared statements were still alive when the connection deleter ran, SQLite returned `SQLITE_BUSY` and left the connection open. The return value was ignored, and no later close attempt was made after the statements were finalized, causing the SQLite connection and related allocations to leak.

This changes the deleter to `sqlite3_close_v2()`. It marks the connection for deferred destruction, allowing SQLite to release it automatically after the final cached statement has been finalized.

## Regression test

The new test:

1. Initializes Drogon and SQLite without creating a cached statement.
2. Records SQLite's memory usage.
3. Creates another client and executes a parameterized query, which enters Drogon's statement cache.
4. Disconnects the client and verifies that SQLite did not retain additional memory.

The test fails with the previous `sqlite3_close()` behavior and passes with `sqlite3_close_v2()`.

## Validation

- Formatted with clang-format 17.0.6
- Debug build with AddressSanitizer
- Full registered test suite: 143/143 passed
- Regression test passed 20 consecutive runs with LeakSanitizer enabled
- Existing SQLite ORM test groups passed:
  - `SQLite3Test`: 104 assertions
  - `SQLite3TransactionTypeTest`: 12 assertions
  - `SQLite3TransactionTypeLockingTest`: 1 assertion
  - `DbApiTest`: 4 assertions