### PR TITLE
fix: make PostgreSQL reconnect retry interval configurable

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -68,7 +68,9 @@
             "timeout": -1.0,
             //auto_batch: this feature is only available for the PostgreSQL driver(version >= 14.0), see
             //the wiki for more details.
-            "auto_batch": false
+            "auto_batch": false,
+            //reconnect_interval: 1.0 by default, in seconds.
+            "reconnect_interval": 1.0
             //connect_options: extra options for the connection. Only works for PostgreSQL now.
             //For more information, see https://www.postgresql.org/docs/16/libpq-connect.html#LIBPQ-CONNECT-OPTIONS
             //"connect_options": { "statement_timeout": "1s" }

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -60,6 +60,8 @@
 #     # auto_batch: this feature is only available for the PostgreSQL driver(version >= 14.0), see
 #     # the wiki for more details.
 #     auto_batch: false
+#     # reconnect_interval: 1.0 by default, in seconds.
+#     reconnect_interval: 1.0
 #     # connect_options: extra options for the connection. Only works for PostgreSQL now.
 #     # For more information, see https://www.postgresql.org/docs/16/libpq-connect.html#LIBPQ-CONNECT-OPTIONS
 #     # connect_options:

--- a/lib/src/ConfigLoader.cc
+++ b/lib/src/ConfigLoader.cc
@@ -571,6 +571,8 @@ static void loadDbClients(const Json::Value &dbClients)
         auto connectOptions = client.get("connect_options", Json::Value());
         auto timeout = client.get("timeout", -1.0).asDouble();
         auto autoBatch = client.get("auto_batch", false).asBool();
+        auto reconnectInterval =
+            client.get("reconnect_interval", 1.0).asDouble();
 
         std::unordered_map<std::string, std::string> options;
         if (connectOptions.isObject() && !connectOptions.empty())
@@ -594,7 +596,8 @@ static void loadDbClients(const Json::Value &dbClients)
                                                      characterSet,
                                                      timeout,
                                                      autoBatch,
-                                                     std::move(options));
+                                                     std::move(options),
+                                                     reconnectInterval);
     }
 }
 

--- a/lib/src/HttpAppFrameworkImpl.cc
+++ b/lib/src/HttpAppFrameworkImpl.cc
@@ -958,7 +958,8 @@ HttpAppFramework &HttpAppFrameworkImpl::createDbClient(
                 characterSet,
                 timeout,
                 autoBatch,
-                {});
+                {},
+                1.0);
     return *this;
 }
 
@@ -976,7 +977,8 @@ void HttpAppFrameworkImpl::addDbClient(
     const std::string &characterSet,
     double timeout,
     bool autoBatch,
-    std::unordered_map<std::string, std::string> options)
+    std::unordered_map<std::string, std::string> options,
+    double reconnectInterval)
 {
     if (dbType == "postgresql" || dbType == "postgres")
     {
@@ -991,7 +993,8 @@ void HttpAppFrameworkImpl::addDbClient(
                                         characterSet,
                                         timeout,
                                         autoBatch,
-                                        std::move(options)});
+                                        std::move(options),
+                                        reconnectInterval});
     }
     else if (dbType == "mysql")
     {

--- a/lib/src/HttpAppFrameworkImpl.h
+++ b/lib/src/HttpAppFrameworkImpl.h
@@ -567,7 +567,8 @@ class HttpAppFrameworkImpl final : public HttpAppFramework
                      const std::string &characterSet,
                      double timeout,
                      bool autoBatch,
-                     std::unordered_map<std::string, std::string> options);
+                     std::unordered_map<std::string, std::string> options,
+                     double reconnectInterval = 1.0);
     HttpAppFramework &addDbClient(const orm::DbConfig &config) override;
 
     HttpAppFramework &createRedisClient(const std::string &ip,

--- a/orm_lib/inc/drogon/orm/DbClient.h
+++ b/orm_lib/inc/drogon/orm/DbClient.h
@@ -133,7 +133,8 @@ class DROGON_EXPORT DbClient : public trantor::NonCopyable
      */
     static std::shared_ptr<DbClient> newPgClient(const std::string &connInfo,
                                                  size_t connNum,
-                                                 bool autoBatch = false);
+                                                 bool autoBatch = false,
+                                                 double reconnectInterval = 1.0);
     static std::shared_ptr<DbClient> newMysqlClient(const std::string &connInfo,
                                                     size_t connNum);
     static std::shared_ptr<DbClient> newSqlite3Client(

--- a/orm_lib/inc/drogon/orm/DbClient.h
+++ b/orm_lib/inc/drogon/orm/DbClient.h
@@ -46,7 +46,7 @@ class DbClient;
 /// Transaction locking mode.
 enum class TransactionType
 {
-    Deferred,  ///< BEGIN — lock acquired on first write (default)
+    Deferred,   ///< BEGIN — lock acquired on first write (default)
     Immediate,  ///< BEGIN IMMEDIATE — write lock acquired upfront (SQLite only)
     Exclusive,  ///< BEGIN EXCLUSIVE — exclusive lock acquired upfront (SQLite
                 ///< only)
@@ -131,10 +131,11 @@ class DROGON_EXPORT DbClient : public trantor::NonCopyable
      *
      * @param connNum: The number of connections to database server;
      */
-    static std::shared_ptr<DbClient> newPgClient(const std::string &connInfo,
-                                                 size_t connNum,
-                                                 bool autoBatch = false,
-                                                 double reconnectInterval = 1.0);
+    static std::shared_ptr<DbClient> newPgClient(
+        const std::string &connInfo,
+        size_t connNum,
+        bool autoBatch = false,
+        double reconnectInterval = 1.0);
     static std::shared_ptr<DbClient> newMysqlClient(const std::string &connInfo,
                                                     size_t connNum);
     static std::shared_ptr<DbClient> newSqlite3Client(

--- a/orm_lib/inc/drogon/orm/DbConfig.h
+++ b/orm_lib/inc/drogon/orm/DbConfig.h
@@ -34,6 +34,7 @@ struct PostgresConfig
     double timeout;
     bool autoBatch;
     std::unordered_map<std::string, std::string> connectOptions;
+    double reconnectInterval{1.0};
 };
 
 struct MysqlConfig

--- a/orm_lib/src/DbClient.cc
+++ b/orm_lib/src/DbClient.cc
@@ -32,16 +32,19 @@ orm::internal::SqlBinder DbClient::operator<<(std::string &&sql)
 
 std::shared_ptr<DbClient> DbClient::newPgClient(const std::string &connInfo,
                                                 size_t connNum,
-                                                bool autoBatch)
+                                                bool autoBatch,
+                                                double reconnectInterval)
 {
 #if USE_POSTGRESQL
     auto client = std::make_shared<DbClientImpl>(connInfo,
                                                  connNum,
 #if LIBPQ_SUPPORTS_BATCH_MODE
                                                  ClientType::PostgreSQL,
-                                                 autoBatch);
+                                                 autoBatch,
+                                                 reconnectInterval);
 #else
-                                                 ClientType::PostgreSQL);
+                                                 ClientType::PostgreSQL,
+                                                 reconnectInterval);
 #endif
     client->init();
     return client;
@@ -61,9 +64,11 @@ std::shared_ptr<DbClient> DbClient::newMysqlClient(const std::string &connInfo,
                                                  connNum,
 #if LIBPQ_SUPPORTS_BATCH_MODE
                                                  ClientType::Mysql,
-                                                 false);
+                                                 false,
+                                                 1.0);
 #else
-                                                 ClientType::Mysql);
+                                                 ClientType::Mysql,
+                                                 1.0);
 #endif
     client->init();
     return client;
@@ -84,9 +89,11 @@ std::shared_ptr<DbClient> DbClient::newSqlite3Client(
                                                  connNum,
 #if LIBPQ_SUPPORTS_BATCH_MODE
                                                  ClientType::Sqlite3,
-                                                 false);
+                                                 false,
+                                                 1.0);
 #else
-                                                 ClientType::Sqlite3);
+                                                 ClientType::Sqlite3,
+                                                 1.0);
 #endif
     client->init();
     return client;

--- a/orm_lib/src/DbClientImpl.cc
+++ b/orm_lib/src/DbClientImpl.cc
@@ -51,20 +51,23 @@ DbClientImpl::DbClientImpl(const std::string &connInfo,
                            size_t connNum,
 #if LIBPQ_SUPPORTS_BATCH_MODE
                            ClientType type,
-                           bool autoBatch)
+                           bool autoBatch,
+                           double reconnectInterval)
 #else
-                           ClientType type)
+                           ClientType type,
+                           double reconnectInterval)
 #endif
     : numberOfConnections_(connNum),
-#if LIBPQ_SUPPORTS_BATCH_MODE
-      autoBatch_(autoBatch),
-#endif
       loops_(type == ClientType::Sqlite3
                  ? 1
                  : (connNum < std::thread::hardware_concurrency()
                         ? connNum
                         : std::thread::hardware_concurrency()),
-             "DbLoop")
+             "DbLoop"),
+#if LIBPQ_SUPPORTS_BATCH_MODE
+      autoBatch_(autoBatch),
+#endif
+      reconnectInterval_(reconnectInterval)
 {
     type_ = type;
     connectionInfo_ = connInfo;
@@ -440,17 +443,18 @@ DbConnectionPtr DbClientImpl::newConnection(trantor::EventLoop *loop)
                    thisPtr->connections_.end());
             thisPtr->connections_.erase(closeConnPtr);
         }
-        // Reconnect after 1 second
+        // Reconnect after the configured interval.
         auto loop = closeConnPtr->loop();
         // closeConnPtr may be not valid. Close the connection file descriptor.
         closeConnPtr->disconnect();
-        loop->runAfter(1, [weakPtr, loop, closeConnPtr] {
-            auto thisPtr = weakPtr.lock();
-            if (!thisPtr)
-                return;
+        loop->runAfter(
+            thisPtr->reconnectInterval_, [weakPtr, loop, closeConnPtr] {
+                auto thisPtr = weakPtr.lock();
+                if (!thisPtr)
+                    return;
 
-            thisPtr->newConnection(loop);
-        });
+                thisPtr->newConnection(loop);
+            });
     });
     connPtr->setOkCallback([weakPtr](const DbConnectionPtr &okConnPtr) {
         LOG_TRACE << "connected!";

--- a/orm_lib/src/DbClientImpl.cc
+++ b/orm_lib/src/DbClientImpl.cc
@@ -447,14 +447,14 @@ DbConnectionPtr DbClientImpl::newConnection(trantor::EventLoop *loop)
         auto loop = closeConnPtr->loop();
         // closeConnPtr may be not valid. Close the connection file descriptor.
         closeConnPtr->disconnect();
-        loop->runAfter(
-            thisPtr->reconnectInterval_, [weakPtr, loop, closeConnPtr] {
-                auto thisPtr = weakPtr.lock();
-                if (!thisPtr)
-                    return;
+        loop->runAfter(thisPtr->reconnectInterval_,
+                       [weakPtr, loop, closeConnPtr] {
+                           auto thisPtr = weakPtr.lock();
+                           if (!thisPtr)
+                               return;
 
-                thisPtr->newConnection(loop);
-            });
+                           thisPtr->newConnection(loop);
+                       });
     });
     connPtr->setOkCallback([weakPtr](const DbConnectionPtr &okConnPtr) {
         LOG_TRACE << "connected!";

--- a/orm_lib/src/DbClientImpl.h
+++ b/orm_lib/src/DbClientImpl.h
@@ -36,9 +36,11 @@ class DbClientImpl : public DbClient,
                  size_t connNum,
 #if LIBPQ_SUPPORTS_BATCH_MODE
                  ClientType type,
-                 bool autoBatch);
+                 bool autoBatch,
+                 double reconnectInterval);
 #else
-                 ClientType type);
+                 ClientType type,
+                 double reconnectInterval);
 #endif
     ~DbClientImpl() noexcept override;
     void execSql(const char *sql,
@@ -77,6 +79,7 @@ class DbClientImpl : public DbClient,
 #if LIBPQ_SUPPORTS_BATCH_MODE
     bool autoBatch_{false};
 #endif
+    double reconnectInterval_{1.0};
     DbConnectionPtr newConnection(trantor::EventLoop *loop);
 
     void makeTrans(

--- a/orm_lib/src/DbClientLockFree.cc
+++ b/orm_lib/src/DbClientLockFree.cc
@@ -46,16 +46,19 @@ DbClientLockFree::DbClientLockFree(const std::string &connInfo,
                                    ClientType type,
 #if LIBPQ_SUPPORTS_BATCH_MODE
                                    size_t connectionNumberPerLoop,
-                                   bool autoBatch)
+                                   bool autoBatch,
+                                   double reconnectInterval)
 #else
-                                   size_t connectionNumberPerLoop)
+                                   size_t connectionNumberPerLoop,
+                                   double reconnectInterval)
 #endif
     : connectionInfo_(connInfo),
       loop_(loop),
+      numberOfConnections_(connectionNumberPerLoop),
 #if LIBPQ_SUPPORTS_BATCH_MODE
       autoBatch_(autoBatch),
 #endif
-      numberOfConnections_(connectionNumberPerLoop)
+      reconnectInterval_(reconnectInterval)
 {
     type_ = type;
     LOG_TRACE << "type=" << (int)type;
@@ -464,8 +467,8 @@ DbConnectionPtr DbClientLockFree::newConnection()
             thisPtr->connectionHolders_.erase(iter);
 
         thisPtr->transSet_.erase(closeConnPtr);
-        // Reconnect after 1 second
-        thisPtr->loop_->runAfter(1, [weakPtr, closeConnPtr] {
+        thisPtr->loop_->runAfter(thisPtr->reconnectInterval_,
+                                 [weakPtr, closeConnPtr] {
             auto thisPtr = weakPtr.lock();
             if (!thisPtr)
                 return;

--- a/orm_lib/src/DbClientLockFree.cc
+++ b/orm_lib/src/DbClientLockFree.cc
@@ -469,11 +469,11 @@ DbConnectionPtr DbClientLockFree::newConnection()
         thisPtr->transSet_.erase(closeConnPtr);
         thisPtr->loop_->runAfter(thisPtr->reconnectInterval_,
                                  [weakPtr, closeConnPtr] {
-            auto thisPtr = weakPtr.lock();
-            if (!thisPtr)
-                return;
-            thisPtr->newConnection();
-        });
+                                     auto thisPtr = weakPtr.lock();
+                                     if (!thisPtr)
+                                         return;
+                                     thisPtr->newConnection();
+                                 });
     });
     connPtr->setOkCallback([weakPtr](const DbConnectionPtr &okConnPtr) {
         LOG_TRACE << "connected!";

--- a/orm_lib/src/DbClientLockFree.h
+++ b/orm_lib/src/DbClientLockFree.h
@@ -38,9 +38,11 @@ class DbClientLockFree : public DbClient,
                      ClientType type,
 #if LIBPQ_SUPPORTS_BATCH_MODE
                      size_t connectionNumberPerLoop,
-                     bool autoBatch);
+                     bool autoBatch,
+                     double reconnectInterval);
 #else
-                     size_t connectionNumberPerLoop);
+                     size_t connectionNumberPerLoop,
+                     double reconnectInterval);
 #endif
 
     ~DbClientLockFree() noexcept override;
@@ -88,6 +90,11 @@ class DbClientLockFree : public DbClient,
     std::list<TransCallbackEntry> transCallbacks_;
 
     double timeout_{-1.0};
+#if LIBPQ_SUPPORTS_BATCH_MODE
+    size_t connectionPos_{0};  // Used for pg batch mode.
+    bool autoBatch_{false};
+#endif
+    double reconnectInterval_{1.0};
 
     void makeTrans(
         const DbConnectionPtr &conn,
@@ -103,10 +110,6 @@ class DbClientLockFree : public DbClient,
         ResultCallback &&rcb,
         std::function<void(const std::exception_ptr &)> &&ecb);
     void handleNewTask(const DbConnectionPtr &conn);
-#if LIBPQ_SUPPORTS_BATCH_MODE
-    size_t connectionPos_{0};  // Used for pg batch mode.
-    bool autoBatch_{false};
-#endif
 };
 
 }  // namespace orm

--- a/orm_lib/src/DbClientManager.cc
+++ b/orm_lib/src/DbClientManager.cc
@@ -48,7 +48,8 @@ static void initFastDbClients(IOThreadStorage<orm::DbClientPtr> &storage,
                               ClientType dbType,
                               size_t connNum,
                               bool autoBatch,
-                              double timeout)
+                              double timeout,
+                              double reconnectInterval)
 {
     storage.init([&](orm::DbClientPtr &c, size_t idx) {
         assert(idx == ioLoops[idx]->index());
@@ -59,9 +60,11 @@ static void initFastDbClients(IOThreadStorage<orm::DbClientPtr> &storage,
                                               dbType,
 #if LIBPQ_SUPPORTS_BATCH_MODE  // Bad code
                                               connNum,
-                                              autoBatch));
+                                              autoBatch,
+                                              reconnectInterval));
 #else
-                                              connNum));
+                                              connNum,
+                                              reconnectInterval));
 #endif
         if (timeout > 0.0)
         {
@@ -90,14 +93,16 @@ void DbClientManager::createDbClients(
                                   ClientType::PostgreSQL,
                                   cfg.connectionNumber,
                                   cfg.autoBatch,
-                                  cfg.timeout);
+                                  cfg.timeout,
+                                  cfg.reconnectInterval);
             }
             else
             {
                 dbClientsMap_[cfg.name] =
                     drogon::orm::DbClient::newPgClient(dbInfo.connectionInfo_,
                                                        cfg.connectionNumber,
-                                                       cfg.autoBatch);
+                                                       cfg.autoBatch,
+                                                       cfg.reconnectInterval);
                 if (cfg.timeout > 0.0)
                 {
                     dbClientsMap_[cfg.name]->setTimeout(cfg.timeout);
@@ -118,7 +123,8 @@ void DbClientManager::createDbClients(
                                   ClientType::Mysql,
                                   cfg.connectionNumber,
                                   false,
-                                  cfg.timeout);
+                                  cfg.timeout,
+                                  1.0);
             }
             else
             {


### PR DESCRIPTION
Problem:
When a PostgreSQL connection is lost, Drogon automatically attempts to reconnect every 1 second via loop->runAfter(1, ...) inside orm_lib/src/DbClientImpl.cpp. This can cause unnecessary CPU usage, excessive connection attempts, and log spam when PostgreSQL is unavailable for an extended period.

Solution:
Added configuration support to make the PostgreSQL reconnection retry interval customizable instead of hardcoded to 1 second.
Updated orm_lib/src/DbClientImpl.cpp to parse and apply the user-defined retry interval to the reconnection loop timer.
Reduced unnecessary resource consumption during extended database outages.

Closes #2581