### PR TITLE
Fix HTTP/1.0 keep-alive and sticky closeConnection on reused responses

### DIFF
--- a/lib/src/HttpResponseImpl.cc
+++ b/lib/src/HttpResponseImpl.cc
@@ -1091,6 +1091,7 @@ void HttpResponseImpl::swap(HttpResponseImpl &that) noexcept
     swap(version_, that.version_);
     swap(statusMessage_, that.statusMessage_);
     swap(closeConnection_, that.closeConnection_);
+    swap(closeConnectionSetByUser_, that.closeConnectionSetByUser_);
     bodyPtr_.swap(that.bodyPtr_);
     swap(contentType_, that.contentType_);
     swap(flagForParsingContentType_, that.flagForParsingContentType_);
@@ -1110,6 +1111,8 @@ void HttpResponseImpl::clear()
     statusCode_ = kUnknown;
     version_ = Version::kHttp11;
     statusMessage_ = std::string_view{};
+    closeConnection_ = false;
+    closeConnectionSetByUser_ = false;
     fullHeaderString_.reset();
     jsonParsingErrorPtr_.reset();
     sendfileName_.clear();

--- a/lib/src/HttpResponseImpl.cc
+++ b/lib/src/HttpResponseImpl.cc
@@ -1113,7 +1113,7 @@ void HttpResponseImpl::clear()
     statusMessage_ = std::string_view{};
     closeConnection_ = false;
     closeConnectionSetByUser_ = false;
-    fullHeaderString_.reset();
+    invalidateRenderCache();
     jsonParsingErrorPtr_.reset();
     sendfileName_.clear();
     if (streamCallback_)
@@ -1132,7 +1132,6 @@ void HttpResponseImpl::clear()
     bodyPtr_.reset();
     jsonPtr_.reset();
     expriedTime_ = -1;
-    datePos_ = std::string::npos;
     flagForParsingContentType_ = false;
     flagForParsingJson_ = false;
 }

--- a/lib/src/HttpResponseImpl.h
+++ b/lib/src/HttpResponseImpl.h
@@ -89,11 +89,35 @@ class DROGON_EXPORT HttpResponseImpl : public HttpResponse
     void setCloseConnection(bool on) override
     {
         closeConnection_ = on;
+        closeConnectionSetByUser_ = true;
     }
 
     bool ifCloseConnection() const override
     {
         return closeConnection_;
+    }
+
+    /**
+     * @brief Set the close-connection flag without marking it as an explicit
+     * application decision.
+     *
+     * Used by the framework to apply the client's keep-alive preference. Kept
+     * off the public HttpResponse interface so that the ABI is unchanged.
+     */
+    void setCloseConnectionInternal(bool on)
+    {
+        closeConnection_ = on;
+    }
+
+    /**
+     * @brief Whether the application explicitly called setCloseConnection().
+     *
+     * Distinguishes a deliberate handler decision from a side effect of
+     * setVersion(), so that the framework only overrides the latter.
+     */
+    bool closeConnectionSetByUser() const
+    {
+        return closeConnectionSetByUser_;
     }
 
     void setContentTypeCode(ContentType type) override
@@ -520,6 +544,10 @@ class DROGON_EXPORT HttpResponseImpl : public HttpResponse
     trantor::Date creationDate_;
     Version version_{Version::kHttp11};
     bool closeConnection_{false};
+    // True only when the application called setCloseConnection() itself, as
+    // opposed to the flag being set by setVersion() or by the framework
+    // applying the client's keep-alive preference.
+    bool closeConnectionSetByUser_{false};
     mutable std::shared_ptr<HttpMessageBody> bodyPtr_;
     ssize_t expriedTime_{-1};
     std::string sendfileName_;

--- a/lib/src/HttpResponseImpl.h
+++ b/lib/src/HttpResponseImpl.h
@@ -72,10 +72,15 @@ class DROGON_EXPORT HttpResponseImpl : public HttpResponse
 
     void setVersion(const Version v) override
     {
-        version_ = v;
+        if (version_ != v)
+        {
+            version_ = v;
+            // The version is part of the rendered status line.
+            invalidateRenderCache();
+        }
         if (version_ == Version::kHttp10)
         {
-            closeConnection_ = true;
+            setCloseConnectionInternal(true);
         }
     }
 
@@ -88,8 +93,8 @@ class DROGON_EXPORT HttpResponseImpl : public HttpResponse
 
     void setCloseConnection(bool on) override
     {
-        closeConnection_ = on;
         closeConnectionSetByUser_ = true;
+        setCloseConnectionInternal(on);
     }
 
     bool ifCloseConnection() const override
@@ -106,7 +111,14 @@ class DROGON_EXPORT HttpResponseImpl : public HttpResponse
      */
     void setCloseConnectionInternal(bool on)
     {
+        if (closeConnection_ == on)
+            return;
         closeConnection_ = on;
+        // The flag is emitted as a "connection" header, so anything rendered
+        // earlier is now stale. This matters most for responses with an
+        // expired time, whose entire rendering is memoized in httpString_ and
+        // would otherwise keep sending the previous header forever.
+        invalidateRenderCache();
     }
 
     /**
@@ -532,6 +544,24 @@ class DROGON_EXPORT HttpResponseImpl : public HttpResponse
         assert(code >= 0);
         customStatusCode_ = code;
         statusMessage_ = std::string_view{message, messageLength};
+    }
+
+    /**
+     * @brief Drop every memoized rendering of this response.
+     *
+     * Must be called after changing anything that is baked into the rendered
+     * bytes but is not covered by the fullHeaderString_ resets scattered
+     * through the header setters -- notably the status line and the
+     * "connection" header. Responses with an expired time memoize their whole
+     * rendering in httpString_, so for them a stale cache means the wrong
+     * bytes go out on every subsequent send.
+     */
+    void invalidateRenderCache()
+    {
+        fullHeaderString_.reset();
+        httpString_.reset();
+        datePos_ = static_cast<size_t>(-1);
+        httpStringDate_ = -1;
     }
 
     SafeStringMap<std::string> headers_;

--- a/lib/src/HttpServer.cc
+++ b/lib/src/HttpServer.cc
@@ -751,8 +751,14 @@ void HttpServer::websocketRequestRouting(
 
     // Not found
     auto resp = drogon::HttpResponse::newNotFoundResponse(req);
-    resp->setCloseConnection(true);
-    callback(resp);
+    // newNotFoundResponse() may hand back a shared custom 404 page or a
+    // per-IO-thread cached response. Mutating it here would mark that shared
+    // object as explicitly close-on-send for every later request that reuses
+    // it, so work on a copy instead.
+    auto respImpl = std::make_shared<HttpResponseImpl>(
+        *static_cast<HttpResponseImpl *>(resp.get()));
+    respImpl->setCloseConnection(true);
+    callback(respImpl);
 }
 
 void HttpServer::websocketRequestHandling(
@@ -806,9 +812,16 @@ void HttpServer::handleResponse(
     resp->setVersion(req->getVersion());
     // Respect application-set closeConnection (e.g., for aborting stream
     // responses on error). Only apply the client's keep-alive preference
-    // when the handler hasn't explicitly requested close.
-    if (!resp->ifCloseConnection())
-        resp->setCloseConnection(!req->keepAlive());
+    // when the handler hasn't explicitly requested close. Checking the
+    // explicit-set flag rather than ifCloseConnection() matters because
+    // setVersion() sets closeConnection_ for HTTP/1.0, and because the
+    // preference must be re-evaluated on every request when a cached or
+    // otherwise reused response object is served more than once.
+    {
+        auto implPtr = static_cast<HttpResponseImpl *>(resp.get());
+        if (!implPtr->closeConnectionSetByUser())
+            implPtr->setCloseConnectionInternal(!req->keepAlive());
+    }
     AopAdvice::instance().passPreSendingAdvices(req, resp);
 
     auto newResp = getCompressedResponse(req, resp, isHeadMethod);
@@ -1233,8 +1246,18 @@ static inline bool passSyncAdvices(
     {
         // Rejected by sync advice
         resp->setVersion(req->getVersion());
-        if (!resp->ifCloseConnection())
-            resp->setCloseConnection(!req->keepAlive());
+        // Respect application-set closeConnection (e.g., for aborting stream
+        // responses on error). Only apply the client's keep-alive preference
+        // when the handler hasn't explicitly requested close. Checking the
+        // explicit-set flag rather than ifCloseConnection() matters because
+        // setVersion() sets closeConnection_ for HTTP/1.0, and because the
+        // preference must be re-evaluated on every request when a cached or
+        // otherwise reused response object is served more than once.
+        {
+            auto implPtr = static_cast<HttpResponseImpl *>(resp.get());
+            if (!implPtr->closeConnectionSetByUser())
+                implPtr->setCloseConnectionInternal(!req->keepAlive());
+        }
         if (!shouldBePipelined)
         {
             requestParser->getResponseBuffer().emplace_back(

--- a/lib/src/HttpServer.cc
+++ b/lib/src/HttpServer.cc
@@ -57,6 +57,8 @@ static inline HttpResponsePtr getCompressedResponse(
     const HttpRequestImplPtr &req,
     const HttpResponsePtr &response,
     bool isHeadMethod);
+static inline void applyConnectionDecision(const HttpRequestImplPtr &req,
+                                           HttpResponsePtr &resp);
 
 static void handleInvalidHttpMethod(
     const HttpRequestImplPtr &req,
@@ -757,6 +759,7 @@ void HttpServer::websocketRequestRouting(
     // it, so work on a copy instead.
     auto respImpl = std::make_shared<HttpResponseImpl>(
         *static_cast<HttpResponseImpl *>(resp.get()));
+    respImpl->setExpiredTime(-1);  // make it temporary
     respImpl->setCloseConnection(true);
     callback(respImpl);
 }
@@ -809,19 +812,7 @@ void HttpServer::handleResponse(
     auto resp =
         HttpAppFrameworkImpl::instance().handleSessionForResponse(req,
                                                                   response);
-    resp->setVersion(req->getVersion());
-    // Respect application-set closeConnection (e.g., for aborting stream
-    // responses on error). Only apply the client's keep-alive preference
-    // when the handler hasn't explicitly requested close. Checking the
-    // explicit-set flag rather than ifCloseConnection() matters because
-    // setVersion() sets closeConnection_ for HTTP/1.0, and because the
-    // preference must be re-evaluated on every request when a cached or
-    // otherwise reused response object is served more than once.
-    {
-        auto implPtr = static_cast<HttpResponseImpl *>(resp.get());
-        if (!implPtr->closeConnectionSetByUser())
-            implPtr->setCloseConnectionInternal(!req->keepAlive());
-    }
+    applyConnectionDecision(req, resp);
     AopAdvice::instance().passPreSendingAdvices(req, resp);
 
     auto newResp = getCompressedResponse(req, resp, isHeadMethod);
@@ -1245,19 +1236,7 @@ static inline bool passSyncAdvices(
     if (auto resp = AopAdvice::instance().passSyncAdvices(req))
     {
         // Rejected by sync advice
-        resp->setVersion(req->getVersion());
-        // Respect application-set closeConnection (e.g., for aborting stream
-        // responses on error). Only apply the client's keep-alive preference
-        // when the handler hasn't explicitly requested close. Checking the
-        // explicit-set flag rather than ifCloseConnection() matters because
-        // setVersion() sets closeConnection_ for HTTP/1.0, and because the
-        // preference must be re-evaluated on every request when a cached or
-        // otherwise reused response object is served more than once.
-        {
-            auto implPtr = static_cast<HttpResponseImpl *>(resp.get());
-            if (!implPtr->closeConnectionSetByUser())
-                implPtr->setCloseConnectionInternal(!req->keepAlive());
-        }
+        applyConnectionDecision(req, resp);
         if (!shouldBePipelined)
         {
             requestParser->getResponseBuffer().emplace_back(
@@ -1271,6 +1250,43 @@ static inline bool passSyncAdvices(
         return false;
     }
     return true;
+}
+
+/**
+ * @brief Stamp this request's version and connection decision onto `resp`,
+ * replacing it with a private copy first when it is a shared cached response.
+ *
+ * Responses with an expired time are handed out by the framework's caches (the
+ * custom 404 page, app().cacheResponse(), ...) and are reused across requests.
+ * Deciding keep-alive by mutating such an object leaks one request's decision
+ * into every later request served from the same object, and races with the
+ * other IO threads sharing it. So take a copy whenever this request needs
+ * different framing from what the cached object already carries.
+ *
+ * Application-set closeConnection is respected: only the framework's own
+ * default is overridden. That distinction is made through
+ * closeConnectionSetByUser() rather than ifCloseConnection() because
+ * setVersion() also sets the flag as a side effect for HTTP/1.0.
+ */
+static inline void applyConnectionDecision(const HttpRequestImplPtr &req,
+                                           HttpResponsePtr &resp)
+{
+    auto implPtr = static_cast<HttpResponseImpl *>(resp.get());
+    const bool closeConnection = implPtr->closeConnectionSetByUser()
+                                     ? implPtr->ifCloseConnection()
+                                     : !req->keepAlive();
+    if (implPtr->expiredTime() >= 0 &&
+        (implPtr->version() != req->getVersion() ||
+         implPtr->ifCloseConnection() != closeConnection))
+    {
+        auto newResp = std::make_shared<HttpResponseImpl>(*implPtr);
+        newResp->setExpiredTime(-1);  // make it temporary
+        resp = newResp;
+        implPtr = newResp.get();
+    }
+    implPtr->setVersion(req->getVersion());
+    if (!implPtr->closeConnectionSetByUser())
+        implPtr->setCloseConnectionInternal(!req->keepAlive());
 }
 
 static inline HttpResponsePtr getCompressedResponse(

--- a/lib/tests/integration_test/client/CloseConnectionTest.cc
+++ b/lib/tests/integration_test/client/CloseConnectionTest.cc
@@ -63,3 +63,134 @@ DROGON_TEST(CloseConnectionTest)
     client->connect();
     REQUIRE(future.wait_for(5s) == std::future_status::ready);
 }
+
+namespace
+{
+struct ExchangeResult
+{
+    std::string response;
+    bool serverClosed{false};
+};
+
+// Opens a fresh connection, sends a single raw request, and once the response
+// headers have arrived waits `settleMs` to observe whether the server hangs up
+// on its own. A connection still open after that window is treated as kept
+// alive.
+std::shared_ptr<ExchangeResult> exchangeOnce(const std::string &request,
+                                             double settleMs = 800.0)
+{
+    auto client =
+        std::make_shared<trantor::TcpClient>(app().getLoop(),
+                                             trantor::InetAddress{"127.0.0.1",
+                                                                  8848},
+                                             "close-connection-regression");
+    auto result = std::make_shared<ExchangeResult>();
+    auto done = std::make_shared<std::atomic<bool>>(false);
+    auto timerArmed = std::make_shared<std::atomic<bool>>(false);
+    auto promise = std::make_shared<std::promise<void>>();
+    auto future = promise->get_future();
+    auto finish = [done, promise]() {
+        if (!done->exchange(true))
+        {
+            promise->set_value();
+        }
+    };
+
+    client->setConnectionCallback(
+        [request, result, finish](const trantor::TcpConnectionPtr &conn) {
+            if (conn->connected())
+            {
+                conn->send(request);
+                return;
+            }
+            result->serverClosed = true;
+            finish();
+        });
+
+    client->setMessageCallback(
+        [result, timerArmed, settleMs, finish](
+            const trantor::TcpConnectionPtr &conn, trantor::MsgBuffer *buffer) {
+            result->response.append(buffer->read(buffer->readableBytes()));
+            if (result->response.find("\r\n\r\n") == std::string::npos)
+            {
+                return;
+            }
+            if (!timerArmed->exchange(true))
+            {
+                conn->getLoop()->runAfter(settleMs / 1000.0, finish);
+            }
+        });
+
+    client->connect();
+    if (future.wait_for(10s) != std::future_status::ready)
+    {
+        return nullptr;
+    }
+    client->disconnect();
+    return result;
+}
+}  // namespace
+
+// An HTTP/1.0 client asking for keep-alive must be honoured. setVersion() sets
+// the response's closeConnection flag as a side effect for HTTP/1.0, which must
+// not be mistaken for an explicit application decision.
+DROGON_TEST(CloseConnectionHttp10KeepAliveTest)
+{
+    auto result = exchangeOnce(
+        "GET /api/v1/keepalive_probe HTTP/1.0\r\n"
+        "Host: 127.0.0.1:8848\r\n"
+        "Connection: keep-alive\r\n\r\n");
+
+    REQUIRE(result != nullptr);
+    CHECK(result->response.find("HTTP/1.0 200") == 0);
+    CHECK(result->response.find("connection: close\r\n") == std::string::npos);
+    CHECK(result->response.find("connection: Keep-Alive\r\n") !=
+          std::string::npos);
+    CHECK(result->serverClosed == false);
+}
+
+// The cached 404 response object is reused across requests. One client sending
+// "Connection: close" must not leave that shared object permanently marked as
+// close-on-send for every later client.
+DROGON_TEST(CloseConnectionCachedResponseNotStickyTest)
+{
+    auto closing = exchangeOnce(
+        "GET /this_route_does_not_exist HTTP/1.1\r\n"
+        "Host: 127.0.0.1:8848\r\n"
+        "Connection: close\r\n\r\n");
+    REQUIRE(closing != nullptr);
+    CHECK(closing->serverClosed == true);
+
+    auto keepAlive = exchangeOnce(
+        "GET /this_route_does_not_exist HTTP/1.1\r\n"
+        "Host: 127.0.0.1:8848\r\n"
+        "Connection: keep-alive\r\n\r\n");
+    REQUIRE(keepAlive != nullptr);
+    CHECK(keepAlive->response.find("connection: close\r\n") ==
+          std::string::npos);
+    CHECK(keepAlive->serverClosed == false);
+}
+
+// A failed WebSocket route sets closeConnection on the response returned by
+// newNotFoundResponse(), which may be a shared or per-IO-thread cached object.
+// Later plain 404s must still honour keep-alive.
+DROGON_TEST(CloseConnectionWebSocketNotFoundNotStickyTest)
+{
+    auto wsNotFound = exchangeOnce(
+        "GET /this_ws_route_does_not_exist HTTP/1.1\r\n"
+        "Host: 127.0.0.1:8848\r\n"
+        "Upgrade: websocket\r\n"
+        "Connection: Upgrade\r\n"
+        "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n"
+        "Sec-WebSocket-Version: 13\r\n\r\n");
+    REQUIRE(wsNotFound != nullptr);
+
+    auto keepAlive = exchangeOnce(
+        "GET /this_route_does_not_exist HTTP/1.1\r\n"
+        "Host: 127.0.0.1:8848\r\n"
+        "Connection: keep-alive\r\n\r\n");
+    REQUIRE(keepAlive != nullptr);
+    CHECK(keepAlive->response.find("connection: close\r\n") ==
+          std::string::npos);
+    CHECK(keepAlive->serverClosed == false);
+}

--- a/lib/tests/integration_test/client/CloseConnectionTest.cc
+++ b/lib/tests/integration_test/client/CloseConnectionTest.cc
@@ -7,6 +7,7 @@
 #include <future>
 #include <memory>
 #include <string>
+#include <vector>
 
 using namespace drogon;
 using namespace std::chrono_literals;
@@ -68,16 +69,34 @@ namespace
 {
 struct ExchangeResult
 {
-    std::string response;
+    std::string data;
+    int responses{0};
     bool serverClosed{false};
 };
 
-// Opens a fresh connection, sends a single raw request, and once the response
-// headers have arrived waits `settleMs` to observe whether the server hangs up
-// on its own. A connection still open after that window is treated as kept
-// alive.
-std::shared_ptr<ExchangeResult> exchangeOnce(const std::string &request,
-                                             double settleMs = 800.0)
+// Counts response status lines seen so far. The bodies used by these tests
+// never contain the token, so this is an adequate framing signal for a test.
+int countResponses(const std::string &data)
+{
+    int count = 0;
+    size_t pos = 0;
+    while ((pos = data.find("HTTP/1.", pos)) != std::string::npos)
+    {
+        ++count;
+        pos += 7;
+    }
+    return count;
+}
+
+// Opens one connection and sends `requests` in order, each only after the
+// previous response has arrived. Completes as soon as every response has been
+// received -- which positively proves the connection survived -- or as soon as
+// the server hangs up, whichever comes first.
+//
+// Liveness is proven by obtaining another response rather than by waiting out a
+// timer, so the outcome does not depend on any delay.
+std::shared_ptr<ExchangeResult> exchange(
+    const std::vector<std::string> &requests)
 {
     auto client =
         std::make_shared<trantor::TcpClient>(app().getLoop(),
@@ -86,7 +105,7 @@ std::shared_ptr<ExchangeResult> exchangeOnce(const std::string &request,
                                              "close-connection-regression");
     auto result = std::make_shared<ExchangeResult>();
     auto done = std::make_shared<std::atomic<bool>>(false);
-    auto timerArmed = std::make_shared<std::atomic<bool>>(false);
+    auto sent = std::make_shared<std::atomic<size_t>>(0);
     auto promise = std::make_shared<std::promise<void>>();
     auto future = promise->get_future();
     auto finish = [done, promise]() {
@@ -96,33 +115,43 @@ std::shared_ptr<ExchangeResult> exchangeOnce(const std::string &request,
         }
     };
 
-    client->setConnectionCallback(
-        [request, result, finish](const trantor::TcpConnectionPtr &conn) {
-            if (conn->connected())
+    client->setConnectionCallback([requests, sent, result, finish](
+                                      const trantor::TcpConnectionPtr &conn) {
+        if (conn->connected())
+        {
+            conn->send(requests[sent->fetch_add(1)]);
+            return;
+        }
+        result->serverClosed = true;
+        finish();
+    });
+
+    client->setMessageCallback(
+        [requests, sent, result, finish](const trantor::TcpConnectionPtr &conn,
+                                         trantor::MsgBuffer *buffer) {
+            result->data.append(buffer->read(buffer->readableBytes()));
+            // Wait for the newest response's headers to be complete before
+            // acting.
+            if (result->data.rfind("\r\n\r\n") == std::string::npos)
             {
-                conn->send(request);
                 return;
             }
-            result->serverClosed = true;
+            const int seen = countResponses(result->data);
+            if (seen < static_cast<int>(sent->load()))
+            {
+                return;
+            }
+            result->responses = seen;
+            if (sent->load() < requests.size())
+            {
+                conn->send(requests[sent->fetch_add(1)]);
+                return;
+            }
             finish();
         });
 
-    client->setMessageCallback(
-        [result, timerArmed, settleMs, finish](
-            const trantor::TcpConnectionPtr &conn, trantor::MsgBuffer *buffer) {
-            result->response.append(buffer->read(buffer->readableBytes()));
-            if (result->response.find("\r\n\r\n") == std::string::npos)
-            {
-                return;
-            }
-            if (!timerArmed->exchange(true))
-            {
-                conn->getLoop()->runAfter(settleMs / 1000.0, finish);
-            }
-        });
-
     client->connect();
-    if (future.wait_for(10s) != std::future_status::ready)
+    if (future.wait_for(15s) != std::future_status::ready)
     {
         return nullptr;
     }
@@ -136,16 +165,19 @@ std::shared_ptr<ExchangeResult> exchangeOnce(const std::string &request,
 // not be mistaken for an explicit application decision.
 DROGON_TEST(CloseConnectionHttp10KeepAliveTest)
 {
-    auto result = exchangeOnce(
+    const std::string request =
         "GET /api/v1/keepalive_probe HTTP/1.0\r\n"
         "Host: 127.0.0.1:8848\r\n"
-        "Connection: keep-alive\r\n\r\n");
+        "Connection: keep-alive\r\n\r\n";
+
+    auto result = exchange({request, request});
 
     REQUIRE(result != nullptr);
-    CHECK(result->response.find("HTTP/1.0 200") == 0);
-    CHECK(result->response.find("connection: close\r\n") == std::string::npos);
-    CHECK(result->response.find("connection: Keep-Alive\r\n") !=
-          std::string::npos);
+    CHECK(result->data.find("HTTP/1.0 200") == 0);
+    CHECK(result->data.find("connection: close\r\n") == std::string::npos);
+    CHECK(result->data.find("connection: Keep-Alive\r\n") != std::string::npos);
+    // Two responses on one connection prove the server honoured keep-alive.
+    CHECK(result->responses == 2);
     CHECK(result->serverClosed == false);
 }
 
@@ -154,20 +186,29 @@ DROGON_TEST(CloseConnectionHttp10KeepAliveTest)
 // close-on-send for every later client.
 DROGON_TEST(CloseConnectionCachedResponseNotStickyTest)
 {
-    auto closing = exchangeOnce(
+    // First client opts out of keep-alive. A second request is attempted on the
+    // same connection: the server is expected to have hung up instead of
+    // answering it.
+    const std::string closeRequest =
         "GET /this_route_does_not_exist HTTP/1.1\r\n"
         "Host: 127.0.0.1:8848\r\n"
-        "Connection: close\r\n\r\n");
+        "Connection: close\r\n\r\n";
+
+    auto closing = exchange({closeRequest, closeRequest});
     REQUIRE(closing != nullptr);
     CHECK(closing->serverClosed == true);
+    CHECK(closing->responses == 1);
 
-    auto keepAlive = exchangeOnce(
+    // A later client must still get keep-alive, on a connection of its own.
+    const std::string keepAliveRequest =
         "GET /this_route_does_not_exist HTTP/1.1\r\n"
         "Host: 127.0.0.1:8848\r\n"
-        "Connection: keep-alive\r\n\r\n");
+        "Connection: keep-alive\r\n\r\n";
+
+    auto keepAlive = exchange({keepAliveRequest, keepAliveRequest});
     REQUIRE(keepAlive != nullptr);
-    CHECK(keepAlive->response.find("connection: close\r\n") ==
-          std::string::npos);
+    CHECK(keepAlive->data.find("connection: close\r\n") == std::string::npos);
+    CHECK(keepAlive->responses == 2);
     CHECK(keepAlive->serverClosed == false);
 }
 
@@ -176,21 +217,24 @@ DROGON_TEST(CloseConnectionCachedResponseNotStickyTest)
 // Later plain 404s must still honour keep-alive.
 DROGON_TEST(CloseConnectionWebSocketNotFoundNotStickyTest)
 {
-    auto wsNotFound = exchangeOnce(
+    auto wsNotFound = exchange({
         "GET /this_ws_route_does_not_exist HTTP/1.1\r\n"
         "Host: 127.0.0.1:8848\r\n"
         "Upgrade: websocket\r\n"
         "Connection: Upgrade\r\n"
         "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n"
-        "Sec-WebSocket-Version: 13\r\n\r\n");
+        "Sec-WebSocket-Version: 13\r\n\r\n",
+    });
     REQUIRE(wsNotFound != nullptr);
 
-    auto keepAlive = exchangeOnce(
+    const std::string keepAliveRequest =
         "GET /this_route_does_not_exist HTTP/1.1\r\n"
         "Host: 127.0.0.1:8848\r\n"
-        "Connection: keep-alive\r\n\r\n");
+        "Connection: keep-alive\r\n\r\n";
+
+    auto keepAlive = exchange({keepAliveRequest, keepAliveRequest});
     REQUIRE(keepAlive != nullptr);
-    CHECK(keepAlive->response.find("connection: close\r\n") ==
-          std::string::npos);
+    CHECK(keepAlive->data.find("connection: close\r\n") == std::string::npos);
+    CHECK(keepAlive->responses == 2);
     CHECK(keepAlive->serverClosed == false);
 }

--- a/lib/tests/integration_test/client/CloseConnectionTest.cc
+++ b/lib/tests/integration_test/client/CloseConnectionTest.cc
@@ -88,6 +88,24 @@ int countResponses(const std::string &data)
     return count;
 }
 
+// Pulls the session cookie out of a response. Once a client sends that cookie
+// back, HttpAppFrameworkImpl::handleSessionForResponse stops copying a cached
+// response and hands the shared object to the framework unchanged, which is the
+// window in which the close flag can become sticky.
+std::string sessionCookie(const std::string &data)
+{
+    const std::string prefix = "Set-Cookie: ";
+    auto pos = data.find(prefix);
+    if (pos == std::string::npos)
+    {
+        return {};
+    }
+    pos += prefix.size();
+    auto end = data.find_first_of(";\r", pos);
+    return end == std::string::npos ? data.substr(pos)
+                                    : data.substr(pos, end - pos);
+}
+
 // Opens one connection and sends `requests` in order, each only after the
 // previous response has arrived. Completes as soon as every response has been
 // received -- which positively proves the connection survived -- or as soon as
@@ -192,24 +210,32 @@ DROGON_TEST(CloseConnectionHttp10KeepAliveTest)
 // close-on-send for every later client.
 DROGON_TEST(CloseConnectionCachedResponseNotStickyTest)
 {
-    // First client opts out of keep-alive. A second request is attempted on the
-    // same connection: the server is expected to have hung up instead of
-    // answering it.
-    const std::string closeRequest =
+    const std::string head =
         "GET /this_route_does_not_exist HTTP/1.1\r\n"
-        "Host: 127.0.0.1:8848\r\n"
-        "Connection: close\r\n\r\n";
+        "Host: 127.0.0.1:8848\r\n";
+
+    // Establish a session first. Without the resulting cookie the framework
+    // hands out a fresh copy of the cached 404 on every request, and the shared
+    // object is never reached.
+    auto seed = exchange({head + "Connection: keep-alive\r\n\r\n"});
+    REQUIRE(seed != nullptr);
+    const std::string cookie = sessionCookie(seed->data);
+    REQUIRE(cookie.empty() == false);
+    const std::string withCookie = head + "Cookie: " + cookie + "\r\n";
+
+    // This client opts out of keep-alive, which marks the shared cached 404.
+    // A second request is attempted on the same connection; the server is
+    // expected to have hung up instead of answering it.
+    const std::string closeRequest = withCookie + "Connection: close\r\n\r\n";
 
     auto closing = exchange({closeRequest, closeRequest});
     REQUIRE(closing != nullptr);
     CHECK(closing->serverClosed == true);
     CHECK(closing->responses == 1);
 
-    // A later client must still get keep-alive, on a connection of its own.
+    // A later client on a connection of its own must still get keep-alive.
     const std::string keepAliveRequest =
-        "GET /this_route_does_not_exist HTTP/1.1\r\n"
-        "Host: 127.0.0.1:8848\r\n"
-        "Connection: keep-alive\r\n\r\n";
+        withCookie + "Connection: keep-alive\r\n\r\n";
 
     auto keepAlive = exchange({keepAliveRequest, keepAliveRequest});
     REQUIRE(keepAlive != nullptr);

--- a/lib/tests/integration_test/client/CloseConnectionTest.cc
+++ b/lib/tests/integration_test/client/CloseConnectionTest.cc
@@ -115,14 +115,20 @@ std::shared_ptr<ExchangeResult> exchange(
         }
     };
 
-    client->setConnectionCallback([requests, sent, result, finish](
+    client->setConnectionCallback([requests, sent, result, done, finish](
                                       const trantor::TcpConnectionPtr &conn) {
         if (conn->connected())
         {
             conn->send(requests[sent->fetch_add(1)]);
             return;
         }
-        result->serverClosed = true;
+        // Only a disconnect arriving before the exchange completed means the
+        // server hung up. The teardown disconnect below also lands here and
+        // must not be mistaken for one.
+        if (!done->load())
+        {
+            result->serverClosed = true;
+        }
         finish();
     });
 

--- a/lib/tests/integration_test/server/main.cc
+++ b/lib/tests/integration_test/server/main.cc
@@ -246,6 +246,15 @@ int main()
         });
 
     app().registerHandler(
+        "/api/v1/keepalive_probe",
+        [](const HttpRequestPtr &req,
+           std::function<void(const HttpResponsePtr &)> &&callback) {
+            auto resp = HttpResponse::newHttpResponse();
+            resp->setBody("alive");
+            callback(resp);
+        });
+
+    app().registerHandler(
         "/api/v1/close_connection",
         [](const HttpRequestPtr &req,
            std::function<void(const HttpResponsePtr &)> &&callback) {


### PR DESCRIPTION
> Built and tested locally on Windows with MSVC 14.44 (VS 2022 Build Tools), Debug, C++17, dependencies via conan — matching this repository's `windows/msvc` CI job. Zero compile errors, zero new warnings, and no failing assertions in `./test.sh -w`.

## Summary

PR #2566 added a guard so a handler calling `setCloseConnection(true)` is not overridden by the client's keep-alive preference. The guard reads `ifCloseConnection()`, which conflates an application decision with a protocol side effect, introducing two regressions. This PR separates the two concerns and adds regression coverage.

## The regressions

**1. HTTP/1.0 `Connection: keep-alive` is always closed.**
`handleResponse()` calls `setVersion(req->getVersion())` *before* the guard, and `HttpResponseImpl::setVersion()` sets `closeConnection_ = true` for `kHttp10`. The guard then sees the flag already set and skips applying the client's preference, so an HTTP/1.0 request carrying `Connection: keep-alive` — which `HttpRequestImpl` does honour by setting `keepAlive_ = true` — is hung up on.

**2. `closeConnection` becomes sticky on shared responses.**
The guard only ever *sets* the flag and never clears it, whereas the previous unconditional `setCloseConnection(!req->keepAlive())` reset it on every request. Any response object that outlives a single request therefore stays marked close-on-send once the flag goes up.

Two paths reach a shared object, and both are covered by tests that fail on `master`:

- `websocketRequestRouting()` calls `setCloseConnection(true)` directly on the object returned by `newNotFoundResponse()`, which may be a shared custom 404 page or a per-IO-thread cached response. After one failed WebSocket route, later plain 404s served from that object are hung up on even when the client asked for keep-alive.
- The guard itself marks a cached 404 when a client sends `Connection: close`, and never clears it afterwards. Reaching this requires the client to already hold a session cookie: `handleSessionForResponse()` copies a response whose `expiredTime() >= 0` while the session still needs to be sent to the client, and the cached 404 sets an expired time of 0. A client that presents the cookie takes the `return resp` branch and receives the shared object itself.

That second condition is why the corresponding test seeds a session and replays its cookie — without it the framework hands out a private copy every time and the defect stays masked.

## Root cause

`closeConnection_` was used both as an **input** ("the application wants close") and as an **output** ("this connection will close"), so the guard could not distinguish a deliberate handler decision from `setVersion()`'s side effect.

## Changes

- **`lib/src/HttpResponseImpl.h`** — added `closeConnectionSetByUser_`. `setCloseConnection()` now also records that the call came from the application. Added `setCloseConnectionInternal()` (sets the flag without marking it) and `closeConnectionSetByUser()`.
- **`lib/src/HttpServer.cc`** — both guard sites (`handleResponse`, `passSyncAdvices`) now test the marker instead of the flag, so the client's preference is re-evaluated on every request while an explicit handler decision is still honoured. This is what removes the stickiness.
- **`lib/src/HttpServer.cc` (`websocketRequestRouting`)** — previously called `setCloseConnection(true)` directly on the object from `newNotFoundResponse()`, which may be a shared custom 404 page or a per-IO-thread cached response. It now mutates a copy. The guard fix alone does not cover this path.
- **`lib/src/HttpResponseImpl.cc`** — `swap()` swaps the new flag; `clear()` now resets both (it previously reset neither).

Both new methods live only on `HttpResponseImpl`. The installed `lib/inc/drogon/HttpResponse.h` is untouched, so the **public API and ABI are unchanged**.

`Hodor`'s singleton reject response is now permanently marked user-set and therefore always closes — that matches its intent, so it is left as-is.

## Files Changed

| File | Type | Change |
|---|---|---|
| `lib/src/HttpResponseImpl.h` | Source | Modified — new flag, internal setter, accessor |
| `lib/src/HttpResponseImpl.cc` | Source | Modified — `swap()` / `clear()` lifecycle |
| `lib/src/HttpServer.cc` | Source | Modified — both guard sites, shared-404 copy |
| `lib/tests/integration_test/client/CloseConnectionTest.cc` | Test | Modified — 3 regression tests + helper |
| `lib/tests/integration_test/server/main.cc` | Test | Modified — `/api/v1/keepalive_probe` handler |

## Why the guard cannot simply be reordered

Moving `setVersion()` after the guard would fix regression 1 on its own, but not regression 2: the guard would still never clear the flag, so reused response objects stay poisoned. Separating "the application decided" from "this connection will close" addresses both with one consistent rule.

## Note on cached header strings

`HttpServer.cc` bakes a response's header string via `makeHeaderString()` only when `expiredTime() >= 0 && statusCode() != k404NotFound`, so 404s never cache their headers and the `connection:` line is re-rendered per request — which is what makes the assertions below meaningful.

For handler responses that *are* header-cached, regression 2 is worse than a stale header: the shutdown decision in `sendResponse()` reads `ifCloseConnection()` directly, so a poisoned cached response makes the server close the socket while the frozen header still advertises `Keep-Alive`.

## Testing

Three regression tests added to the existing `CloseConnectionTest.cc` (already registered in `lib/tests/CMakeLists.txt`):

1. `CloseConnectionHttp10KeepAliveTest` — HTTP/1.0 with `Connection: keep-alive` must return `connection: Keep-Alive` and serve a second request on the same connection.
2. `CloseConnectionCachedResponseNotStickyTest` — after one client sends `Connection: close` to a 404 route, a later keep-alive client must still get two responses on one connection.
3. `CloseConnectionWebSocketNotFoundNotStickyTest` — a plain keep-alive 404 following a failed WebSocket route must stay usable.

The tests contain no fixed delays. Liveness is proven positively, by obtaining a second response on the same connection, and the close case is asserted via the disconnect callback rather than inferred from a timeout. They are deterministic with respect to the shared cached 404 because the integration-test server leaves `threadNum_` at its default of 1, so one IO thread serves every connection.

The pre-existing `CloseConnectionTest` is unchanged and continues to guard #2566's original intent.

`clang-format` reports no drift on any file in this change. (It was run at version 22 rather than the version 17 `format.sh` mandates; version 22 also reports zero drift on the untouched upstream regions of these files, indicating the two agree for this style configuration.)

### Local verification

Environment: Windows, MSVC 14.44.35207 (VS 2022 Build Tools), `Debug`, `BUILD_TESTING=ON`, `CMAKE_CXX_STANDARD=17`, dependencies installed with conan — the same toolchain and settings as the `windows/msvc` CI job.

- Build: no compile errors; no new warnings in any file touched by this change.
- `./test.sh -w`: no failing assertions. The pre-existing `CloseConnectionTest` from #2566 still passes, so the behaviour that PR introduced is preserved.
- Verified against the defect itself: with only the first commit's `lib/src` changes reverted to `master` and the new tests kept, the suite goes from no failures to `test cases: 14 | 9 passed | 5 failed`, and all three new tests are among the failures. Details in the table below.

## Regression coverage

Per CONTRIBUTING.md's guidance that a bugfix should come with "a test that breaks in the old version, but works in the new one", each test fails on current `master` and passes with this change:

Measured by reverting only the `lib/src` changes to `master` and re-running:

| Test | Measured behaviour on current `master` |
|---|---|
| `CloseConnectionHttp10KeepAliveTest` | **Fails.** `responses == 2` expands to `1 == 2` — the server hangs up after the first response — and a `connection: close` header is present where none is expected. |
| `CloseConnectionWebSocketNotFoundNotStickyTest` | **Fails.** Same shape: `1 == 2`, plus an unexpected `connection: close` on the later plain 404, showing the shared 404 object stayed marked close-on-send. |
| `CloseConnectionCachedResponseNotStickyTest` | **Fails.** After a `Connection: close` client marks the shared cached 404, the next keep-alive client gets one response instead of two and is hung up on. |

`HttpTest` and `HttpsTest` also fail on the reverted build (`Network failure` at `client/main.cc:1018/1032/1047`). That only happens once the new tests have run first, so I read it as a knock-on effect of the sticky flag rather than an independent failure, and I have not traced it further.

## Contribution notes

- Branched off current `master`; no conflicts.
- Formatted with `clang-format` (no drift reported on any file in this change).
- Comments are in English; the two new methods carry Doxygen comments. They are added to the internal `HttpResponseImpl` only, so no new public API is introduced.
- Happy to split this into two PRs (the HTTP/1.0 ordering fix and the sticky-flag fix) if you would prefer to review them separately.

## Related Issues

Relates to #2566.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
