### PR TITLE
fix: swap every member of HttpResponseImpl

### DIFF
--- a/lib/src/HttpResponseImpl.cc
+++ b/lib/src/HttpResponseImpl.cc
@@ -1082,28 +1082,49 @@ void HttpResponseImpl::addHeader(const char *start,
     }
 }
 
+// Every data member must be listed here, in declaration order. Leaving one out
+// splices the two responses together instead of exchanging them, and the
+// members that depend on each other make that fatal rather than merely wrong:
+//   - expriedTime_ decides whether renderToBuffer() trusts httpString_, while
+//     datePos_ indexes into it. Swapping the latter two without the former
+//     hands a response a null httpString_ alongside a valid datePos_, and the
+//     next render dereferences it.
+//   - contentType_ without contentTypeString_, or statusCode_ without
+//     customStatusCode_, renders a response that contradicts its own
+//     accessors.
 void HttpResponseImpl::swap(HttpResponseImpl &that) noexcept
 {
     using std::swap;
     headers_.swap(that.headers_);
     cookies_.swap(that.cookies_);
+    swap(customStatusCode_, that.customStatusCode_);
     swap(statusCode_, that.statusCode_);
-    swap(version_, that.version_);
     swap(statusMessage_, that.statusMessage_);
+    swap(creationDate_, that.creationDate_);
+    swap(version_, that.version_);
     swap(closeConnection_, that.closeConnection_);
     swap(closeConnectionSetByUser_, that.closeConnectionSetByUser_);
     bodyPtr_.swap(that.bodyPtr_);
-    swap(contentType_, that.contentType_);
-    swap(flagForParsingContentType_, that.flagForParsingContentType_);
-    swap(flagForParsingJson_, that.flagForParsingJson_);
+    swap(expriedTime_, that.expriedTime_);
     swap(sendfileName_, that.sendfileName_);
+    swap(sendfileRange_, that.sendfileRange_);
     swap(streamCallback_, that.streamCallback_);
     swap(asyncStreamCallback_, that.asyncStreamCallback_);
+    swap(asyncStreamDisableKickoff_, that.asyncStreamDisableKickoff_);
     jsonPtr_.swap(that.jsonPtr_);
     fullHeaderString_.swap(that.fullHeaderString_);
+    swap(peerCertificate_, that.peerCertificate_);
     httpString_.swap(that.httpString_);
     swap(datePos_, that.datePos_);
+    swap(httpStringDate_, that.httpStringDate_);
+    swap(flagForParsingJson_, that.flagForParsingJson_);
+    swap(flagForSerializingJson_, that.flagForSerializingJson_);
+    swap(contentType_, that.contentType_);
+    swap(flagForParsingContentType_, that.flagForParsingContentType_);
     swap(jsonParsingErrorPtr_, that.jsonParsingErrorPtr_);
+    swap(contentTypeString_, that.contentTypeString_);
+    swap(passThrough_, that.passThrough_);
+    swap(allowCompression_, that.allowCompression_);
 }
 
 void HttpResponseImpl::clear()

--- a/lib/tests/CMakeLists.txt
+++ b/lib/tests/CMakeLists.txt
@@ -13,6 +13,7 @@ set(UNITTEST_SOURCES
     unittests/ClassNameTest.cc
     unittests/HttpDateTest.cc
     unittests/HttpHeaderTest.cc
+    unittests/HttpResponseSwapTest.cc
     unittests/MD5Test.cc
     unittests/MsgBufferTest.cc
     unittests/OStringStreamTest.cc

--- a/lib/tests/unittests/HttpResponseSwapTest.cc
+++ b/lib/tests/unittests/HttpResponseSwapTest.cc
@@ -1,0 +1,63 @@
+#include <drogon/drogon_test.h>
+#include <drogon/HttpResponse.h>
+#include "../../lib/src/HttpResponseImpl.h"
+
+using namespace drogon;
+
+static std::string render(HttpResponseImpl &resp)
+{
+    auto buffer = resp.renderToBuffer();
+    return std::string{buffer->peek(), buffer->readableBytes()};
+}
+
+DROGON_TEST(HttpResponseSwapExchangesEveryMember)
+{
+    HttpResponseImpl one;
+    one.setStatusCode(k200OK);
+    one.setContentTypeCode(CT_TEXT_PLAIN);
+    one.setBody("one");
+    one.setExpiredTime(0);
+    one.setCloseConnection(true);
+
+    HttpResponseImpl two;
+    two.setStatusCode(k404NotFound);
+    two.setContentTypeCode(CT_APPLICATION_JSON);
+    two.setBody("two");
+    two.setExpiredTime(-1);
+
+    // Render first, so both objects carry whatever they memoize internally.
+    render(one);
+    render(two);
+
+    one.swap(two);
+
+    CHECK(one.statusCode() == k404NotFound);
+    CHECK(two.statusCode() == k200OK);
+
+    // contentType_ and contentTypeString_ are a pair: the enum drives
+    // contentType(), the string drives the rendered header. Moving only one of
+    // them leaves a response that contradicts itself.
+    CHECK(one.contentType() == CT_APPLICATION_JSON);
+    CHECK(two.contentType() == CT_TEXT_PLAIN);
+
+    CHECK(one.expiredTime() == -1);
+    CHECK(two.expiredTime() == 0);
+
+    CHECK(one.ifCloseConnection() == false);
+    CHECK(two.ifCloseConnection() == true);
+    CHECK(one.closeConnectionSetByUser() == false);
+    CHECK(two.closeConnectionSetByUser() == true);
+
+    auto oneStr = render(one);
+    auto twoStr = render(two);
+
+    CHECK(oneStr.find("404") != std::string::npos);
+    CHECK(oneStr.find("application/json") != std::string::npos);
+    CHECK(oneStr.find("two") != std::string::npos);
+    CHECK(oneStr.find("connection: close\r\n") == std::string::npos);
+
+    CHECK(twoStr.find("200") != std::string::npos);
+    CHECK(twoStr.find("text/plain") != std::string::npos);
+    CHECK(twoStr.find("one") != std::string::npos);
+    CHECK(twoStr.find("connection: close\r\n") != std::string::npos);
+}


### PR DESCRIPTION
### The bug

`HttpResponseImpl::swap()` listed 19 of the class's 30 data members. Rather than exchanging two responses it spliced them together.

**The worst omission is `expriedTime_`, and it is a null dereference, not just wrong output.** `renderToBuffer()` consults `expriedTime_` to decide whether `httpString_` holds a usable memoized rendering, and `datePos_` indexes into that buffer. `httpString_` and `datePos_` were swapped but `expriedTime_` was not, so a response that memoizes can come out of a swap holding a null `httpString_` next to a valid `datePos_`. The next render takes the fast path, reaches the `memcpy` that patches the date header in place, and dereferences the null. On the pre-fix code the new unit test reproduces this as an access violation (`0xC0000005`).

Two more pairs were split the same way, with milder results:

| swapped | not swapped | result |
| --- | --- | --- |
| `contentType_` | `contentTypeString_` | `contentType()` reports `CT_APPLICATION_JSON` while the rendered header says `content-type: text/plain` |
| `statusCode_`, `statusMessage_` | `customStatusCode_` | the status line is rendered from the *other* response's custom code |

Also dropped: `passThrough_`, `creationDate_`, `sendfileRange_`, `peerCertificate_`, `httpStringDate_`, `flagForSerializingJson_`, `asyncStreamDisableKickoff_`, `allowCompression_`.

### The fix

All 30 members, in declaration order, plus a comment saying so — the failure mode here is a member added later and never wired in. The list was verified exhaustive by diffing every `foo_` member declared in the header against every member named in the swap body, in both directions.

### Why this went unnoticed

`swap()` has zero callers anywhere in the repository, so nothing ever observed the splice. The new unit test gives it one.

### Testing

Adds `lib/tests/unittests/HttpResponseSwapTest.cc`. It builds two responses that differ in status code, content type, body, expired time and close-connection flag, renders both so any internal memoization is populated, swaps, and then asserts both the accessors and the rendered bytes followed the swap.

Verified locally on Windows (MSVC 14.44, static build, vcpkg jsoncpp/zlib):

- with the fix: `All tests passed (1338 assertions in 62 tests cases)`
- with `swap()` reverted to its previous body: the new test fails on `expiredTime()` and then crashes with an access violation, confirming it pins the defect rather than merely passing
