### PR TITLE
fix: defer EventLoopThread teardown off DbLoop to avoid self-join

### DIFF
--- a/orm_lib/src/DbClientImpl.cc
+++ b/orm_lib/src/DbClientImpl.cc
@@ -59,12 +59,13 @@ DbClientImpl::DbClientImpl(const std::string &connInfo,
 #if LIBPQ_SUPPORTS_BATCH_MODE
       autoBatch_(autoBatch),
 #endif
-      loops_(type == ClientType::Sqlite3
-                 ? 1
-                 : (connNum < std::thread::hardware_concurrency()
-                        ? connNum
-                        : std::thread::hardware_concurrency()),
-             "DbLoop")
+      loops_(std::make_unique<trantor::EventLoopThreadPool>(
+          type == ClientType::Sqlite3
+              ? 1
+              : (connNum < std::thread::hardware_concurrency()
+                     ? connNum
+                     : std::thread::hardware_concurrency()),
+          "DbLoop"))
 {
     type_ = type;
     connectionInfo_ = connInfo;
@@ -74,13 +75,13 @@ DbClientImpl::DbClientImpl(const std::string &connInfo,
 
 void DbClientImpl::init()
 {
-    // LOG_DEBUG << loops_.getLoopNum();
-    loops_.start();
+    // LOG_DEBUG << loops_->getLoopNum();
+    loops_->start();
     if (type_ == ClientType::PostgreSQL || type_ == ClientType::Mysql)
     {
         for (size_t i = 0; i < numberOfConnections_; ++i)
         {
-            auto loop = loops_.getNextLoop();
+            auto loop = loops_->getNextLoop();
             loop->runInLoop([this, loop]() { newConnection(loop); });
         }
     }
@@ -99,6 +100,28 @@ void DbClientImpl::init()
 DbClientImpl::~DbClientImpl() noexcept
 {
     closeAll();
+    // If the last shared_ptr was released from inside a DbLoop callback,
+    // destroying EventLoopThreadPool here would self-join and throw
+    // std::system_error (resource_deadlock_would_occur). Hand the pool to a
+    // helper thread so join() runs off the loop thread. See #2552.
+    if (!loops_)
+        return;
+    bool onPoolThread = false;
+    for (auto *loop : loops_->getLoops())
+    {
+        if (loop && loop->isInLoopThread())
+        {
+            onPoolThread = true;
+            break;
+        }
+    }
+    if (onPoolThread)
+    {
+        auto pool =
+            std::make_shared<std::unique_ptr<trantor::EventLoopThreadPool>>(
+                std::move(loops_));
+        std::thread([pool]() mutable { pool->reset(); }).detach();
+    }
 }
 
 void DbClientImpl::closeAll()
@@ -221,7 +244,7 @@ void DbClientImpl::newTransactionAsync(
                     std::make_shared<std::weak_ptr<std::function<void(
                         const std::shared_ptr<Transaction> &)>>>();
                 auto timeoutFlagPtr = std::make_shared<TaskTimeoutFlag>(
-                    loops_.getNextLoop(),
+                    loops_->getNextLoop(),
                     std::chrono::duration<double>(timeout_),
                     [newCallbackPtr, callbackPtr, this]() {
                         auto cbPtr = (*newCallbackPtr).lock();
@@ -513,7 +536,7 @@ void DbClientImpl::execSqlWithTimeout(
         std::make_shared<std::function<void(const std::exception_ptr &)>>(
             std::move(ecb));
     auto timeoutFlagPtr = std::make_shared<drogon::TaskTimeoutFlag>(
-        loops_.getNextLoop(),
+        loops_->getNextLoop(),
         std::chrono::duration<double>(timeout_),
         [cmd, ecpPtr, thisPtr = shared_from_this()]() {
             auto cbPtr = (*cmd).lock();

--- a/orm_lib/src/DbClientImpl.h
+++ b/orm_lib/src/DbClientImpl.h
@@ -41,6 +41,7 @@ class DbClientImpl : public DbClient,
                  ClientType type);
 #endif
     ~DbClientImpl() noexcept override;
+
     void execSql(const char *sql,
                  size_t sqlLength,
                  size_t paraNum,
@@ -71,7 +72,9 @@ class DbClientImpl : public DbClient,
 
   private:
     size_t numberOfConnections_;
-    trantor::EventLoopThreadPool loops_;
+    // Heap-allocated so we can defer destruction when the last reference is
+    // released on one of the pool's own loop threads (see #2552).
+    std::unique_ptr<trantor::EventLoopThreadPool> loops_;
     std::shared_ptr<SharedMutex> sharedMutexPtr_;
     double timeout_{-1.0};
 #if LIBPQ_SUPPORTS_BATCH_MODE

--- a/orm_lib/src/postgresql_impl/PgListener.cc
+++ b/orm_lib/src/postgresql_impl/PgListener.cc
@@ -14,6 +14,8 @@
 
 #include "PgListener.h"
 #include "PgConnection.h"
+#include <memory>
+#include <thread>
 
 using namespace drogon;
 using namespace drogon::orm;
@@ -38,6 +40,14 @@ PgListener::~PgListener()
     {
         conn_->disconnect();
         conn_ = nullptr;
+    }
+    // Same self-join hazard as DbClientImpl / Sqlite3Connection (#2552).
+    if (threadPtr_ && loop_ && loop_->isInLoopThread())
+    {
+        auto thr =
+            std::make_shared<std::unique_ptr<trantor::EventLoopThread>>(
+                std::move(threadPtr_));
+        std::thread([thr]() mutable { thr->reset(); }).detach();
     }
 }
 

--- a/orm_lib/src/sqlite3_impl/Sqlite3Connection.cc
+++ b/orm_lib/src/sqlite3_impl/Sqlite3Connection.cc
@@ -23,6 +23,7 @@
 #include <exception>
 #include <mutex>
 #include <regex>
+#include <thread>
 
 using namespace drogon;
 using namespace drogon::orm;
@@ -82,14 +83,33 @@ Sqlite3Connection::Sqlite3Connection(
     trantor::EventLoop *loop,
     const std::string &connInfo,
     const std::shared_ptr<SharedMutex> &sharedMutex)
-    : DbConnection(loop), sharedMutexPtr_(sharedMutex), connInfo_(connInfo)
+    : DbConnection(loop),
+      loopThread_(std::make_unique<trantor::EventLoopThread>()),
+      sharedMutexPtr_(sharedMutex),
+      connInfo_(connInfo)
 {
+}
+
+Sqlite3Connection::~Sqlite3Connection()
+{
+    // Releasing the last connection ref from a callback on this connection's
+    // own loop thread would self-join in ~EventLoopThread. See #2552.
+    if (!loopThread_)
+        return;
+    auto *loop = loopThread_->getLoop();
+    if (loop && loop->isInLoopThread())
+    {
+        auto thr =
+            std::make_shared<std::unique_ptr<trantor::EventLoopThread>>(
+                std::move(loopThread_));
+        std::thread([thr]() mutable { thr->reset(); }).detach();
+    }
 }
 
 void Sqlite3Connection::init()
 {
-    loopThread_.run();
-    loop_ = loopThread_.getLoop();
+    loopThread_->run();
+    loop_ = loopThread_->getLoop();
     std::call_once(once_, []() {
         auto ret = sqlite3_config(SQLITE_CONFIG_MULTITHREAD);
         if (ret != SQLITE_OK)
@@ -146,7 +166,7 @@ void Sqlite3Connection::execSql(
     std::function<void(const std::exception_ptr &)> &&exceptCallback)
 {
     auto thisPtr = shared_from_this();
-    loopThread_.getLoop()->queueInLoop(
+    loopThread_->getLoop()->queueInLoop(
         [thisPtr,
          sql = std::move(sql),
          paraNum,
@@ -381,7 +401,7 @@ void Sqlite3Connection::disconnect()
     auto f = pro.get_future();
     auto thisPtr = shared_from_this();
     std::weak_ptr<Sqlite3Connection> weakPtr = thisPtr;
-    loopThread_.getLoop()->runInLoop([weakPtr, &pro]() {
+    loopThread_->getLoop()->runInLoop([weakPtr, &pro]() {
         {
             auto thisPtr = weakPtr.lock();
             if (!thisPtr)

--- a/orm_lib/src/sqlite3_impl/Sqlite3Connection.h
+++ b/orm_lib/src/sqlite3_impl/Sqlite3Connection.h
@@ -63,6 +63,8 @@ class Sqlite3Connection : public DbConnection,
 
     void disconnect() override;
 
+    ~Sqlite3Connection() override;
+
   private:
     static std::once_flag once_;
     void execSqlInQueue(
@@ -80,7 +82,8 @@ class Sqlite3Connection : public DbConnection,
     int stmtStep(sqlite3_stmt *stmt,
                  const std::shared_ptr<Sqlite3ResultImpl> &resultPtr,
                  int columnNum);
-    trantor::EventLoopThread loopThread_;
+    // Heap-allocated so destruction can be deferred off the loop thread (#2552).
+    std::unique_ptr<trantor::EventLoopThread> loopThread_;
     std::shared_ptr<sqlite3> connectionPtr_;
     std::shared_ptr<SharedMutex> sharedMutexPtr_;
     std::unordered_map<std::string_view, std::shared_ptr<sqlite3_stmt>>


### PR DESCRIPTION
## Summary
Fixes `std::system_error` / “Resource deadlock avoided” when the last `DbClient` / SQLite connection / `PgListener` reference is released from inside its own `EventLoopThread` callback (#2552).

`~EventLoopThread` calls `thread_.join()`. If that destructor runs on the same worker thread (via a completion lambda holding the last `shared_ptr`), `join()` throws and the process aborts.

- Heap-allocate `EventLoopThread` / `EventLoopThreadPool` so ownership can be moved off the loop thread
- When destroying from `isInLoopThread()`, hand the handle to a short-lived helper thread that performs the real teardown and `join()`

Touches `DbClientImpl`, `Sqlite3Connection`, and `PgListener` (same hazard on each).

## Test plan
- [ ] Run the SQLite `:memory:` reproducer from #2552 in a loop; process should no longer abort
- [ ] Normal `DbClient` construct / `execSql` / destroy from a non-loop thread still works
- [ ] Postgres path: create client, run a transaction, release from a result callback without aborting

Closes #2552
