### PR TITLE
Fix FindSQLite3.cmake for repeated calls

### DIFF
--- a/cmake_modules/FindSQLite3.cmake
+++ b/cmake_modules/FindSQLite3.cmake
@@ -43,16 +43,16 @@ find_package_handle_standard_args(SQLite3
                                   SQLITE3_INCLUDE_DIRS)
 
 # Copy the results to the output variables.
-if(SQLite3_FOUND)
+if(SQLite3_FOUND AND NOT TARGET SQLite3_lib)
   add_library(SQLite3_lib INTERFACE IMPORTED)
   set_target_properties(SQLite3_lib
                         PROPERTIES INTERFACE_INCLUDE_DIRECTORIES
                                    "${SQLITE3_INCLUDE_DIRS}"
                                    INTERFACE_LINK_LIBRARIES
                                    "${SQLITE3_LIBRARIES}")
-else(SQLite3_FOUND)
+elseif(NOT SQLite3_FOUND)
   set(SQLITE3_LIBRARIES)
   set(SQLITE3_INCLUDE_DIRS)
-endif(SQLite3_FOUND)
+endif()
 
 mark_as_advanced(SQLITE3_INCLUDE_DIRS SQLITE3_LIBRARIES)


### PR DESCRIPTION
The problem is that `DrogonConfig.cmake` appends Drogon's CMake directory to `CMAKE_MODULE_PATH` and then calls:

```cmake
find_dependency(SQLite3)
```

That resolves to Drogon's custom `FindSQLite3.cmake`.

The bug in that file is that it unconditionally creates an imported target.

If `find_package(SQLite3)` is called again later in the same configure, e.g. from another included project, then Drogon's module runs again and tries to create `SQLite3_lib` a second time. CMake then fails with:

```text
add_library cannot create imported target "SQLite3_lib" because another target with the same name already exists.
```

To fix this, make the creation conditionally.