### PR TITLE
Add DROGON_USE_BOOST_UUID option to use Boost.UUID instead of OS libuuid

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ option(BUILD_EXAMPLES "Build examples" ON)
 option(BUILD_ORM "Build orm" ON)
 option(COZ_PROFILING "Use coz for profiling" OFF)
 option(BUILD_SHARED_LIBS "Build drogon as a shared lib" OFF)
+option(DROGON_USE_BOOST_UUID "Use Boost.UUID instead of the OS uuid library" OFF)
 option(BUILD_DOC "Build Doxygen documentation" OFF)
 option(BUILD_BROTLI "Build Brotli" ON)
 option(BUILD_YAML_CONFIG "Build yaml config" ON)
@@ -230,23 +231,30 @@ endif(BUILD_YAML_CONFIG)
 if (NOT ${CMAKE_SYSTEM_NAME} STREQUAL "FreeBSD"
     AND NOT ${CMAKE_SYSTEM_NAME} STREQUAL "OpenBSD"
     AND NOT WIN32)
-    find_package(UUID REQUIRED)
-    target_link_libraries(${PROJECT_NAME} PRIVATE UUID_lib)
-
-    try_compile(normal_uuid ${CMAKE_BINARY_DIR}/cmaketest
-        ${PROJECT_SOURCE_DIR}/cmake/tests/normal_uuid_lib_test.cc
-        LINK_LIBRARIES UUID_lib
-        OUTPUT_VARIABLE NORMAL_UUID_COMPILE_OUTPUT)
-    try_compile(ossp_uuid ${CMAKE_BINARY_DIR}/cmaketest
-        ${PROJECT_SOURCE_DIR}/cmake/tests/ossp_uuid_lib_test.cc
-        LINK_LIBRARIES UUID_lib
-        OUTPUT_VARIABLE OSSP_UUID_COMPILE_OUTPUT)
-    if (normal_uuid)
-        add_definitions(-DUSE_OSSP_UUID=0)
-    elseif (ossp_uuid)
-        add_definitions(-DUSE_OSSP_UUID=1)
+    if (DROGON_USE_BOOST_UUID)
+        find_package(Boost REQUIRED)
+        target_link_libraries(${PROJECT_NAME} PRIVATE Boost::boost)
+        add_definitions(-DUSE_BOOST_UUID=1)
     else ()
-        message(FATAL_ERROR "uuid lib error:\n${NORMAL_UUID_COMPILE_OUTPUT}\n${OSSP_UUID_COMPILE_OUTPUT}")
+        add_definitions(-DUSE_BOOST_UUID=0)
+        find_package(UUID REQUIRED)
+        target_link_libraries(${PROJECT_NAME} PRIVATE UUID_lib)
+
+        try_compile(normal_uuid ${CMAKE_BINARY_DIR}/cmaketest
+            ${PROJECT_SOURCE_DIR}/cmake/tests/normal_uuid_lib_test.cc
+            LINK_LIBRARIES UUID_lib
+            OUTPUT_VARIABLE NORMAL_UUID_COMPILE_OUTPUT)
+        try_compile(ossp_uuid ${CMAKE_BINARY_DIR}/cmaketest
+            ${PROJECT_SOURCE_DIR}/cmake/tests/ossp_uuid_lib_test.cc
+            LINK_LIBRARIES UUID_lib
+            OUTPUT_VARIABLE OSSP_UUID_COMPILE_OUTPUT)
+        if (normal_uuid)
+            add_definitions(-DUSE_OSSP_UUID=0)
+        elseif (ossp_uuid)
+            add_definitions(-DUSE_OSSP_UUID=1)
+        else ()
+            message(FATAL_ERROR "uuid lib error:\n${NORMAL_UUID_COMPILE_OUTPUT}\n${OSSP_UUID_COMPILE_OUTPUT}")
+        endif ()
     endif ()
 endif (NOT ${CMAKE_SYSTEM_NAME} STREQUAL "FreeBSD"
     AND NOT ${CMAKE_SYSTEM_NAME} STREQUAL "OpenBSD"

--- a/lib/src/Utilities.cc
+++ b/lib/src/Utilities.cc
@@ -398,7 +398,7 @@ std::string getUuid(bool lowercase)
     boost::uuids::uuid uuid = generator();
     char bytes[16];
     std::copy(uuid.begin(), uuid.end(), bytes);
-    return createUuidString(bytes, 16, lowercase);  
+    return createUuidString(bytes, 16, lowercase);
 #elif USE_OSSP_UUID
     uuid_t *uuid;
     uuid_create(&uuid);

--- a/lib/src/Utilities.cc
+++ b/lib/src/Utilities.cc
@@ -26,7 +26,12 @@
 #include <io.h>
 #include <iomanip>
 #else
+#if USE_BOOST_UUID
+#include <boost/uuid/uuid.hpp>
+#include <boost/uuid/uuid_generators.hpp>
+#else
 #include <uuid.h>
+#endif
 #include <unistd.h>
 #endif
 #include <zlib.h>
@@ -388,7 +393,13 @@ inline std::string createUuidString(const char *str, size_t len, bool lowercase)
 
 std::string getUuid(bool lowercase)
 {
-#if USE_OSSP_UUID
+#if USE_BOOST_UUID
+    static thread_local boost::uuids::random_generator generator;
+    boost::uuids::uuid uuid = generator();
+    char bytes[16];
+    std::copy(uuid.begin(), uuid.end(), bytes);
+    return createUuidString(bytes, 16, lowercase);  
+#elif USE_OSSP_UUID
     uuid_t *uuid;
     uuid_create(&uuid);
     uuid_make(uuid, UUID_MAKE_V4);


### PR DESCRIPTION
Closes #2562.

Adds a `DROGON_USE_BOOST_UUID` CMake option that generate UUIDs using `boost::uuids::random_generator` instead of the OS `libuuid`. This is useful on Linux, where requiring `libuuid` can be inconvenient. The new code reuses the existing `createUuidString` formatting helper, so the output format stays exactly the same as before.

I tested both setups against the full unit test suite - the default build (using `libuuid`) and the new build with 
`-DDROGON_USE_BOOST_UUID=ON`. Both passed all 1308 assertions across 61 test cases.