### PR TITLE
fix: return 400 for invalid integer path parameters (#2551)

### DIFF
--- a/lib/inc/drogon/HttpBinder.h
+++ b/lib/inc/drogon/HttpBinder.h
@@ -186,6 +186,10 @@ DROGON_EXPORT void handleException(
     const std::exception &,
     const HttpRequestPtr &,
     std::function<void(const HttpResponsePtr &)> &&);
+DROGON_EXPORT void handleBadPathParameter(
+    const std::exception &,
+    const HttpRequestPtr &,
+    std::function<void(const HttpResponsePtr &)> &&);
 
 using HttpBinderBasePtr = std::shared_ptr<HttpBinderBase>;
 
@@ -306,6 +310,17 @@ class HttpBinder : public HttpBinderBase
                             std::move(value));
                         return;
                     }
+                }
+                catch (const std::invalid_argument &e)
+                {
+                    // Malformed path parameters are client errors (#2551).
+                    handleBadPathParameter(e, req, std::move(callback));
+                    return;
+                }
+                catch (const std::out_of_range &e)
+                {
+                    handleBadPathParameter(e, req, std::move(callback));
+                    return;
                 }
                 catch (const std::exception &e)
                 {

--- a/lib/src/HttpBinder.cc
+++ b/lib/src/HttpBinder.cc
@@ -25,5 +25,18 @@ void handleException(const std::exception &e,
 {
     app().getExceptionHandler()(e, req, std::move(callback));
 }
+
+void handleBadPathParameter(
+    const std::exception &e,
+    const HttpRequestPtr &req,
+    std::function<void(const HttpResponsePtr &)> &&callback)
+{
+    std::string pathWithQuery = req->path();
+    if (!req->query().empty())
+        pathWithQuery += "?" + req->query();
+    LOG_ERROR << "Invalid path parameter in " << pathWithQuery
+              << ", what(): " << e.what();
+    callback(app().getCustomErrorHandler()(k400BadRequest, req));
+}
 }  // namespace internal
 }  // namespace drogon


### PR DESCRIPTION
﻿## Summary
Returns HTTP 400 for invalid or out-of-range integer path parameters instead of treating them as unhandled 500s (#2551).

Automatic route argument conversion (`std::stoi` / `stol` / …) throws `std::invalid_argument` or `std::out_of_range` on bad client input. Those exceptions were forwarded to the generic exception handler, which logs "Unhandled exception" and answers 500.

## Change
- New `internal::handleBadPathParameter` that logs the failure and responds with `k400BadRequest` via the custom error handler
- Path-parameter conversion in `HttpBinder::run` catches `invalid_argument` / `out_of_range` and uses that path; other exceptions still go through `handleException` (500)

Closes #2551
