### PR TITLE
Fix duplicate auto relationship method names

### DIFF
--- a/drogon_ctl/create_model.cc
+++ b/drogon_ctl/create_model.cc
@@ -185,10 +185,12 @@ static void tryAddAutoRelationship(std::vector<Relationship> &allRelationships,
                                    const std::string &referencedColumn,
                                    bool normalizeNames)
 {
+    const auto targetTableName =
+        normalizeNames ? toLower(referencedTable) : referencedTable;
     for (const auto &r : allRelationships)
     {
         if (r.originalKey() == fkColumn &&
-            r.targetTableName() == referencedTable)
+            r.targetTableName() == targetTableName)
         {
             return;  // Already exists in user config
         }
@@ -198,12 +200,45 @@ static void tryAddAutoRelationship(std::vector<Relationship> &allRelationships,
     relJson["original_table_name"] =
         normalizeNames ? toLower(originalTable) : originalTable;
     relJson["original_key"] = fkColumn;
-    relJson["target_table_name"] =
-        normalizeNames ? toLower(referencedTable) : referencedTable;
+    relJson["target_table_name"] = targetTableName;
     relJson["target_key"] = referencedColumn;
     relJson["enable_reverse"] = true;
     try
     {
+        auto relationshipAlias = [](const std::string &column,
+                                    const std::string &targetColumn) {
+            auto alias = column;
+            const auto suffix = "_" + targetColumn;
+            if (alias.length() > suffix.length() &&
+                alias.compare(alias.length() - suffix.length(),
+                              suffix.length(),
+                              suffix) == 0)
+            {
+                alias.resize(alias.length() - suffix.length());
+            }
+            return nameTransform(alias, true);
+        };
+
+        bool needsAlias = false;
+        for (auto &relationship : allRelationships)
+        {
+            if (relationship.targetTableName() == targetTableName)
+            {
+                needsAlias = true;
+                if (relationship.targetTableAlias().empty())
+                {
+                    relationship.setTargetTableAlias(
+                        relationshipAlias(relationship.originalKey(),
+                                          relationship.targetKey()));
+                }
+            }
+        }
+        if (needsAlias)
+        {
+            relJson["target_table_alias"] =
+                relationshipAlias(fkColumn, referencedColumn);
+        }
+
         Relationship autoRel(relJson);
         allRelationships.push_back(autoRel);
         std::cout << "    Auto-detected FK: " << originalTable << "."

--- a/drogon_ctl/create_model.h
+++ b/drogon_ctl/create_model.h
@@ -339,6 +339,11 @@ class Relationship
         return targetTableAlias_;
     }
 
+    void setTargetTableAlias(const std::string &alias)
+    {
+        targetTableAlias_ = alias;
+    }
+
     const std::string &targetKey() const
     {
         return targetKey_;

--- a/test.sh
+++ b/test.sh
@@ -271,6 +271,17 @@ EOF
         run_ns_test "config_ns" "override_ns" "override_ns" "CLI namespace overrides config"
         run_ns_test "should_be_ignored" "" "" "Empty namespace from CLI" "true"
 
+        echo "Testing auto-detected relationship names..."
+        sqlite3 test.db "CREATE TABLE types (id INTEGER PRIMARY KEY, name TEXT); CREATE TABLE cars (id INTEGER PRIMARY KEY, plate_type_id INTEGER REFERENCES types(id), color_id INTEGER REFERENCES types(id));"
+        ${drogon_ctl_exec} create model . --table=cars -f > /dev/null 2>&1
+        if ! grep -q "Types getPlateType(" Cars.h ||
+            ! grep -q "Types getColor(" Cars.h ||
+            grep -q "Types getTypes(" Cars.h; then
+            echo "✗ Auto-detected relationship name test failed"
+            exit -1
+        fi
+        echo "✓ Auto-detected relationship names are unique"
+
         cd ..
         rm -rf test_models
         echo "Namespace customization tests passed"


### PR DESCRIPTION
## Summary

- generate foreign-key-derived aliases when multiple relationships target the same table
- remove the referenced-key suffix from aliases, producing names such as `getPlateType()` and `getColor()`
- preserve the existing target-table-based method name when there is only one relationship
- add a SQLite model-generation regression test

## Testing

- built all configured targets with CMake and MSVC
- passed all 66 configured CTest tests
- generated models from a SQLite schema with two foreign keys to the same table
- compiled the generated `Cars.cc` and `Types.cc` with MSVC C++20
- verified a single foreign key still generates the existing `getTypes()` API

Fixes #2584
