### PR TITLE
feat: add drogon_ctl build and run subcommands

### DIFF
--- a/drogon_ctl/CMakeLists.txt
+++ b/drogon_ctl/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(ctl_sources
+    build.cc
     cmd.cc
     create.cc
     create_controller.cc
@@ -10,6 +11,7 @@ set(ctl_sources
     help.cc
     main.cc
     press.cc
+    run.cc
     version.cc)
 add_executable(_drogon_ctl
                main.cc

--- a/drogon_ctl/build.cc
+++ b/drogon_ctl/build.cc
@@ -1,0 +1,196 @@
+/**
+ *
+ *  build.cc
+ *
+ *  Copyright 2026, Drogon authors.  All rights reserved.
+ *  https://github.com/drogonframework/drogon
+ *  Use of this source code is governed by a MIT license
+ *  that can be found in the License file.
+ *
+ *  Drogon
+ *
+ */
+
+#include "build.h"
+#include <cctype>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <regex>
+#include <sstream>
+
+namespace fs = std::filesystem;
+
+namespace drogon_ctl
+{
+namespace project_build
+{
+int runCommand(const std::string &cmd)
+{
+    std::cout << "==> " << cmd << std::endl;
+    return std::system(cmd.c_str());
+}
+
+bool ensureCmakeProject()
+{
+    if (!fs::exists("CMakeLists.txt"))
+    {
+        std::cerr << "No CMakeLists.txt in the current directory. "
+                     "Run this from a Drogon project root "
+                     "(e.g. after 'drogon_ctl create project <name>')."
+                  << std::endl;
+        return false;
+    }
+    return true;
+}
+
+std::string projectName()
+{
+    std::ifstream in("CMakeLists.txt");
+    if (!in)
+        return fs::current_path().filename().string();
+
+    std::string content((std::istreambuf_iterator<char>(in)),
+                        std::istreambuf_iterator<char>());
+    // Match: project(Name ...) or project(Name)
+    static const std::regex re(
+        R"(project\s*\(\s*([A-Za-z0-9_.-]+))",
+        std::regex::icase);
+    std::smatch m;
+    if (std::regex_search(content, m, re) && m.size() > 1)
+        return m[1].str();
+    return fs::current_path().filename().string();
+}
+
+bool configureAndBuild(const std::vector<std::string> &extraCmakeArgs)
+{
+    if (!ensureCmakeProject())
+        return false;
+
+    std::error_code ec;
+    fs::create_directories("build", ec);
+    if (ec)
+    {
+        std::cerr << "Failed to create build/: " << ec.message() << std::endl;
+        return false;
+    }
+
+    std::ostringstream cfg;
+    cfg << "cmake -S . -B build";
+    for (const auto &arg : extraCmakeArgs)
+    {
+        cfg << ' ' << arg;
+    }
+    if (runCommand(cfg.str()) != 0)
+    {
+        std::cerr << "cmake configure failed" << std::endl;
+        return false;
+    }
+    if (runCommand("cmake --build build") != 0)
+    {
+        std::cerr << "cmake build failed" << std::endl;
+        return false;
+    }
+    return true;
+}
+
+static bool isExecutableFile(const fs::path &p)
+{
+    if (!fs::is_regular_file(p))
+        return false;
+#ifdef _WIN32
+    auto ext = p.extension().string();
+    for (auto &c : ext)
+        c = static_cast<char>(::tolower(static_cast<unsigned char>(c)));
+    return ext == ".exe";
+#else
+    auto perms = fs::status(p).permissions();
+    return (perms & fs::perms::owner_exec) != fs::perms::none ||
+           (perms & fs::perms::group_exec) != fs::perms::none ||
+           (perms & fs::perms::others_exec) != fs::perms::none;
+#endif
+}
+
+std::string findBuiltExecutable(const std::string &name)
+{
+#ifdef _WIN32
+    const std::string exeName = name + ".exe";
+#else
+    const std::string exeName = name;
+#endif
+    const fs::path candidates[] = {
+        fs::path("build") / exeName,
+        fs::path("build") / "Debug" / exeName,
+        fs::path("build") / "Release" / exeName,
+        fs::path("build") / "RelWithDebInfo" / exeName,
+        fs::path("build") / "MinSizeRel" / exeName,
+    };
+    for (const auto &c : candidates)
+    {
+        if (isExecutableFile(c))
+            return c.string();
+    }
+
+    // Fallback: first matching executable under build/
+    if (fs::exists("build"))
+    {
+        for (auto it = fs::recursive_directory_iterator("build");
+             it != fs::recursive_directory_iterator();
+             ++it)
+        {
+            // Skip nested cmake/compiler dirs that are huge
+            if (it->is_directory())
+            {
+                auto dirName = it->path().filename().string();
+                if (dirName == "CMakeFiles" || dirName == ".cmake" ||
+                    dirName == "Testing")
+                {
+                    it.disable_recursion_pending();
+                    continue;
+                }
+            }
+            if (!it->is_regular_file())
+                continue;
+            if (it->path().filename().string() == exeName &&
+                isExecutableFile(it->path()))
+            {
+                return it->path().string();
+            }
+        }
+    }
+    return {};
+}
+
+}  // namespace project_build
+
+void build::handleCommand(std::vector<std::string> &parameters)
+{
+    std::vector<std::string> cmakeArgs;
+    for (const auto &p : parameters)
+    {
+        if (p == "--")
+            continue;
+        cmakeArgs.push_back(p);
+    }
+    if (!project_build::configureAndBuild(cmakeArgs))
+        exit(1);
+    std::cout << "Build succeeded." << std::endl;
+}
+
+std::string build::detail()
+{
+    return R"(Use drogon_ctl build to configure and compile the Drogon project
+in the current working directory.
+
+  drogon_ctl build
+  drogon_ctl build -- -DCMAKE_BUILD_TYPE=Release
+
+Creates ./build if missing, runs `cmake -S . -B build`, then
+`cmake --build build`. Extra arguments are forwarded to the configure step.
+)";
+}
+
+}  // namespace drogon_ctl
+
+template class drogon::DrObject<drogon_ctl::build>;

--- a/drogon_ctl/build.h
+++ b/drogon_ctl/build.h
@@ -1,0 +1,53 @@
+/**
+ *
+ *  build.h
+ *
+ *  Copyright 2026, Drogon authors.  All rights reserved.
+ *  https://github.com/drogonframework/drogon
+ *  Use of this source code is governed by a MIT license
+ *  that can be found in the License file.
+ *
+ *  Drogon
+ *
+ */
+
+#pragma once
+
+#include "CommandHandler.h"
+#include <drogon/DrObject.h>
+#include <string>
+#include <vector>
+
+using namespace drogon;
+
+namespace drogon_ctl
+{
+/// Shared helpers used by `build` and `run`.
+namespace project_build
+{
+bool ensureCmakeProject();
+std::string projectName();
+bool configureAndBuild(const std::vector<std::string> &extraCmakeArgs);
+std::string findBuiltExecutable(const std::string &name);
+int runCommand(const std::string &cmd);
+}  // namespace project_build
+
+class build : public DrObject<build>, public CommandHandler
+{
+  public:
+    void handleCommand(std::vector<std::string> &parameters) override;
+
+    std::string script() override
+    {
+        return "configure and build the current Drogon project "
+               "(Use 'drogon_ctl help build' for more information)";
+    }
+
+    bool isTopCommand() override
+    {
+        return true;
+    }
+
+    std::string detail() override;
+};
+}  // namespace drogon_ctl

--- a/drogon_ctl/run.cc
+++ b/drogon_ctl/run.cc
@@ -1,0 +1,84 @@
+/**
+ *
+ *  run.cc
+ *
+ *  Copyright 2026, Drogon authors.  All rights reserved.
+ *  https://github.com/drogonframework/drogon
+ *  Use of this source code is governed by a MIT license
+ *  that can be found in the License file.
+ *
+ *  Drogon
+ *
+ */
+
+#include "run.h"
+#include "build.h"
+#include <iostream>
+#include <sstream>
+
+using namespace drogon_ctl;
+
+void run::handleCommand(std::vector<std::string> &parameters)
+{
+    // Arguments before "--" go to cmake configure; after "--" go to the app.
+    std::vector<std::string> cmakeArgs;
+    std::vector<std::string> appArgs;
+    bool pastSeparator = false;
+    for (const auto &p : parameters)
+    {
+        if (!pastSeparator && p == "--")
+        {
+            pastSeparator = true;
+            continue;
+        }
+        if (pastSeparator)
+            appArgs.push_back(p);
+        else
+            cmakeArgs.push_back(p);
+    }
+
+    if (!project_build::configureAndBuild(cmakeArgs))
+        exit(1);
+
+    auto name = project_build::projectName();
+    auto exe = project_build::findBuiltExecutable(name);
+    if (exe.empty())
+    {
+        std::cerr << "Could not find built executable for project '" << name
+                  << "' under ./build. Build may have produced a different "
+                     "target name."
+                  << std::endl;
+        exit(1);
+    }
+
+    std::ostringstream cmd;
+#ifdef _WIN32
+    cmd << '"' << exe << '"';
+#else
+    cmd << exe;
+#endif
+    for (const auto &a : appArgs)
+    {
+        cmd << ' ' << a;
+    }
+    int rc = project_build::runCommand(cmd.str());
+    if (rc != 0)
+        exit(rc);
+}
+
+std::string run::detail()
+{
+    return R"(Use drogon_ctl run to build the current Drogon project (if needed)
+and execute the generated binary.
+
+  drogon_ctl run
+  drogon_ctl run -- -DCMAKE_BUILD_TYPE=Release
+  drogon_ctl run -- -DCMAKE_BUILD_TYPE=Release -- arg1 arg2
+
+The project name is taken from `project(...)` in CMakeLists.txt.
+Arguments before `--` are passed to cmake configure; arguments after
+`--` are passed to the application.
+)";
+}
+
+template class drogon::DrObject<drogon_ctl::run>;

--- a/drogon_ctl/run.h
+++ b/drogon_ctl/run.h
@@ -1,0 +1,43 @@
+/**
+ *
+ *  run.h
+ *
+ *  Copyright 2026, Drogon authors.  All rights reserved.
+ *  https://github.com/drogonframework/drogon
+ *  Use of this source code is governed by a MIT license
+ *  that can be found in the License file.
+ *
+ *  Drogon
+ *
+ */
+
+#pragma once
+
+#include "CommandHandler.h"
+#include <drogon/DrObject.h>
+#include <string>
+#include <vector>
+
+using namespace drogon;
+
+namespace drogon_ctl
+{
+class run : public DrObject<run>, public CommandHandler
+{
+  public:
+    void handleCommand(std::vector<std::string> &parameters) override;
+
+    std::string script() override
+    {
+        return "build (if needed) and run the current Drogon project "
+               "(Use 'drogon_ctl help run' for more information)";
+    }
+
+    bool isTopCommand() override
+    {
+        return true;
+    }
+
+    std::string detail() override;
+};
+}  // namespace drogon_ctl


### PR DESCRIPTION
## Summary
Adds `drogon_ctl build` and `drogon_ctl run` so scaffolded projects can be compiled and started without dropping to raw cmake/make (#2529).

- `build`: creates `./build` if needed, runs `cmake -S . -B build`, then `cmake --build build`
- `run`: builds first, locates the `project(...)` target binary under `build/` (including multi-config `Debug`/`Release` dirs), then executes it
- Extra args: cmake configure flags before `--`; application args after `--`
- Appears in `drogon_ctl help` like other top-level commands

## Test plan
- [ ] `drogon_ctl create project demo && cd demo && drogon_ctl build` configures and builds
- [ ] `drogon_ctl run` starts the demo binary after a successful build
- [ ] `drogon_ctl help build` / `drogon_ctl help run` show the new detail text
- [ ] `drogon_ctl build -- -DCMAKE_BUILD_TYPE=Release` forwards the flag to cmake

Closes #2529
