### PR TITLE
Fix/join single presFix QueryBuilder JOIN state when using singleerve joins

### DIFF
--- a/orm_lib/inc/drogon/orm/TransformBuilder.h
+++ b/orm_lib/inc/drogon/orm/TransformBuilder.h
@@ -47,6 +47,7 @@ class TransformBuilder : public BaseBuilder<T, SelectAll, Single>
         this->from_ = tb.from_;
         this->columns_ = tb.columns_;
         this->filters_ = tb.filters_;
+        this->joins_ = tb.joins_;
         this->limit_ = tb.limit_;
         this->offset_ = tb.offset_;
         this->orders_ = tb.orders_;

--- a/orm_lib/tests/db_test.cc
+++ b/orm_lib/tests/db_test.cc
@@ -893,6 +893,40 @@ DROGON_TEST(PostgreTest)
         FAULT("postgresql - ORM QueryBuilder synchronous interface(3) what():",
               e.base().what());
     }
+    try
+    {
+        const Users user =
+            QueryBuilder<Users>{}
+                .from("users")
+                .selectAll()
+                .leftJoin("wallets", "users.user_id", "wallets.user_id")
+                .eq("user_name", "postgres")
+                .single()
+                .execSync(clientPtr);
+        MANDATE(user.getValueOfUserName() == "postgres");
+    }
+    catch (const DrogonDbException &e)
+    {
+        FAULT("postgresql - ORM QueryBuilder JOIN + single() model what():",
+              e.base().what());
+    }
+    try
+    {
+        const Row wallet =
+            QueryBuilder<Users>{}
+                .from("users")
+                .select("wallets.amount")
+                .leftJoin("wallets", "users.user_id", "wallets.user_id")
+                .limit(1)
+                .single()
+                .execSync(clientPtr);
+        MANDATE(wallet["amount"].isNull());
+    }
+    catch (const DrogonDbException &e)
+    {
+        FAULT("postgresql - ORM QueryBuilder JOIN + single() row what():",
+              e.base().what());
+    }
 
     /// execAsyncFuture
     {
@@ -2272,6 +2306,40 @@ DROGON_TEST(MySQLTest)
         FAULT("mysql - ORM QueryBuilder synchronous interface(3) what():",
               e.base().what());
     }
+    try
+    {
+        const Users user =
+            QueryBuilder<Users>{}
+                .from("users")
+                .selectAll()
+                .leftJoin("wallets", "users.user_id", "wallets.user_id")
+                .eq("user_name", "postgres")
+                .single()
+                .execSync(clientPtr);
+        MANDATE(user.getValueOfUserName() == "postgres");
+    }
+    catch (const DrogonDbException &e)
+    {
+        FAULT("mysql - ORM QueryBuilder JOIN + single() model what():",
+              e.base().what());
+    }
+    try
+    {
+        const Row wallet =
+            QueryBuilder<Users>{}
+                .from("users")
+                .select("wallets.amount")
+                .leftJoin("wallets", "users.user_id", "wallets.user_id")
+                .limit(1)
+                .single()
+                .execSync(clientPtr);
+        MANDATE(wallet["amount"].isNull());
+    }
+    catch (const DrogonDbException &e)
+    {
+        FAULT("mysql - ORM QueryBuilder JOIN + single() row what():",
+              e.base().what());
+    }
 
     /// execAsyncFuture
     {
@@ -3547,6 +3615,40 @@ DROGON_TEST(SQLite3Test)
     catch (const DrogonDbException &e)
     {
         FAULT("sqlite3 - ORM QueryBuilder synchronous interface(3) what():",
+              e.base().what());
+    }
+    try
+    {
+        const Users user =
+            QueryBuilder<Users>{}
+                .from("users")
+                .selectAll()
+                .leftJoin("wallets", "users.user_id", "wallets.user_id")
+                .eq("user_name", "postgres")
+                .single()
+                .execSync(clientPtr);
+        MANDATE(user.getValueOfUserName() == "postgres");
+    }
+    catch (const DrogonDbException &e)
+    {
+        FAULT("sqlite3 - ORM QueryBuilder JOIN + single() model what():",
+              e.base().what());
+    }
+    try
+    {
+        const Row wallet =
+            QueryBuilder<Users>{}
+                .from("users")
+                .select("wallets.amount")
+                .leftJoin("wallets", "users.user_id", "wallets.user_id")
+                .limit(1)
+                .single()
+                .execSync(clientPtr);
+        MANDATE(wallet["amount"].isNull());
+    }
+    catch (const DrogonDbException &e)
+    {
+        FAULT("sqlite3 - ORM QueryBuilder JOIN + single() row what():",
               e.base().what());
     }
 


### PR DESCRIPTION
Fix QueryBuilder JOIN state when using single

## Summary

- Preserve JOIN clauses when converting a `QueryBuilder` to a single-result builder.
- Add regression tests for model and `Row` results with `LEFT JOIN + single()`.
- Cover the PostgreSQL, MySQL, and SQLite test sections.

## Problem

`TransformBuilder::single()` converts a non-single builder into a single-result builder. The conversion constructor copied the existing query state except for `joins_`.

As a result, a query such as:

```cpp
QueryBuilder<Users>{}
    .from("users")
    .select("wallets.amount")
    .leftJoin("wallets", "users.user_id", "wallets.user_id")
    .limit(1)
    .single()
    .execSync(clientPtr);
```

lost its `LEFT JOIN` clause. The generated SQL still referenced `wallets.amount`, causing a database error or incorrect query behavior.

## Changes

Copy `joins_` in the `TransformBuilder<T, SelectAll, true>` conversion constructor:

```cpp
this->joins_ = tb.joins_;
```

This keeps `FROM`, JOIN, filters, ordering, limit, and offset unchanged when `.single()` only changes the result cardinality.

## Tests

- Added model-result regression tests for `LEFT JOIN + single()`.
- Added `Row`-result regression tests that select `wallets.amount`.
- Added tests to the PostgreSQL, MySQL, and SQLite sections of `orm_lib/tests/db_test.cc`.
- SQLite database tests passed: 124 assertions in 3 test cases.
- `clang-format` and `git diff --check` passed.

Fixes #2577