### PR TITLE
fix(http 2559): accept zero-length body with Expect: 100-continue

### DIFF
--- a/lib/src/HttpRequestParser.cc
+++ b/lib/src/HttpRequestParser.cc
@@ -284,12 +284,10 @@ int HttpRequestParser::parseRequest(MsgBuffer *buf)
                 if (expect == "100-continue" &&
                     request_->getVersion() >= Version::kHttp11)
                 {
-                    if (remainContentLength_ == 0)
-                    {
-                        // error
-                        return -k400BadRequest;
-                    }
-                    else
+                    // There is nothing to negotiate when the framing indicates
+                    // that the request has no body. RFC 9110 Section 10.1.1
+                    // permits omitting the interim response in this case.
+                    if (remainContentLength_ != 0)
                     {
                         // rfc2616-8.2.3
                         // TODO: consider adding an AOP for expect header

--- a/lib/tests/CMakeLists.txt
+++ b/lib/tests/CMakeLists.txt
@@ -57,6 +57,7 @@ if (BUILD_CTL)
       integration_test/client/WebSocketKeepAliveUpgradeTest.cc
       integration_test/client/MultipleWsTest.cc
       integration_test/client/HttpPipeliningTest.cc
+      integration_test/client/ExpectContinueTest.cc
       integration_test/client/RequestStreamTest.cc)
 
   set(INTEGRATION_TEST_SERVER_SOURCES

--- a/lib/tests/integration_test/client/ExpectContinueTest.cc
+++ b/lib/tests/integration_test/client/ExpectContinueTest.cc
@@ -1,0 +1,72 @@
+#include <drogon/HttpClient.h>
+#include <drogon/drogon_test.h>
+#include <trantor/net/TcpClient.h>
+
+#include <future>
+#include <string>
+#include <string_view>
+
+using namespace drogon;
+
+namespace
+{
+std::string sendRawRequest(trantor::EventLoop *loop, std::string_view request)
+{
+    auto client = std::make_shared<trantor::TcpClient>(
+        loop, trantor::InetAddress{"127.0.0.1", 8848}, "expect-continue-test");
+    auto response = std::make_shared<std::string>();
+    std::promise<void> disconnected;
+
+    client->setMessageCallback(
+        [response](const trantor::TcpConnectionPtr &,
+                   trantor::MsgBuffer *buffer) {
+            response->append(buffer->read(buffer->readableBytes()));
+        });
+    client->setConnectionCallback(
+        [request, &disconnected](const trantor::TcpConnectionPtr &connection) {
+            if (connection->connected())
+            {
+                connection->send(request.data(), request.size());
+                connection->shutdown();
+            }
+            else
+            {
+                disconnected.set_value();
+            }
+        });
+
+    client->connect();
+    disconnected.get_future().wait();
+    return *response;
+}
+}  // namespace
+
+DROGON_TEST(EmptyBodyWithExpectContinue)
+{
+    auto client = HttpClient::newHttpClient("127.0.0.1", 8848);
+    const auto response = sendRawRequest(
+        client->getLoop(),
+        "PUT /api/v1/apitest/static HTTP/1.1\r\n"
+        "Host: localhost\r\n"
+        "Content-Length: 0\r\n"
+        "Expect: 100-continue\r\n"
+        "Connection: close\r\n\r\n");
+
+    CHECK(response.rfind("HTTP/1.1 200 OK\r\n", 0) == 0);
+}
+
+DROGON_TEST(NonEmptyBodyWithExpectContinue)
+{
+    auto client = HttpClient::newHttpClient("127.0.0.1", 8848);
+    const auto response = sendRawRequest(
+        client->getLoop(),
+        "PUT /api/v1/apitest/static HTTP/1.1\r\n"
+        "Host: localhost\r\n"
+        "Content-Length: 1\r\n"
+        "Expect: 100-continue\r\n"
+        "Connection: close\r\n\r\n"
+        "x");
+
+    CHECK(response.rfind("HTTP/1.1 100 Continue\r\n", 0) == 0);
+    CHECK(response.find("HTTP/1.1 200 OK\r\n") != std::string::npos);
+}

--- a/lib/tests/integration_test/client/ExpectContinueTest.cc
+++ b/lib/tests/integration_test/client/ExpectContinueTest.cc
@@ -17,11 +17,10 @@ std::string sendRawRequest(trantor::EventLoop *loop, std::string_view request)
     auto response = std::make_shared<std::string>();
     std::promise<void> disconnected;
 
-    client->setMessageCallback(
-        [response](const trantor::TcpConnectionPtr &,
-                   trantor::MsgBuffer *buffer) {
-            response->append(buffer->read(buffer->readableBytes()));
-        });
+    client->setMessageCallback([response](const trantor::TcpConnectionPtr &,
+                                          trantor::MsgBuffer *buffer) {
+        response->append(buffer->read(buffer->readableBytes()));
+    });
     client->setConnectionCallback(
         [request, &disconnected](const trantor::TcpConnectionPtr &connection) {
             if (connection->connected())
@@ -44,13 +43,13 @@ std::string sendRawRequest(trantor::EventLoop *loop, std::string_view request)
 DROGON_TEST(EmptyBodyWithExpectContinue)
 {
     auto client = HttpClient::newHttpClient("127.0.0.1", 8848);
-    const auto response = sendRawRequest(
-        client->getLoop(),
-        "PUT /api/v1/apitest/static HTTP/1.1\r\n"
-        "Host: localhost\r\n"
-        "Content-Length: 0\r\n"
-        "Expect: 100-continue\r\n"
-        "Connection: close\r\n\r\n");
+    const auto response =
+        sendRawRequest(client->getLoop(),
+                       "PUT /api/v1/apitest/static HTTP/1.1\r\n"
+                       "Host: localhost\r\n"
+                       "Content-Length: 0\r\n"
+                       "Expect: 100-continue\r\n"
+                       "Connection: close\r\n\r\n");
 
     CHECK(response.rfind("HTTP/1.1 200 OK\r\n", 0) == 0);
 }
@@ -58,14 +57,14 @@ DROGON_TEST(EmptyBodyWithExpectContinue)
 DROGON_TEST(NonEmptyBodyWithExpectContinue)
 {
     auto client = HttpClient::newHttpClient("127.0.0.1", 8848);
-    const auto response = sendRawRequest(
-        client->getLoop(),
-        "PUT /api/v1/apitest/static HTTP/1.1\r\n"
-        "Host: localhost\r\n"
-        "Content-Length: 1\r\n"
-        "Expect: 100-continue\r\n"
-        "Connection: close\r\n\r\n"
-        "x");
+    const auto response =
+        sendRawRequest(client->getLoop(),
+                       "PUT /api/v1/apitest/static HTTP/1.1\r\n"
+                       "Host: localhost\r\n"
+                       "Content-Length: 1\r\n"
+                       "Expect: 100-continue\r\n"
+                       "Connection: close\r\n\r\n"
+                       "x");
 
     CHECK(response.rfind("HTTP/1.1 100 Continue\r\n", 0) == 0);
     CHECK(response.find("HTTP/1.1 200 OK\r\n") != std::string::npos);


### PR DESCRIPTION
Fixes #2559.

`HttpRequestParser::parseRequest` returned 400 for any HTTP/1.1 request
carrying `Expect: 100-continue` with `Content-Length: 0`. This falls
through to the normal path instead.

RFC 9110 Section 10.1.1 lets a server skip the interim response when the
framing shows no message body, which is what `Content-Length: 0` says.
There is no body to withhold, so the expectation has nothing to negotiate.

| Request | Before | After |
|---|---|---|
| `Content-Length: 0` + Expect | 400 | handler runs |
| `Content-Length: 0`, no Expect | handler runs | unchanged |
| non-empty body + Expect | 100 Continue, then handler | unchanged |

The non-empty path remains unchanged. Socket-level integration tests cover
both the zero-length case and the existing non-empty behavior.

Found while building an S3-compatible server on Drogon. boto3 and the AWS
CLI both write empty objects this way, so `put_object(Body=b"")` and
`aws s3 cp` of an empty file failed with an unexplained 400.
