### PR TITLE
Fix const string_view SQL binding

### DIFF
--- a/orm_lib/inc/drogon/orm/SqlBinder.h
+++ b/orm_lib/inc/drogon/orm/SqlBinder.h
@@ -470,6 +470,11 @@ class DROGON_EXPORT SqlBinder : public trantor::NonCopyable
         return operator<<((const std::string_view &)str);
     }
 
+    self &operator<<(const std::string_view &&str)
+    {
+        return operator<<((const std::string_view &)str);
+    }
+
     self &operator<<(std::string_view &str)
     {
         return operator<<((const std::string_view &)str);

--- a/orm_lib/tests/db_api_test.cc
+++ b/orm_lib/tests/db_api_test.cc
@@ -6,6 +6,19 @@
 using namespace drogon;
 using namespace trantor;
 
+namespace
+{
+const std::string_view makeConstStringView()
+{
+    return "value";
+}
+
+[[maybe_unused]] void bindConstStringViewRvalue(orm::DbClient &client)
+{
+    client.execSqlSync("SELECT $1", makeConstStringView());
+}
+}  // namespace
+
 DROGON_TEST(DbApiTest)
 {
 #if USE_POSTGRESQL


### PR DESCRIPTION
## Summary
- add the missing `const std::string_view&&` binder overload so const prvalues use the string binding path instead of the generic numeric template
- add a compile-time regression through the public `execSqlSync` API

Fixes #2570.

## Validation
- reproduced before the fix with GCC 16.1.0: `SqlBinder::operator<<` instantiated with `T = const std::string_view` and failed on numeric casts
- `cmake --build build-issue-2570-before --target db_api_test -j2`
- `db_api_test.exe`: all tests passed (2 assertions in 1 test case)
- formatted changed files with clang-format 22.1.8
- `git diff --check upstream/master...HEAD`