### PR TITLE
fix: make Task promise_type a non-aggregate to prevent Clang 21 SIGSEGV

### DIFF
--- a/lib/inc/drogon/utils/coroutine.h
+++ b/lib/inc/drogon/utils/coroutine.h
@@ -196,6 +196,11 @@ struct [[nodiscard]] Task
 
     struct promise_type
     {
+        // Make promise_type a non-aggregate so Clang >= 21 does not
+        // aggregate-initialize `value` from the first coroutine argument
+        // (crashes if the conversion throws). See issue #2579.
+        promise_type() = default;
+
         Task<T> get_return_object()
         {
             return Task<T>{handle_type::from_promise(*this)};
@@ -300,6 +305,9 @@ struct [[nodiscard]] Task<void>
 
     struct promise_type
     {
+        // Same as Task<T>::promise_type above. See issue #2579.
+        promise_type() = default;
+
         Task<> get_return_object()
         {
             return Task<>{handle_type::from_promise(*this)};

--- a/lib/tests/unittests/CoroutineTest.cc
+++ b/lib/tests/unittests/CoroutineTest.cc
@@ -328,3 +328,27 @@ DROGON_TEST(WhenAll)
         CHECK(counter == 1);
     }(TEST_CTX);
 }
+
+DROGON_TEST(PromiseNotAggregateInitializedFromArgs)
+{
+    // Clang >= 21 used to aggregate-initialize Task<T>::promise_type::value
+    // from the first coroutine argument. If the argument was implicitly
+    // convertible to T and the conversion threw (e.g. nlohmann::json), the
+    // exception escaped the partially constructed coroutine frame and crashed
+    // the process. promise_type is a non-aggregate now, so the promise is
+    // default-constructed and the conversion never runs.
+    struct ThrowOnConvert
+    {
+        operator std::string() const
+        {
+            throw std::runtime_error("must not be converted");
+        }
+    };
+
+    auto returnOk = [](const ThrowOnConvert &) -> Task<std::string> {
+        co_return "ok";
+    };
+
+    ThrowOnConvert arg;
+    CHECK(sync_wait(returnOk(arg)) == "ok");
+}


### PR DESCRIPTION
Fixes #2579
  
  ## What
  
  `drogon::Task<T>::promise_type` declares no constructor, which makes it an aggregate. Clang 21 aggregate-initializes the promise from the coroutine arguments, positionally: the first argument initializes the first member, `std::optional<T> value`. If the argument is implicitly convertible to `T` and the
  conversion throws (most commonly `nlohmann::json`'s implicit `operator ValueType()` on a mismatched value, throwing `type_error.302`), the exception is thrown during promise construction — before the coroutine body runs — and unwinding from the partially constructed coroutine frame crashes the process inside
  `_Unwind_Resume` (SIGSEGV; the exception is never catchable).
  
  ## How
  
  Add a user-declared default constructor to `Task<T>::promise_type` (and `Task<void>::promise_type`, same latent hazard), making it a non-aggregate. Compilers then fall back to default-constructing the promise — exactly the behavior prescribed when no promise constructor takes the coroutine parameters, and the
  behavior of pre-Clang-21 compilers. `AsyncTask::promise_type` has no data members and is unaffected.
  
  ## Test
  
  `PromiseNotAggregateInitializedFromArgs` in `CoroutineTest.cc`: a `Task<std::string>` whose argument is implicitly convertible to `std::string` and throws. Before this change the process segfaulted at the call, before the test body could run; after it, the coroutine completes and returns normally.
  
  Verified on Apple clang 21.0.0 (clang-2100.1.1.101), macOS 26.5.2 (arm64), C++20. A standalone minimal repro and the full crash analysis are in #2579.