### PR TITLE
Respect application-set closeConnection in response processing

### DIFF
--- a/lib/src/HttpServer.cc
+++ b/lib/src/HttpServer.cc
@@ -804,7 +804,11 @@ void HttpServer::handleResponse(
         HttpAppFrameworkImpl::instance().handleSessionForResponse(req,
                                                                   response);
     resp->setVersion(req->getVersion());
-    resp->setCloseConnection(!req->keepAlive());
+    // Respect application-set closeConnection (e.g., for aborting stream
+    // responses on error). Only apply the client's keep-alive preference
+    // when the handler hasn't explicitly requested close.
+    if (!resp->ifCloseConnection())
+        resp->setCloseConnection(!req->keepAlive());
     AopAdvice::instance().passPreSendingAdvices(req, resp);
 
     auto newResp = getCompressedResponse(req, resp, isHeadMethod);
@@ -1229,7 +1233,8 @@ static inline bool passSyncAdvices(
     {
         // Rejected by sync advice
         resp->setVersion(req->getVersion());
-        resp->setCloseConnection(!req->keepAlive());
+        if (!resp->ifCloseConnection())
+            resp->setCloseConnection(!req->keepAlive());
         if (!shouldBePipelined)
         {
             requestParser->getResponseBuffer().emplace_back(

--- a/lib/tests/CMakeLists.txt
+++ b/lib/tests/CMakeLists.txt
@@ -55,6 +55,7 @@ if (BUILD_CTL)
       integration_test/client/main.cc
       integration_test/client/WebSocketTest.cc
       integration_test/client/WebSocketKeepAliveUpgradeTest.cc
+      integration_test/client/CloseConnectionTest.cc
       integration_test/client/MultipleWsTest.cc
       integration_test/client/HttpPipeliningTest.cc
       integration_test/client/RequestStreamTest.cc)

--- a/lib/tests/integration_test/client/CloseConnectionTest.cc
+++ b/lib/tests/integration_test/client/CloseConnectionTest.cc
@@ -1,0 +1,65 @@
+#include <drogon/HttpAppFramework.h>
+#include <drogon/drogon_test.h>
+#include <trantor/net/TcpClient.h>
+
+#include <atomic>
+#include <chrono>
+#include <future>
+#include <memory>
+#include <string>
+
+using namespace drogon;
+using namespace std::chrono_literals;
+
+// The handler sets closeConnection on the response while the client asks for
+// keep-alive. The server must honour the handler and hang up on its own.
+DROGON_TEST(CloseConnectionTest)
+{
+    auto client =
+        std::make_shared<trantor::TcpClient>(app().getLoop(),
+                                             trantor::InetAddress{"127.0.0.1",
+                                                                  8848},
+                                             "close-connection-test");
+    auto response = std::make_shared<std::string>();
+    auto gotResponse = std::make_shared<std::atomic<bool>>(false);
+    auto completed = std::make_shared<std::atomic<bool>>(false);
+    auto promise = std::make_shared<std::promise<void>>();
+    auto future = promise->get_future();
+
+    client->setConnectionCallback([TEST_CTX, gotResponse, completed, promise](
+                                      const trantor::TcpConnectionPtr &conn) {
+        if (conn->connected())
+        {
+            conn->send(
+                "GET /api/v1/close_connection HTTP/1.1\r\n"
+                "Host: 127.0.0.1:8848\r\n"
+                "Connection: keep-alive\r\n\r\n");
+            return;
+        }
+
+        CHECK(gotResponse->load());
+        if (!completed->exchange(true))
+        {
+            promise->set_value();
+        }
+    });
+
+    client->setMessageCallback([TEST_CTX,
+                                response,
+                                gotResponse](const trantor::TcpConnectionPtr &,
+                                             trantor::MsgBuffer *buffer) {
+        response->append(buffer->read(buffer->readableBytes()));
+        if (response->find("\r\n\r\n") == std::string::npos)
+        {
+            return;
+        }
+        if (!gotResponse->exchange(true))
+        {
+            CHECK(response->find("HTTP/1.1 200") == 0);
+            CHECK(response->find("connection: close\r\n") != std::string::npos);
+        }
+    });
+
+    client->connect();
+    REQUIRE(future.wait_for(5s) == std::future_status::ready);
+}

--- a/lib/tests/integration_test/server/main.cc
+++ b/lib/tests/integration_test/server/main.cc
@@ -245,6 +245,16 @@ int main()
             throw std::runtime_error("this should fail");
         });
 
+    app().registerHandler(
+        "/api/v1/close_connection",
+        [](const HttpRequestPtr &req,
+           std::function<void(const HttpResponsePtr &)> &&callback) {
+            auto resp = HttpResponse::newHttpResponse();
+            resp->setBody("closed");
+            resp->setCloseConnection(true);
+            callback(resp);
+        });
+
     app().setDocumentRoot("./");
     app().enableSession(60);
 


### PR DESCRIPTION
HttpServer::handleResponse() overwrites closeConnection_ with the client's keep-alive preference just before the response is sent, discarding an explicit setCloseConnection(true) from the handler. The sync-advice rejection path does the same.

Apply the keep-alive default only when the handler has not already asked for close. Handlers that never touch setCloseConnection are unaffected.

Adds CloseConnectionTest, which sends a keep-alive request to a handler that sets closeConnection and checks that the response carries "connection: close" and that the server closes the socket.